### PR TITLE
Add alternative cluster option for request method

### DIFF
--- a/src/components/settings/Cluster.tsx
+++ b/src/components/settings/Cluster.tsx
@@ -25,7 +25,7 @@ const Cluster: React.FunctionComponent<IClusterProps> = ({ cluster }) => {
   useEffect(() => {
     (async() => {
       try {
-        await context.request('GET', '/api/v1', '');
+        await context.request('GET', '/api/v1', '', cluster);
         setStatus(true);
       } catch (err) {
         setStatus(false);

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -96,8 +96,8 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
     localStorage.setItem('clusters', JSON.stringify(updatedClusters));
   };
 
-  const request = async(method: string, url: string, body: string) => {
-    if (cluster === '') {
+  const request = async(method: string, url: string, body: string, alternativeCluster?: ICluster) => {
+    if (cluster === '' && alternativeCluster === undefined) {
       throw new Error('Select an active cluster');
     }
 
@@ -113,12 +113,12 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
       let data = await plugin.request({
         server: SERVER,
         method: method,
-        url: clusters[cluster].url + url,
+        url: alternativeCluster ? alternativeCluster.url : clusters[cluster].url + url,
         body: body,
-        certificateAuthorityData: clusters[cluster].certificateAuthorityData,
-        clientCertificateData: clusters[cluster].clientCertificateData,
-        clientKeyData: clusters[cluster].clientKeyData,
-        token: clusters[cluster].token,
+        certificateAuthorityData: alternativeCluster ? alternativeCluster.certificateAuthorityData : clusters[cluster].certificateAuthorityData,
+        clientCertificateData: alternativeCluster ? alternativeCluster.clientCertificateData : clusters[cluster].clientCertificateData,
+        clientKeyData: alternativeCluster ? alternativeCluster.clientKeyData : clusters[cluster].clientKeyData,
+        token: alternativeCluster ? alternativeCluster.token : clusters[cluster].token,
       });
 
       if (isJSON(data.data)) {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -64,7 +64,7 @@ export interface IContext {
   deleteCluster: (id: string) => void;
   editCluster: (editCluster: ICluster) => void;
   setNamespace: (namespace: string) => void;
-  request: (method: string, url: string, body: string) => Promise<any>;
+  request: (method: string, url: string, body: string, alternativeCluster?: ICluster) => Promise<any>;
 }
 
 export interface IKubeconfig {


### PR DESCRIPTION
The request method for the context doesn't have an option to pass in an alternative cluster than the currently selected cluster. This leads to problems with the cluster status in the cluster overview. There is the status of the active cluster shown for every cluster.

Now it's possible to pass an alternative cluster to the request method, which then is used instead of the active cluster.