### PR TITLE
Improve log handling

### DIFF
--- a/src/components/kubernetes/Container.tsx
+++ b/src/components/kubernetes/Container.tsx
@@ -18,6 +18,7 @@ import {
   IonRow,
   IonTitle,
   IonToolbar,
+  isPlatform,
 } from '@ionic/react';
 import { V1Container, V1ContainerPort, V1ContainerState, V1ContainerStatus, V1EnvVarSource } from '@kubernetes/client-node'
 import { close } from 'ionicons/icons';
@@ -93,11 +94,12 @@ const Container: React.FunctionComponent<IContainerProps> = ({ container, logs, 
           <IonLabel>
             <h2>{container.name}</h2>
           </IonLabel>
+          {!isPlatform('hybrid') && logs && name && namespace ? <Logs activator="button" name={name} namespace={namespace} container={container.name} /> : null}
         </IonItem>
 
-        {logs && name && namespace ? (
+        {isPlatform('hybrid') && logs && name && namespace ? (
           <IonItemOptions side="end">
-            <Logs name={name} namespace={namespace} container={container.name} />
+            <Logs activator="item-option" name={name} namespace={namespace} container={container.name} />
           </IonItemOptions>
         ) : null}
       </IonItemSliding>

--- a/src/components/kubernetes/Logs.tsx
+++ b/src/components/kubernetes/Logs.tsx
@@ -19,16 +19,17 @@ import { close, list, more } from 'ionicons/icons';
 import React, { useContext, useEffect, useState } from 'react';
 
 import { AppContext } from '../../context';
-import { IContext } from '../../declarations';
+import { IContext, TActivator } from '../../declarations';
 import Editor from '../misc/Editor';
 
 interface ILogsProps {
+  activator: TActivator;
   name: string;
   namespace: string;
   container: string;
 }
 
-const Logs: React.FunctionComponent<ILogsProps> = ({ name, namespace, container }) => {
+const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace, container }) => {
   const context = useContext<IContext>(AppContext);
 
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -76,38 +77,47 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, namespace, container 
     <React.Fragment>
       {error !== '' ? <IonAlert isOpen={error !== ''} onDidDismiss={() => setError('')} header="Could not load logs" message={error} buttons={['OK']} /> : null}
 
-      <IonItemOption color="primary" onClick={() => setShowModal(true)}>
-        <IonIcon slot="start" icon={list} />
-        Logs
-      </IonItemOption>
+      {activator === 'item-option' ? (
+        <IonItemOption color="primary" onClick={() => setShowModal(true)}>
+          <IonIcon slot="start" icon={list} />
+          Logs
+        </IonItemOption>
+      ) : null}
+
+      {activator === 'button' ? (
+        <IonButton fill="outline" slot="end" onClick={(e) => { e.stopPropagation(); setShowModal(true); }}>
+          <IonIcon slot="start" icon={list} />
+          Logs
+        </IonButton>
+      ) : null}
 
       <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
         <IonHeader>
           <IonToolbar>
             <IonButtons slot="start">
-              <IonButton onClick={() => setShowModal(false)}>
+              <IonButton onClick={(e) => { e.stopPropagation(); setShowModal(false); }}>
                 <IonIcon slot="icon-only" icon={close} />
               </IonButton>
             </IonButtons>
             <IonTitle>{container}</IonTitle>
             <IonButtons slot="primary">
-              <IonButton onClick={(e) => { e.persist(); setPopoverEvent(e); setShowPopover(true); }}>
+              <IonButton onClick={(e) => { e.stopPropagation(); e.persist(); setPopoverEvent(e); setShowPopover(true); }}>
                 <IonIcon slot="icon-only" icon={more} />
               </IonButton>
             </IonButtons>
 
             <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
               <IonList>
-                <IonItem button={true} onClick={() => { setShowPopover(false); load(false, 1000); }}>
+                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 1000); }}>
                   <IonLabel>Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={() => { setShowPopover(false); load(false, 0); }}>
+                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 0); }}>
                   <IonLabel>Complete Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={() => { setShowPopover(false); load(true, 1000); }}>
+                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 1000); }}>
                   <IonLabel>Previous Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={() => { setShowPopover(false); load(true, 0); }}>
+                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 0); }}>
                   <IonLabel>Complete Previous Log</IonLabel>
                 </IonItem>
               </IonList>

--- a/src/components/kubernetes/Logs.tsx
+++ b/src/components/kubernetes/Logs.tsx
@@ -22,6 +22,8 @@ import { AppContext } from '../../context';
 import { IContext, TActivator } from '../../declarations';
 import Editor from '../misc/Editor';
 
