### PR TITLE
Add link to Google OAuth 2.0 configuration

### DIFF
--- a/src/components/settings/clusters/Google.tsx
+++ b/src/components/settings/clusters/Google.tsx
@@ -31,7 +31,7 @@ const Google: React.FunctionComponent = () => {
 
       <IonCardContent>
         <p className="paragraph-margin-bottom">
-          Choose this option to import your GKE clusters from the Google Cloud Platform. First of all you have to add the client ID of your Google OAuth application. More information for the setup of Google OAuth can be found in the FAQ section of the app. When you have added the client ID click the button sign in with Google. You will be redirect to the Google login form, , then you get a list of your existing clusters and you can select the clusters you want to add.
+          Choose this option to import your GKE clusters from the Google Cloud Platform. First of all you have to add the client ID of your Google OAuth application. More information for the setup of Google OAuth 2.0 can be found on the following page: <a href="https://kubenav.io/help/google-oauth2-configuration.html" target="_blank">Google OAuth 2.0 Configuration</a>. When you have added the client ID click the button sign in with Google. You will be redirect to the Google login form, , then you get a list of your existing clusters and you can select the clusters you want to add.
         </p>
 
         <IonList className="paragraph-margin-bottom" lines="full">

--- a/src/pages/Info.tsx
+++ b/src/pages/Info.tsx
@@ -72,19 +72,19 @@ const Info: React.FunctionComponent = () => {
               <IonListHeader>
                 <IonLabel>Links</IonLabel>
               </IonListHeader>
-              <IonItem href="https://kubenav.io" target="_system">
+              <IonItem href="https://kubenav.io" target="_blank">
                 <IonAvatar slot="start">
                   <img alt="Website" src="/assets/icons/misc/browser.png" />
                 </IonAvatar>
                 <IonLabel>Website</IonLabel>
               </IonItem>
-              <IonItem href="https://github.com/kubenav/kubenav" target="_system">
+              <IonItem href="https://github.com/kubenav/kubenav" target="_blank">
                 <IonAvatar slot="start">
                   <img alt="GitHub" src="/assets/icons/misc/github.png" />
                 </IonAvatar>
                 <IonLabel>GitHub</IonLabel>
               </IonItem>
-              <IonItem href="https://twitter.com/kubenav" target="_system">
+              <IonItem href="https://twitter.com/kubenav" target="_blank">
                 <IonAvatar slot="start">
                   <img alt="Twitter" src="/assets/icons/misc/twitter.png" />
                 </IonAvatar>


### PR DESCRIPTION
- Add link to the instructions for the configuration of Google OAuth 2.0 to support GKE clusters for Google Cloud Platform
- Fix `target` for multiple links.