### PR TITLE
Improve status check for clusters

### DIFF
--- a/src/components/settings/Cluster.tsx
+++ b/src/components/settings/Cluster.tsx
@@ -25,8 +25,12 @@ const Cluster: React.FunctionComponent<IClusterProps> = ({ cluster }) => {
   useEffect(() => {
     (async() => {
       try {
-        await context.request('GET', '/api/v1', '', cluster);
-        setStatus(true);
+        const data = await context.request('GET', '/api/v1', '', cluster);
+        if (data && data.paths) {
+          setStatus(true);
+        } else {
+          setStatus(false);
+        }
       } catch (err) {
         setStatus(false);
       }


### PR DESCRIPTION
If the HTTP request was successful we are now checking the returned data. They must contain a `paths` field to be successful.