+const TAIL_LINES = 1000;
+
 interface ILogsProps {
   activator: TActivator;
   name: string;
@@ -43,7 +45,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
     if (showModal) {
       (async() => {
         setLogs('');
-        await load(false, 1000);
+        await load(false, TAIL_LINES);
       })();
     }
 
@@ -108,17 +110,17 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
 
             <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
               <IonList>
-                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 1000); }}>
-                  <IonLabel>Log</IonLabel>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, TAIL_LINES); }}>
+                  <IonLabel>{`Last ${TAIL_LINES} Log Lines`}</IonLabel>
                 </IonItem>
                 <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 0); }}>
-                  <IonLabel>Complete Log</IonLabel>
+                  <IonLabel>All Log Lines</IonLabel>
                 </IonItem>
-                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 1000); }}>
-                  <IonLabel>Previous Log</IonLabel>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, TAIL_LINES); }}>
+                  <IonLabel>{`Previous Last ${TAIL_LINES} Log Lines`}</IonLabel>
                 </IonItem>
                 <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 0); }}>
-                  <IonLabel>Complete Previous Log</IonLabel>
+                  <IonLabel>All Previous Log Lines</IonLabel>
                 </IonItem>
               </IonList>
             </IonPopover>

--- a/src/components/kubernetes/Logs.tsx
+++ b/src/components/kubernetes/Logs.tsx
@@ -108,16 +108,16 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
 
             <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
               <IonList>
-                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 1000); }}>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 1000); }}>
                   <IonLabel>Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 0); }}>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 0); }}>
                   <IonLabel>Complete Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 1000); }}>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 1000); }}>
                   <IonLabel>Previous Log</IonLabel>
                 </IonItem>
-                <IonItem button={true} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 0); }}>
+                <IonItem button={true} detail={false} onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 0); }}>
                   <IonLabel>Complete Previous Log</IonLabel>
                 </IonItem>
               </IonList>

--- a/src/components/kubernetes/Logs.tsx
+++ b/src/components/kubernetes/Logs.tsx
@@ -5,14 +5,18 @@ import {
   IonContent,
   IonHeader,
   IonIcon,
+  IonItem,
   IonItemOption,
+  IonLabel,
+  IonList,
   IonModal,
+  IonPopover,
   IonProgressBar,
   IonTitle,
   IonToolbar,
 } from '@ionic/react';
-import { close, list, refresh } from 'ionicons/icons';
-import React, {useContext, useEffect, useState} from 'react';
+import { close, list, more } from 'ionicons/icons';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { AppContext } from '../../context';
 import { IContext } from '../../declarations';
@@ -31,23 +35,35 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, namespace, container 
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [logs, setLogs] = useState<string>('');
+  const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [popoverEvent, setPopoverEvent] = useState();
 
   useEffect(() => {
     if (showModal) {
       (async() => {
         setLogs('');
-        await load();
+        await load(false, 1000);
       })();
     }
 
     return () => {};
   }, [showModal]); /* eslint-disable-line */
 
