### PR TITLE
Fix logs modal for valid json

### DIFF
--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -36,7 +36,7 @@ import { formatResourceValue } from '../../../../../utils/helpers';
 import Editor from '../../../../misc/Editor';
 import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
 import Row from '../../template/Row';
-import Logs from '../Logs';
+import Logs from './Logs';
 
 // getState returns the current state of the given container. This is used for the list view for init containers and
 // containers.

--- a/src/components/resources/misc/podTemplate/containers/Logs.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Logs.tsx
@@ -18,9 +18,9 @@ import {
 import { close, ellipsisHorizontal, ellipsisVertical, list } from 'ionicons/icons';
 import React, { useContext, useEffect, useState } from 'react';
 
-import { IContext, TActivator } from '../../../../declarations';
-import { AppContext } from '../../../../utils/context';
-import Editor from '../../../misc/Editor';
+import { IContext, TActivator } from '../../../../../declarations';
+import { AppContext } from '../../../../../utils/context';
+import Editor from '../../../../misc/Editor';
 
 const TAIL_LINES = 1000;
 
@@ -66,8 +66,10 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
         parameters = `${parameters}&tailLines=${tailLines}`;
       }
 
+      // It is possible that the returned log only contains one line with valid json. This gets parsed by the requests
+      // function and so an object instead of a string is returned. In this case we have to revert the parsing.
       const data: any = await context.request('GET', `/api/v1/namespaces/${namespace}/pods/${name}/log?${parameters}`, '');
-      setLogs(data);
+      setLogs(typeof data === 'string' ? data : JSON.stringify(data));
     } catch (err) {
       setError(err);
     }


### PR DESCRIPTION
If the returned logs from the Kubernetes API server are a valid JSON object we are parsing the log and returning an object instead of a string.

This had break the modal and the app crashes. This is now fixed, by checking if the returned data is a string. If not we are reverting the parsing befor passing the data to the Editor component.