### PR TITLE
Add support for basic authentication

### DIFF
--- a/electron/server.js
+++ b/electron/server.js
@@ -42,6 +42,10 @@ server.post('/request', function (req, res) {
     options.headers['Authorization'] = 'Bearer ' + postData.token;
   }
 
+  if (postData.username !== '' && postData.password !== '') {
+    options.headers['Authorization'] = 'Basic ' + Buffer.from(postData.username + ':' + postData.password).toString('base64');
+  }
+
   const request = https.request(postData.url, options, function(response) {
     let body = '';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1329,9 +1329,9 @@
       }
     },
     "@kubenav/kubenav-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@kubenav/kubenav-plugin/1.1.3/a3fb341a5b1cc5ab9fa497b1364df3044abf472c230f31e3d4d99bc1e61abd0f",
-      "integrity": "sha512-oYBk+uQPFNdy9FCoPJ82WzLMjtQkSArJx4fGGk0Dz0Z8uG4yYISGFE/NcKuQHyseE931KyxEYHwYUiAeZ77YHg==",
+      "version": "1.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@kubenav/kubenav-plugin/1.2.0/4f45a5ce638a4586df9ed07f6709669089863214f581e6a2aa2df5808d0850aa",
+      "integrity": "sha512-abk6ixy+Dsv2wAIJaIFgGVit7fKEpYvqLgxPmexX8r3ZlIVzdDv9How8Vd/wkRMMIP8C2w/z8Afk0spUQySCEA==",
       "requires": {
         "@capacitor/core": "^1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ionic/react": "^4.11.7",
     "@ionic/react-hooks": "0.0.5",
     "@ionic/react-router": "^4.11.7",
-    "@kubenav/kubenav-plugin": "1.1.3",
+    "@kubenav/kubenav-plugin": "1.2.0",
     "@kubernetes/client-node": "^0.11.0",
     "@types/jest": "^24.0.24",
     "@types/node": "^12.12.21",

--- a/src/components/settings/AddCluster.tsx
+++ b/src/components/settings/AddCluster.tsx
@@ -58,6 +58,8 @@ const AddCluster: React.FunctionComponent = () => {
   const [clientKeyData, setClientKeyData] = useState<string>('');
   const [kubeconfig, setKubeconfig] = useState<string>('');
   const [token, setToken] = useState<string>('');
+  const [username, setUsername] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
 
   const handleType = (event) => {
     setType(event.detail.value);
@@ -87,6 +89,14 @@ const AddCluster: React.FunctionComponent = () => {
     setToken(event.target.value);
   };
 
+  const handleUsername = (event) => {
+    setUsername(event.target.value);
+  };
+
+  const handlePassword = (event) => {
+    setPassword(event.target.value);
+  };
+
   const handleKubeconfig = (event) => {
     setKubeconfig(event.target.value);
   };
@@ -100,8 +110,8 @@ const AddCluster: React.FunctionComponent = () => {
       setError('Invalid URL')
     } else if (type === 'manual' && certificateAuthorityData === '') {
       setError('Certificate Authority Data is required')
-    } else if (type === 'manual' && clientCertificateData === '' && clientKeyData === '' && token === '') {
-      setError('Client Certificate Data and Client Key Data or Token is required')
+    } else if (type === 'manual' && clientCertificateData === '' && clientKeyData === '' && token === '' && username === '' && password === '') {
+      setError('Client Certificate Data and Client Key Data or Token or Username and Password is required')
     } else if (type === 'kubeconfig' && kubeconfig === '') {
       setError('Kubeconfig is required')
     } else {
@@ -115,6 +125,8 @@ const AddCluster: React.FunctionComponent = () => {
             clientCertificateData: clientCertificateData,
             clientKeyData: clientKeyData,
             token: token,
+            username: username,
+            password: password,
             namespace: 'default',
           }]);
         } else if (type === 'kubeconfig') {
@@ -125,7 +137,7 @@ const AddCluster: React.FunctionComponent = () => {
             const cluster = getKubeconfigCluster(ctx.context.cluster, config.clusters);
             const user = getKubeconfigUser(ctx.context.user, config.users);
 
-            if (ctx.name === '' || cluster === null || user === null || !cluster.server || !cluster['certificate-authority-data'] || !((user['client-certificate-data'] && user['client-key-data']) || user.token)) {
+            if (ctx.name === '' || cluster === null || user === null || !cluster.server || !cluster['certificate-authority-data'] || !((user['client-certificate-data'] && user['client-key-data']) || user.token || !(user.username && user.password))) {
               throw new Error('Invalid kubeconfig');
             }
 
@@ -137,6 +149,8 @@ const AddCluster: React.FunctionComponent = () => {
               clientCertificateData: user['client-certificate-data'] ? user['client-certificate-data'] : '',
               clientKeyData: user['client-key-data'] ? user['client-key-data'] : '',
               token: user.token ? user.token : '',
+              username: user.username ? user.username : '',
+              password: user.password ? user.password : '',
               namespace: 'default',
             });
           }
@@ -151,6 +165,8 @@ const AddCluster: React.FunctionComponent = () => {
         setClientCertificateData('');
         setClientKeyData('');
         setToken('');
+        setUsername('');
+        setPassword('');
         setShowModal(false);
       } catch (err) {
         setError(err.message);
@@ -224,6 +240,14 @@ const AddCluster: React.FunctionComponent = () => {
               <IonItem>
                 <IonLabel position="stacked">Token</IonLabel>
                 <IonTextarea autoGrow={true} value={token} onInput={handleToken} />
+              </IonItem>
+              <IonItem>
+                <IonLabel position="stacked">Username</IonLabel>
+                <IonInput type="text" value={username} onInput={handleUsername} />
+              </IonItem>
+              <IonItem>
+                <IonLabel position="stacked">Password</IonLabel>
+                <IonInput type="password" value={password} onInput={handlePassword} />
               </IonItem>
             </IonList>
           ) : null}

--- a/src/components/settings/EditCluster.tsx
+++ b/src/components/settings/EditCluster.tsx
@@ -36,6 +36,8 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
   const [clientCertificateData, setClientCertificateData] = useState<string>(cluster.clientCertificateData);
   const [clientKeyData, setClientKeyData] = useState<string>(cluster.clientKeyData);
   const [token, setToken] = useState<string>(cluster.token);
+  const [username, setUsername] = useState<string>(cluster.username);
+  const [password, setPassword] = useState<string>(cluster.password);
 
   const handleName = (event) => {
     setName(event.target.value);
@@ -61,6 +63,14 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
     setToken(event.target.value);
   };
 
+  const handleUsername = (event) => {
+    setUsername(event.target.value);
+  };
+
+  const handlePassword = (event) => {
+    setPassword(event.target.value);
+  };
+
   const editCluster = () => {
     if (name === '') {
       setError('Name is required')
@@ -70,8 +80,8 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
       setError('Invalid URL')
     } else if (certificateAuthorityData === '') {
       setError('Certificate Authority Data is required')
-    } else if (clientCertificateData === '' && clientKeyData === '' && token === '') {
-      setError('Client Certificate Data and Client Key Data or Token is required')
+    } else if (clientCertificateData === '' && clientKeyData === '' && token === '' && username === '' && password === '') {
+      setError('Client Certificate Data and Client Key Data or Token or Username and Password is required')
     } else {
       context.editCluster({
         id: cluster.id,
@@ -81,6 +91,8 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
         clientCertificateData: clientCertificateData,
         clientKeyData: clientKeyData,
         token: token,
+        username: username,
+        password: password,
         namespace: cluster.namespace,
       });
 
@@ -139,6 +151,14 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
             <IonItem>
               <IonLabel position="stacked">Token</IonLabel>
               <IonTextarea autoGrow={true} value={token} onInput={handleToken} />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Username</IonLabel>
+              <IonInput type="text" value={username} onInput={handleUsername} />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Password</IonLabel>
+              <IonInput type="password" value={password} onInput={handlePassword} />
             </IonItem>
           </IonList>
         </IonContent>

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -126,14 +126,14 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
       let data = await plugin.request({
         server: SERVER,
         method: method,
-        url: alternativeCluster ? alternativeCluster.url : clusters && cluster ? clusters[cluster].url + url : '',
+        url: alternativeCluster ? alternativeCluster.url : clusters && cluster && clusters[cluster].url ? clusters[cluster].url + url : '',
         body: body,
-        certificateAuthorityData: alternativeCluster ? alternativeCluster.certificateAuthorityData : clusters && cluster ? clusters[cluster].certificateAuthorityData : '',
-        clientCertificateData: alternativeCluster ? alternativeCluster.clientCertificateData : clusters && cluster ? clusters[cluster].clientCertificateData : '',
-        clientKeyData: alternativeCluster ? alternativeCluster.clientKeyData : clusters && cluster ? clusters[cluster].clientKeyData : '',
-        token: alternativeCluster ? alternativeCluster.token : clusters && cluster ? clusters[cluster].token : '',
-        username: alternativeCluster ? alternativeCluster.username : clusters && cluster ? clusters[cluster].username : '',
-        password: alternativeCluster ? alternativeCluster.password : clusters && cluster ? clusters[cluster].password : '',
+        certificateAuthorityData: alternativeCluster ? alternativeCluster.certificateAuthorityData : clusters && cluster && clusters[cluster].certificateAuthorityData ? clusters[cluster].certificateAuthorityData : '',
+        clientCertificateData: alternativeCluster ? alternativeCluster.clientCertificateData : clusters && cluster && clusters[cluster].clientCertificateData ? clusters[cluster].clientCertificateData : '',
+        clientKeyData: alternativeCluster ? alternativeCluster.clientKeyData : clusters && cluster && clusters[cluster].clientKeyData ? clusters[cluster].clientKeyData : '',
+        token: alternativeCluster ? alternativeCluster.token : clusters && cluster && clusters[cluster].token ? clusters[cluster].token : '',
+        username: alternativeCluster ? alternativeCluster.username : clusters && cluster && clusters[cluster].username ? clusters[cluster].username : '',
+        password: alternativeCluster ? alternativeCluster.password : clusters && cluster && clusters[cluster].password ? clusters[cluster].password : '',
       });
 
       if (isJSON(data.data)) {

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -126,12 +126,14 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
       let data = await plugin.request({
         server: SERVER,
         method: method,
-        url: alternativeCluster ? alternativeCluster.url : clusters![cluster!].url + url,
+        url: alternativeCluster ? alternativeCluster.url : clusters && cluster ? clusters[cluster].url + url : '',
         body: body,
-        certificateAuthorityData: alternativeCluster ? alternativeCluster.certificateAuthorityData : clusters![cluster!].certificateAuthorityData,
-        clientCertificateData: alternativeCluster ? alternativeCluster.clientCertificateData : clusters![cluster!].clientCertificateData,
-        clientKeyData: alternativeCluster ? alternativeCluster.clientKeyData : clusters![cluster!].clientKeyData,
-        token: alternativeCluster ? alternativeCluster.token : clusters![cluster!].token,
+        certificateAuthorityData: alternativeCluster ? alternativeCluster.certificateAuthorityData : clusters && cluster ? clusters[cluster].certificateAuthorityData : '',
+        clientCertificateData: alternativeCluster ? alternativeCluster.clientCertificateData : clusters && cluster ? clusters[cluster].clientCertificateData : '',
+        clientKeyData: alternativeCluster ? alternativeCluster.clientKeyData : clusters && cluster ? clusters[cluster].clientKeyData : '',
+        token: alternativeCluster ? alternativeCluster.token : clusters && cluster ? clusters[cluster].token : '',
+        username: alternativeCluster ? alternativeCluster.username : clusters && cluster ? clusters[cluster].username : '',
+        password: alternativeCluster ? alternativeCluster.password : clusters && cluster ? clusters[cluster].password : '',
       });
 
       if (isJSON(data.data)) {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -43,6 +43,8 @@ export interface ICluster {
   clientCertificateData: string;
   clientKeyData: string;
   token: string;
+  username: string;
+  password: string;
   namespace: string;
 }
 
@@ -96,7 +98,9 @@ export interface IKubeconfigContext {
 export interface IKubeconfigUser {
   'client-certificate-data'?: string;
   'client-key-data'?: string;
-  token?: string
+  token?: string;
+  username?: string;
+  password?: string;
 }
 
 export interface IKubeconfigUserRef {


### PR DESCRIPTION
We updated the bind and kubenav-plugin to support basic authentication. The username and password fields can be used for basic authentication in the manual cluster configuration. Also the username and password fields in a provided kubeconfig file are parsed now.