### PR TITLE
Fix status for init containers

### DIFF
--- a/src/components/kubernetes/details/Pod.tsx
+++ b/src/components/kubernetes/details/Pod.tsx
@@ -67,7 +67,7 @@ const Pod: React.FunctionComponent<IPodProps> = ({ item, type }) => {
       {item.metadata ?  <Metadata metadata={item.metadata} type={type} /> : null}
 
       <IonRow>
-        {item.spec && item.spec.initContainers && item.spec.initContainers.length > 0 ? <Containers containers={item.spec.initContainers} logs={true} metrics={metrics ? metrics.containers : undefined} name={item.metadata ? item.metadata.name : ''} namespace={item.metadata ? item.metadata.namespace : ''} statuses={item.status && item.status.containerStatuses ? item.status.containerStatuses : undefined} title="Init Containers" /> : null}
+        {item.spec && item.spec.initContainers && item.spec.initContainers.length > 0 ? <Containers containers={item.spec.initContainers} logs={true} metrics={metrics ? metrics.containers : undefined} name={item.metadata ? item.metadata.name : ''} namespace={item.metadata ? item.metadata.namespace : ''} statuses={item.status && item.status.initContainerStatuses ? item.status.initContainerStatuses : undefined} title="Init Containers" /> : null}
         {item.spec && item.spec.containers && item.spec.containers.length > 0 ? <Containers containers={item.spec.containers} logs={true} metrics={metrics ? metrics.containers : undefined} name={item.metadata ? item.metadata.name : ''} namespace={item.metadata ? item.metadata.namespace : ''} statuses={item.status && item.status.containerStatuses ? item.status.containerStatuses : undefined} title="Containers" /> : null}
       </IonRow>
 


### PR DESCRIPTION
For the init containers the `item.status.containerStatuses` instead of `item.status.initContainerStatuses` was passed to the `Containers` component. Therefore no status was displayed for init containers.