### PR TITLE
Improve pod and container view

### DIFF
--- a/src/components/resources/workloads/pods/PodItem.tsx
+++ b/src/components/resources/workloads/pods/PodItem.tsx
@@ -3,12 +3,14 @@ import {
   IonLabel,
 } from '@ionic/react';
 import { V1Pod } from '@kubernetes/client-node'
-import React from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext, IPodMetrics } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
 import { timeDifference } from '../../../../utils/helpers';
 import ItemStatus from '../../misc/template/ItemStatus';
-import { getReady, getRestarts, getStatus } from './podHelpers';
+import { getReady, getResources, getRestarts, getStatus } from './podHelpers';
 
 interface IPodItemProps extends RouteComponentProps {
   item: V1Pod;
@@ -17,6 +19,25 @@ interface IPodItemProps extends RouteComponentProps {
 }
 
 const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [metrics, setMetrics] = useState<IPodMetrics>();
+
+  useEffect(() => {
+    if (item.metadata && item.metadata.namespace && item.metadata.name) {
+      (async() => {
+        try {
+          const data: IPodMetrics = await context.request('GET', `/apis/metrics.k8s.io/v1beta1/namespaces/${item.metadata!.namespace}/pods/${item.metadata!.name}`, '');
+          setMetrics(data)
+        } catch (err) {
+          // TODO: Implement error handling.
+        }
+      })();
+    }
+
+    return () => {};
+  }, [item, type]); /* eslint-disable-line */
+
   // Get the status of the pod. If the status is running or completed we set the status to success.  If the pod stuck
   // in the pending state, we set the status to warning. If none of these conditions applies we set the status to error.
   const podStatus = getStatus(item);
@@ -33,6 +54,7 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
   // - Ready: The number of ready containers and the number of containers in the pod.
   // - Restarts: Number of restarts for the pod, using the sum of restarts for all containers.
   // - Status: Show the status of the pod, using the status of the running containers.
+  // - Resources: Show the requests and limits for CPU and Memory.
   // - Age: The time when the pod was created.
   return (
     <IonItem routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${item.metadata ? item.metadata.name : ''}`} routerDirection="forward">
@@ -41,6 +63,7 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
         <p>
           Ready: {getReady(item)} | Restarts: {getRestarts(item)} | Status: {podStatus}
+          {item.spec && item.spec.initContainers && item.spec.containers ? ` | ${getResources(item.spec.initContainers.concat(item.spec.containers), metrics)}` : item.spec && item.spec.containers ? ` | ${getResources(item.spec.containers, metrics)}` : ''}
           {item.metadata && item.metadata.creationTimestamp ? ` | Age: ${timeDifference(new Date().getTime(), new Date(item.metadata.creationTimestamp.toString()).getTime())}` : ''}
         </p>
       </IonLabel>

--- a/src/components/resources/workloads/pods/podHelpers.ts
+++ b/src/components/resources/workloads/pods/podHelpers.ts
@@ -1,4 +1,7 @@
-import { V1Pod } from '@kubernetes/client-node'
+import { V1Container, V1Pod } from '@kubernetes/client-node';
+
+import { IPodMetrics } from '../../../../declarations';
+import { formatResourceValue } from '../../../../utils/helpers';
 
 // getReady returns the number of ready containers for a pod and the number of container which should be ready. The
 // function returns a string 'number of ready containers / number of containers'.
@@ -16,6 +19,49 @@ export const getReady = (pod: V1Pod): string => {
   }
 
   return `${isReady}/${shouldReady}`;
+};
+
+// getResources returns the summed up usage and resources over each container for a pod. It returns a string in the
+// following format: CPU usage (request/limit) | Memory: usage (request/limit)
+export const getResources = (containers: V1Container[], metrics: IPodMetrics|undefined): string => {
+  let cpuRequests = 0;
+  let cpuLimits = 0;
+  let cpuUsage = 0;
+  let memoryRequests = 0;
+  let memoryLimits = 0;
+  let memoryUsage = 0;
+
+  for (let container of containers) {
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu')) {
+      cpuRequests = cpuRequests + parseInt(formatResourceValue('cpu', container.resources.requests['cpu']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu')) {
+      cpuLimits = cpuLimits + parseInt(formatResourceValue('cpu', container.resources.limits['cpu']));
+    }
+
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('memory')) {
+      memoryRequests = memoryRequests + parseInt(formatResourceValue('memory', container.resources.requests['memory']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory')) {
+      memoryLimits = memoryLimits + parseInt(formatResourceValue('memory', container.resources.limits['memory']));
+    }
+  }
+
+  if (metrics && metrics.containers) {
+    for (let container of metrics.containers) {
+      if (container.usage && container.usage.hasOwnProperty('cpu')) {
+        cpuUsage = cpuUsage + parseInt(formatResourceValue('cpu', container.usage['cpu']))
+      }
+
+      if (container.usage && container.usage.hasOwnProperty('memory')) {
+        memoryUsage = memoryUsage + parseInt(formatResourceValue('memory', container.usage['memory']))
+      }
+    }
+  }
+
+  return `CPU: ${cpuUsage}m (${cpuRequests}m/${cpuLimits}m) | Memory: ${memoryUsage}Mi (${memoryRequests}Mi/${memoryLimits}Mi)`;
 };
 
 // getRestarts returns the number of restarts for the pod, using the sum of container restarts.


### PR DESCRIPTION
Show the resources and the current usage for each pod in the list view. Show resource, usage, status, restarts and ready status for each container on the pods detail page.

Since the container modal has a width of 90% on larger screen, we show some of the cards next to each other. The modal width and height was changed in PR #22.