### PR TITLE
Fix add cluster overwrites existing clusters

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -28,7 +28,7 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
   const [cluster, setCluster] = useState<string|undefined>(() => localStorage.getItem('cluster') !== null && localStorage.getItem('cluster') !== '' ? localStorage.getItem('cluster') as string : clusters && Object.keys(clusters).length > 0 ? Object.keys(clusters)[0] : undefined);
 
   const addCluster = (newClusters: ICluster[]) => {
-    let updatedClusters = {};
+    let updatedClusters = clusters ? clusters : {};
 
     for (let newCluster of newClusters) {
       let id = '';


### PR DESCRIPTION
When adding a new cluster all existing clusters where overwritten. This should be fixed now. When adding a new cluster, all existing cluster are still available.