### PR TITLE
Fix adding EKS and GKE clusters

### DIFF
--- a/src/pages/ClustersAWS.tsx
+++ b/src/pages/ClustersAWS.tsx
@@ -63,9 +63,11 @@ const ClustersAWS: React.FunctionComponent<IClustersAWSProps> = ({ match, histor
             match.params.region
           );
 
+          const tmpClusters: ICluster[] = [];
+
           // eslint-disable-next-line
           awsClusters.map((cluster) => {
-            setClusters([...clusters, {
+            tmpClusters.push({
               id: `aws_${match.params.region}_${cluster.Name}`,
               name: `aws_${match.params.region}_${cluster.Name}`,
               url: `${cluster.Endpoint}`,
@@ -77,8 +79,10 @@ const ClustersAWS: React.FunctionComponent<IClustersAWSProps> = ({ match, histor
               password: '',
               authProvider: 'aws',
               namespace: 'default',
-            }]);
+            });
           });
+
+          setClusters(tmpClusters);
         }
       } catch (err) {
         setError(err.message);

--- a/src/pages/ClustersGoogle.tsx
+++ b/src/pages/ClustersGoogle.tsx
@@ -60,10 +60,12 @@ const ClustersGoogle: React.FunctionComponent<IClustersGoogleProps> = ({ locatio
           for (let project of projects) {
             const projectClusters = await getGoogleClusters(tokens.access_token, project.projectId);
 
+            const tmpClusters: ICluster[] = [];
+
             if (projectClusters) {
               // eslint-disable-next-line
               projectClusters.map((cluster) => {
-                setClusters([...clusters, {
+                tmpClusters.push({
                   id: `gke_${project.projectId}_${cluster.location}_${cluster.name}`,
                   name: `gke_${project.projectId}_${cluster.location}_${cluster.name}`,
                   url: `https://${cluster.endpoint}`,
@@ -75,8 +77,10 @@ const ClustersGoogle: React.FunctionComponent<IClustersGoogleProps> = ({ locatio
                   password: cluster.masterAuth.password ? cluster.masterAuth.password : '',
                   authProvider: 'google',
                   namespace: 'default',
-                }]);
+                });
               });
+
+              setClusters(tmpClusters);
             }
           }
         }


### PR DESCRIPTION
After loading all clusters from EKS and GKE only one cluster was shown in the clusters view. Now all loaded clusters are shown in the selection screen.

Closes #35.