### PR TITLE
Show namespace in list view

### DIFF
--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourceItem.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourceItem.tsx
@@ -27,7 +27,6 @@ const CustomResourceItem: React.FunctionComponent<ICustomResourceItemProps> = ({
       <IonItem button={true} onClick={() => setShowModal(true)}>
         <IonLabel>
           <h2>{item.metadata ? item.metadata.name : ''}</h2>
-          <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
         </IonLabel>
       </IonItem>
 

--- a/src/components/resources/configAndStorage/configMaps/ConfigMapItem.tsx
+++ b/src/components/resources/configAndStorage/configMaps/ConfigMapItem.tsx
@@ -17,7 +17,6 @@ const ConfigMapItem: React.FunctionComponent<IConfigMapItemProps> = ({ item, sec
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimItem.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimItem.tsx
@@ -21,7 +21,7 @@ const PersistentVolumeClaimItem: React.FunctionComponent<IPersistentVolumeClaimI
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}{item.status ? ` | Phase: ${item.status.phase}` : ''}{item.status && item.status.capacity ? ` | Capacity: ${item.status.capacity.storage}` : ''}</p>
+        <p>{item.status ? ` | Phase: ${item.status.phase}` : ''}{item.status && item.status.capacity ? ` | Capacity: ${item.status.capacity.storage}` : ''}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/configAndStorage/secrets/SecretItem.tsx
+++ b/src/components/resources/configAndStorage/secrets/SecretItem.tsx
@@ -17,7 +17,6 @@ const SecretItem: React.FunctionComponent<ISecretItemProps> = ({ item, section, 
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountItem.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountItem.tsx
@@ -17,7 +17,6 @@ const ServiceAccountItem: React.FunctionComponent<IServiceAccountItemProps> = ({
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/discoveryAndLoadbalancing/ingresses/IngressItem.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/ingresses/IngressItem.tsx
@@ -17,7 +17,6 @@ const IngressItem: React.FunctionComponent<IIngressItemProps> = ({ item, section
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceItem.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceItem.tsx
@@ -17,7 +17,6 @@ const ServiceItem: React.FunctionComponent<IServiceItemProps> = ({ item, section
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/rbac/roleBindings/RoleBindingItem.tsx
+++ b/src/components/resources/rbac/roleBindings/RoleBindingItem.tsx
@@ -17,7 +17,6 @@ const RoleBindingItem: React.FunctionComponent<IRoleBindingItemProps> = ({ item,
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/rbac/roles/RoleItem.tsx
+++ b/src/components/resources/rbac/roles/RoleItem.tsx
@@ -17,7 +17,6 @@ const RoleItem: React.FunctionComponent<IRoleItemProps> = ({ item, section, type
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/cronJobs/CronJobItem.tsx
+++ b/src/components/resources/workloads/cronJobs/CronJobItem.tsx
@@ -20,8 +20,7 @@ const CronJobItem: React.FunctionComponent<ICronJobItemProps> = ({ item, section
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
         <p>
-          Namespace: {item.metadata ? item.metadata.namespace : '-'}
-          | Last Time Schedule : {item.status && item.status.lastScheduleTime
+          Last Time Schedule : {item.status && item.status.lastScheduleTime
           ? timeDifference(new Date().getTime(), new Date(item.status.lastScheduleTime.toString()).getTime()) : '-'}
         </p>
       </IonLabel>

--- a/src/components/resources/workloads/daemonSets/DaemonSetItem.tsx
+++ b/src/components/resources/workloads/daemonSets/DaemonSetItem.tsx
@@ -46,7 +46,6 @@ const DaemonSetItem: React.FunctionComponent<IDaemonSetItemProps> = ({ item, sec
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/deployments/DeploymentItem.tsx
+++ b/src/components/resources/workloads/deployments/DeploymentItem.tsx
@@ -39,7 +39,6 @@ const DeploymentItem: React.FunctionComponent<IDeploymentItemProps> = ({ item, s
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/jobs/JobItem.tsx
+++ b/src/components/resources/workloads/jobs/JobItem.tsx
@@ -30,7 +30,6 @@ const JobItem: React.FunctionComponent<IJobItemProps> = ({ item, section, type }
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/pods/PodItem.tsx
+++ b/src/components/resources/workloads/pods/PodItem.tsx
@@ -58,7 +58,6 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/replicaSets/ReplicaSetItem.tsx
+++ b/src/components/resources/workloads/replicaSets/ReplicaSetItem.tsx
@@ -35,7 +35,6 @@ const ReplicaSetItem: React.FunctionComponent<IReplicaSetItemProps> = ({ item, s
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/replicationControllers/ReplicationControllerItem.tsx
+++ b/src/components/resources/workloads/replicationControllers/ReplicationControllerItem.tsx
@@ -39,7 +39,6 @@ const ReplicationControllerItem: React.FunctionComponent<IReplicationControllerI
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )

--- a/src/components/resources/workloads/statefulSets/StatefulSetItem.tsx
+++ b/src/components/resources/workloads/statefulSets/StatefulSetItem.tsx
@@ -32,7 +32,6 @@ const StatefulSetItem: React.FunctionComponent<IStatefulSetItemProps> = ({ item,
       <ItemStatus status={status} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        <p>Namespace: {item.metadata ? item.metadata.namespace : '-'}</p>
       </IonLabel>
     </IonItem>
   )


### PR DESCRIPTION
For namespaced resources we are grouping the retrieved items in the list view by namespace via the IonListHeader component. So we can omit the namespace in the description part of each item.

This space can be used to show more status information about the component.