### PR TITLE
Fix cluster management

### DIFF
--- a/src/components/misc/LoadingErrorCard.tsx
+++ b/src/components/misc/LoadingErrorCard.tsx
@@ -7,32 +7,46 @@ import {
 } from '@ionic/react';
 import React from 'react';
 
+import { IClusters } from '../../declarations';
+
 interface ILoadingErrorCard {
+  cluster?: string;
+  clusters?: IClusters
   error: string;
-  exists: boolean;
   icon: string;
   text: string;
 }
 
-const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({ error, exists, icon, text }) => {
+const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({ cluster, clusters, error, icon, text }) => {
   return (
     <IonCard style={{textAlign: 'center'}}>
       <img alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
       <IonCardHeader>
         <IonCardTitle>{text}</IonCardTitle>
       </IonCardHeader>
-      {exists ? (
+      {!clusters ? (
         <IonCardContent>
-          <p className="paragraph-margin-bottom">{error}</p>
+          <p className="paragraph-margin-bottom">
+            Welcome to the kubenav app. After you added a cluster you can start the exploration of them within the kubenav app. To add a new Kubernetes cluster to the app use the button <b>Add a Cluster</b> or the <b>Clusters</b> item from the menu.
+          </p>
+          <IonButton expand="block" routerLink="/settings/clusters" routerDirection="none">Add a Cluster</IonButton>
         </IonCardContent>
-      ) : (
+      ) : null}
+
+      {clusters && !cluster ? (
         <IonCardContent>
           <p className="paragraph-margin-bottom">
             You have to select an active cluster before you can proceed.
           </p>
           <IonButton expand="block" routerLink="/settings/clusters" routerDirection="none">Select a Cluster</IonButton>
         </IonCardContent>
-      )}
+      ) : null}
+
+      {clusters && cluster ? (
+        <IonCardContent>
+          <p className="paragraph-margin-bottom">{error}</p>
+        </IonCardContent>
+      ) : null}
     </IonCard>
   );
 };

--- a/src/components/settings/AddCluster.tsx
+++ b/src/components/settings/AddCluster.tsx
@@ -21,7 +21,7 @@ import yaml from 'js-yaml';
 import React, { useContext, useState } from 'react';
 
 import { AppContext } from '../../context';
-import { IContext, IKubeconfig, IKubeconfigCluster, IKubeconfigClusterRef, IKubeconfigUser, IKubeconfigUserRef } from '../../declarations';
+import { ICluster, IContext, IKubeconfig, IKubeconfigCluster, IKubeconfigClusterRef, IKubeconfigUser, IKubeconfigUserRef } from '../../declarations';
 import Editor from '../misc/Editor';
 
 const getKubeconfigCluster = (name: string, clusters: IKubeconfigClusterRef[]): IKubeconfigCluster|null => {
@@ -102,7 +102,7 @@ const AddCluster: React.FunctionComponent = () => {
     } else {
       try {
         if (type === 'manual') {
-          context.addCluster({
+          context.addCluster([{
             id: '',
             name: name,
             url: url,
@@ -111,8 +111,9 @@ const AddCluster: React.FunctionComponent = () => {
             clientKeyData: clientKeyData,
             token: token,
             namespace: 'default',
-          });
+          }]);
         } else if (type === 'kubeconfig') {
+          const clusters: ICluster[] = [];
           const config: IKubeconfig = yaml.safeLoad(kubeconfig);
 
           for (let ctx of config.contexts) {
@@ -123,7 +124,7 @@ const AddCluster: React.FunctionComponent = () => {
               throw new Error('Invalid kubeconfig');
             }
 
-            context.addCluster({
+            clusters.push({
               id: '',
               name: ctx.name,
               url: cluster.server,
@@ -134,6 +135,8 @@ const AddCluster: React.FunctionComponent = () => {
               namespace: 'default',
             });
           }
+
+          context.addCluster(clusters);
         }
 
         setError('');

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -59,7 +59,7 @@ export interface IContext {
   clusters?: IClusters;
   cluster?: string;
 
-  addCluster: (newCluster: ICluster) => void;
+  addCluster: (newCluster: ICluster[]) => void;
   changeCluster: (id: string) => void;
   deleteCluster: (id: string) => void;
   editCluster: (editCluster: ICluster) => void;

--- a/src/pages/CustomResourcesList.tsx
+++ b/src/pages/CustomResourcesList.tsx
@@ -108,7 +108,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
               )
             }) : null}
           </IonList>
-        ) : <LoadingErrorCard error={error} exists={context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? true  : false} icon="/assets/icons/kubernetes/crd.png" text={`Could not get Custom Resource "${match.params.name}"`} />}
+        ) : <LoadingErrorCard cluster={context.cluster} clusters={context.clusters} error={error} icon="/assets/icons/kubernetes/crd.png" text={`Could not get Custom Resource "${match.params.name}"`} />}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -97,7 +97,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ match }) => {
 
         {error === '' && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && match.url === url && item ? (
           <Component item={item} section={match.params.section} type={match.params.type} />
-        ) : <LoadingErrorCard error={error} exists={context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? true  : false} icon={page.icon} text={`Could not get ${page.pluralText}`} />}
+        ) : <LoadingErrorCard cluster={context.cluster} clusters={context.clusters} error={error} icon={page.icon} text={`Could not get ${page.pluralText}`} />}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,7 +36,7 @@ const Home: React.FunctionComponent = () => {
       </IonHeader>
       <IonContent>
         <IonList>
-          {context.cluster !== '' ? (
+          {context.clusters && context.cluster ? (
             <IonCard>
               <img alt="kubenav" src="/assets/card-header.png" />
               <IonCardHeader>

--- a/src/pages/List.tsx
+++ b/src/pages/List.tsx
@@ -110,7 +110,7 @@ const List: React.FunctionComponent<IListProps> = ({ match }) => {
               )
             }) : null}
           </IonList>
-        ) : <LoadingErrorCard error={error} exists={context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? true  : false} icon={page.icon} text={`Could not get ${page.pluralText}`} />}
+        ) : <LoadingErrorCard cluster={context.cluster} clusters={context.clusters} error={error} icon={page.icon} text={`Could not get ${page.pluralText}`} />}
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
- Fix a bug where only the last cluster was added when adding multiple clusters via kubeconfig.
- Fix a bug where the false type where set when all clusters where deleted.
- Improve the error message for, which is shown in the LoadingErrorCard component. We distinguish between no clusters where added and no active cluster where selected.