### PR TITLE
Improve Error Handling

### DIFF
--- a/src/components/misc/LoadingErrorCard.tsx
+++ b/src/components/misc/LoadingErrorCard.tsx
@@ -1,0 +1,40 @@
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+} from '@ionic/react';
+import React from 'react';
+
+interface ILoadingErrorCard {
+  error: string;
+  exists: boolean;
+  icon: string;
+  text: string;
+}
+
+const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({ error, exists, icon, text }) => {
+  return (
+    <IonCard style={{textAlign: 'center'}}>
+      <img alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
+      <IonCardHeader>
+        <IonCardTitle>{text}</IonCardTitle>
+      </IonCardHeader>
+      {exists ? (
+        <IonCardContent>
+          <p className="paragraph-margin-bottom">{error}</p>
+        </IonCardContent>
+      ) : (
+        <IonCardContent>
+          <p className="paragraph-margin-bottom">
+            You have to select an active cluster before you can proceed.
+          </p>
+          <IonButton expand="block" routerLink="/settings/clusters" routerDirection="none">Select a Cluster</IonButton>
+        </IonCardContent>
+      )}
+    </IonCard>
+  );
+};
+
+export default LoadingErrorCard;

--- a/src/components/settings/EditCluster.tsx
+++ b/src/components/settings/EditCluster.tsx
@@ -68,6 +68,10 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
       setError('URL is required')
     } else if (!url.startsWith('https://')) {
       setError('Invalid URL')
+    } else if (certificateAuthorityData === '') {
+      setError('Certificate Authority Data is required')
+    } else if (clientCertificateData === '' && clientKeyData === '' && token === '') {
+      setError('Client Certificate Data and Client Key Data or Token is required')
     } else {
       context.editCluster({
         id: cluster.id,

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -56,8 +56,8 @@ export interface IContainerMetrics {
 }
 
 export interface IContext {
-  clusters: IClusters;
-  cluster: string;
+  clusters?: IClusters;
+  cluster?: string;
 
   addCluster: (newCluster: ICluster) => void;
   changeCluster: (id: string) => void;

--- a/src/pages/Clusters.tsx
+++ b/src/pages/Clusters.tsx
@@ -29,11 +29,11 @@ const Clusters: React.FunctionComponent = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        {Object.keys(context.clusters).map(key => {
+        {context.clusters ? Object.keys(context.clusters).map(key => {
           return (
-            <Cluster key={key} cluster={context.clusters[key]} />
+            <Cluster key={key} cluster={context.clusters![key]} />
           )
-        })}
+        }) : null}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,5 +1,4 @@
 import {
-  IonAlert,
   IonBackButton,
   IonButtons,
   IonContent,
@@ -13,6 +12,7 @@ import {
 import React, {useContext, useEffect, useState} from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import LoadingErrorCard from '../components/misc/LoadingErrorCard';
 import { AppContext } from '../context';
 import { IContext } from '../declarations';
 import { sections } from '../sections';
@@ -57,6 +57,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ match }) => {
 
     try {
       const data: any = await context.request('GET', page.detailsURL(match.params.namespace, match.params.name), '');
+      setError('');
       setItem(data);
     } catch (err) {
       setError(err);
@@ -76,11 +77,12 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ match }) => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        {error !== '' ? <IonAlert isOpen={error !== ''} onDidDismiss={() => setError('')} header={`Could not get ${page.pluralText}`} message={error} buttons={['OK']} /> : null}
         {showLoading ? <IonProgressBar slot="fixed" type="indeterminate" color="primary" /> : null}
         <IonRefresher slot="fixed"  onIonRefresh={doRefresh} />
 
-        {match.url === url && item ? <Component item={item} section={match.params.section} type={match.params.type} /> : null}
+        {error === '' && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && match.url === url && item ? (
+          <Component item={item} section={match.params.section} type={match.params.type} />
+        ) : <LoadingErrorCard error={error} exists={context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? true  : false} icon={page.icon} text={`Could not get ${page.pluralText}`} />}
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
This PR contains several improvements regarding the error handling:

- When adding a cluster via kubeconfig file we are now showing an error, if the provided file could not be parsed.
- When a resource could not be loaded, we are showing a card instead of an alert. Therefor we use `undefined` for the `clusters` object and `cluster` string. This improves the readability and validation of the provided values.