-  const load = async () => {
+  const load = async (previous: boolean, tailLines: number) => {
     setShowLoading(true);
 
     try {
-      const data: any = await context.request('GET', `/api/v1/namespaces/${namespace}/pods/${name}/log?container=${container}`, '');
+      let parameters = `container=${container}`;
+
+      if (previous) {
+        parameters = `${parameters}&previous=true`;
+      }
+
+      if (tailLines !== 0) {
+        parameters = `${parameters}&tailLines=${tailLines}`;
+      }
+
+      const data: any = await context.request('GET', `/api/v1/namespaces/${namespace}/pods/${name}/log?${parameters}`, '');
       setLogs(data);
     } catch (err) {
       setError(err);
@@ -74,9 +90,28 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, namespace, container 
               </IonButton>
             </IonButtons>
             <IonTitle>{container}</IonTitle>
-            <IonButtons slot="primary" onClick={() => load()}>
-              <IonIcon slot="icon-only" icon={refresh} />
+            <IonButtons slot="primary">
+              <IonButton onClick={(e) => { e.persist(); setPopoverEvent(e); setShowPopover(true); }}>
+                <IonIcon slot="icon-only" icon={more} />
+              </IonButton>
             </IonButtons>
+
+            <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
+              <IonList>
+                <IonItem onClick={() => { setShowPopover(false); load(false, 1000); }}>
+                  <IonLabel>Log</IonLabel>
+                </IonItem>
+                <IonItem onClick={() => { setShowPopover(false); load(false, 0); }}>
+                  <IonLabel>Complete Log</IonLabel>
+                </IonItem>
+                <IonItem onClick={() => { setShowPopover(false); load(true, 1000); }}>
+                  <IonLabel>Previous Log</IonLabel>
+                </IonItem>
+                <IonItem onClick={() => { setShowPopover(false); load(true, 0); }}>
+                  <IonLabel>Complete Previous Log</IonLabel>
+                </IonItem>
+              </IonList>
+            </IonPopover>
           </IonToolbar>
         </IonHeader>
         <IonContent>

--- a/src/components/kubernetes/Logs.tsx
+++ b/src/components/kubernetes/Logs.tsx
@@ -98,16 +98,16 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, namespace, container 
 
             <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
               <IonList>
-                <IonItem onClick={() => { setShowPopover(false); load(false, 1000); }}>
+                <IonItem button={true} onClick={() => { setShowPopover(false); load(false, 1000); }}>
                   <IonLabel>Log</IonLabel>
                 </IonItem>
-                <IonItem onClick={() => { setShowPopover(false); load(false, 0); }}>
+                <IonItem button={true} onClick={() => { setShowPopover(false); load(false, 0); }}>
                   <IonLabel>Complete Log</IonLabel>
                 </IonItem>
-                <IonItem onClick={() => { setShowPopover(false); load(true, 1000); }}>
+                <IonItem button={true} onClick={() => { setShowPopover(false); load(true, 1000); }}>
                   <IonLabel>Previous Log</IonLabel>
                 </IonItem>
-                <IonItem onClick={() => { setShowPopover(false); load(true, 0); }}>
+                <IonItem button={true} onClick={() => { setShowPopover(false); load(true, 0); }}>
                   <IonLabel>Complete Previous Log</IonLabel>
                 </IonItem>
               </IonList>

--- a/src/components/kubernetes/NamespacePopover.tsx
+++ b/src/components/kubernetes/NamespacePopover.tsx
@@ -50,14 +50,14 @@ const NamespacePopover: React.FunctionComponent = () => {
         <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
           {namespaces ? (
             <IonList>
-              <IonItem button={true} onClick={() => setAllNamespaces()}>
+              <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
                 {context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && context.clusters[context.cluster].namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
                 <IonLabel>All Namespaces</IonLabel>
               </IonItem>
 
               {namespaces.items.map((namespace, index) => {
                 return (
-                  <IonItem key={index} button={true} onClick={() => setNamespace(namespace)}>
+                  <IonItem key={index} button={true} detail={false} onClick={() => setNamespace(namespace)}>
                     {namespace.metadata && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && context.clusters[context.cluster].namespace === namespace.metadata.name ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
                     <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
                   </IonItem>

--- a/src/components/kubernetes/NamespacePopover.tsx
+++ b/src/components/kubernetes/NamespacePopover.tsx
@@ -50,14 +50,14 @@ const NamespacePopover: React.FunctionComponent = () => {
         <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
           {namespaces ? (
             <IonList>
-              <IonItem onClick={() => setAllNamespaces()}>
+              <IonItem button={true} onClick={() => setAllNamespaces()}>
                 {context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && context.clusters[context.cluster].namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
                 <IonLabel>All Namespaces</IonLabel>
               </IonItem>
 
               {namespaces.items.map((namespace, index) => {
                 return (
-                  <IonItem key={index} onClick={() => setNamespace(namespace)}>
+                  <IonItem key={index} button={true} onClick={() => setNamespace(namespace)}>
                     {namespace.metadata && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) && context.clusters[context.cluster].namespace === namespace.metadata.name ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
                     <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
                   </IonItem>

--- a/src/components/misc/Editor.tsx
+++ b/src/components/misc/Editor.tsx
@@ -58,7 +58,7 @@ const Editor: React.FunctionComponent<IEditorProps> = ({ onChange, readOnly, mod
     <React.Fragment>
       {showScrollToBottomButton ? (
         <div className="editor-scroll-to-bottom-button">
-          <IonButton size="small" onClick={() => scrollToBottom()}>Scroll to Bottom</IonButton>
+          <IonButton size="small" onClick={(e) => { e.stopPropagation(); scrollToBottom(); }}>Scroll to Bottom</IonButton>
         </div>
       ) : null}
 

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -68,7 +68,7 @@ th {
 .editor-scroll-to-bottom-button {
   position: absolute;
   z-index: 999;
-  bottom: 10px;
+  bottom: 20px;
   width: 100%;
   text-align: center;
 }


### PR DESCRIPTION
The log handling was improved and instead of the refresh button it's now possible to select from multiple options for the logs:

- By default only the last 1000 lines are loaded to improve loading speed on mobile.
- Load the complete log.
- Load the previous logs of the container. By default the last 1000 lines are loaded.
- Load the complete log of the previous container.

By clicking on one of the provided items again, the logs will be refreshed.

![Bildschirmfoto 2020-01-26 um 00 00 08](https://user-images.githubusercontent.com/18552168/73128377-ebcb3f00-3fce-11ea-9663-f328e7991c9e.png)

The access to the logs on desktop was improved by adding a button to the container item.

![Bildschirmfoto 2020-01-25 um 23 59 36](https://user-images.githubusercontent.com/18552168/73128380-f259b680-3fce-11ea-9247-a273bc86204a.png)

Closes #11 