### PR TITLE
Multiple UI Fixes

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -35,49 +35,47 @@ const HomePage: React.FunctionComponent = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <IonList>
-          {context.clusters && context.cluster ? (
-            <IonCard>
-              <img alt="kubenav" src="/assets/card-header.png" />
-              <IonCardHeader>
-                  <IonCardSubtitle>Welcome to kubenav</IonCardSubtitle>
-                  <IonCardTitle>Explore your Kubernetes Clusters</IonCardTitle>
-              </IonCardHeader>
-              <IonCardContent>
-                <p className="paragraph-margin-bottom">
-                  Welcome back to the kubenav app. You are ready to explore your Kubernetes clusters. To get an overview
-                  of your running Nodes, Deployments, Pods and Containers select the corresponding item from the menu or
-                  from below.
-                </p>
-                <IonList>
-                  <Sections sections={resources} isMenu={false} />
-                </IonList>
-              </IonCardContent>
-            </IonCard>
-          ) : (
-            <IonCard>
-              <img alt="kubenav" src="/assets/card-header.png" />
-              <IonCardHeader>
+        {context.clusters && context.cluster ? (
+          <IonCard>
+            <img alt="kubenav" src="/assets/card-header.png" />
+            <IonCardHeader>
                 <IonCardSubtitle>Welcome to kubenav</IonCardSubtitle>
-                <IonCardTitle>Introduction</IonCardTitle>
-              </IonCardHeader>
-              <IonCardContent>
-                <p className="paragraph-margin-bottom">
-                  Welcome to the kubenav app. After you added a cluster you can start the exploration of them within the
-                  kubenav app. To add a new Kubernetes cluster to the app use the button <b>Add a Cluster</b> or the
-                  <b>Clusters</b> item from the menu.
-                </p>
-                <IonButton
-                  expand="block"
-                  routerLink="/settings/clusters"
-                  routerDirection="none"
-                >
-                  Add a Cluster
-                </IonButton>
-              </IonCardContent>
-            </IonCard>
-          )}
-        </IonList>
+                <IonCardTitle>Explore your Kubernetes Clusters</IonCardTitle>
+            </IonCardHeader>
+            <IonCardContent>
+              <p className="paragraph-margin-bottom">
+                Welcome back to the kubenav app. You are ready to explore your Kubernetes clusters. To get an overview
+                of your running Nodes, Deployments, Pods and Containers select the corresponding item from the menu or
+                from below.
+              </p>
+              <IonList>
+                <Sections sections={resources} isMenu={false} />
+              </IonList>
+            </IonCardContent>
+          </IonCard>
+        ) : (
+          <IonCard>
+            <img alt="kubenav" src="/assets/card-header.png" />
+            <IonCardHeader>
+              <IonCardSubtitle>Welcome to kubenav</IonCardSubtitle>
+              <IonCardTitle>Introduction</IonCardTitle>
+            </IonCardHeader>
+            <IonCardContent>
+              <p className="paragraph-margin-bottom">
+                Welcome to the kubenav app. After you added a cluster you can start the exploration of them within the
+                kubenav app. To add a new Kubernetes cluster to the app use the button <b>Add a Cluster</b> or the
+                <b>Clusters</b> item from the menu.
+              </p>
+              <IonButton
+                expand="block"
+                routerLink="/settings/clusters"
+                routerDirection="none"
+              >
+                Add a Cluster
+              </IonButton>
+            </IonCardContent>
+          </IonCard>
+        )}
       </IonContent>
     </IonPage>
   );

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -43,7 +43,7 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections }) => {
         <IonList>
           <Sections sections={sections} isMenu={true} />
 
-          <IonListHeader>
+          <IonListHeader mode="md">
             <IonLabel>Settings</IonLabel>
           </IonListHeader>
           <IonMenuToggle autoHide={false}>

--- a/src/components/menu/Section.tsx
+++ b/src/components/menu/Section.tsx
@@ -18,7 +18,7 @@ interface ISectionProps {
 const Section: React.FunctionComponent<ISectionProps> = ({ pages, title, sectionKey, isMenu }) => {
   return (
     <React.Fragment>
-      <IonListHeader>
+      <IonListHeader mode="md">
         <IonLabel>{title}</IonLabel>
       </IonListHeader>
       {Object.keys(pages).map(pageKey =>

--- a/src/components/misc/Editor.tsx
+++ b/src/components/misc/Editor.tsx
@@ -105,10 +105,7 @@ const Editor: React.FunctionComponent<IEditorProps> = ({
     <React.Fragment>
       {showScrollToBottomButton ? (
         <div className="editor-scroll-to-bottom-button">
-          <IonButton
-            size="small"
-            onClick={(e) => { e.stopPropagation(); scrollToBottom(); }}
-          >
+          <IonButton size="small"  onClick={() => { scrollToBottom(); }}>
             Scroll to Bottom
           </IonButton>
         </div>

--- a/src/components/misc/ErrorCard.tsx
+++ b/src/components/misc/ErrorCard.tsx
@@ -15,7 +15,7 @@ interface IErrorCard {
 const ErrorCard: React.FunctionComponent<IErrorCard> = ({ error, icon, text }) => {
   return (
     <IonCard style={{textAlign: 'center'}}>
-      <img alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
+      <img className="image-margin-top" alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
       <IonCardHeader>
         <IonCardTitle>{text}</IonCardTitle>
       </IonCardHeader>

--- a/src/components/misc/LoadingErrorCard.tsx
+++ b/src/components/misc/LoadingErrorCard.tsx
@@ -20,7 +20,7 @@ interface ILoadingErrorCard {
 const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({ cluster, clusters, error, icon, text }) => {
   return (
     <IonCard style={{textAlign: 'center'}}>
-      <img alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
+      <img className="image-margin-top" alt={text} src={icon} style={{width: '128px', margin: 'auto'}} />
       <IonCardHeader>
         <IonCardTitle>{text}</IonCardTitle>
       </IonCardHeader>

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -4,9 +4,10 @@ import {
   IonContent,
   IonHeader,
   IonIcon,
+  IonItemDivider,
+  IonItemGroup,
   IonLabel,
   IonList,
-  IonListHeader,
   IonMenuButton,
   IonPage,
   IonProgressBar,
@@ -40,7 +41,7 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }) => {
   const context = useContext<IContext>(AppContext);
 
   // namespace and showNamespace is used to group all items by namespace and to only show the namespace once via the
-  // IonListHeader component.
+  // IonItemDivider component.
   let namespace = '';
   let showNamespace = false;
 
@@ -133,11 +134,11 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }) => {
               }
 
               return (
-                <React.Fragment key={index}>
+                <IonItemGroup key={index}>
                   {showNamespace ? (
-                    <IonListHeader>
+                    <IonItemDivider>
                       <IonLabel>{namespace}</IonLabel>
-                    </IonListHeader>
+                    </IonItemDivider>
                   ) : null}
                   <ItemOptions
                     item={item}
@@ -148,7 +149,7 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }) => {
                   >
                     <Component key={index} item={item} section={match.params.section} type={match.params.type} />
                   </ItemOptions>
-                </React.Fragment>
+                </IonItemGroup>
               )
             }) : null}
           </IonList>

--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -11,6 +11,7 @@ import {
   IonHeader,
   IonIcon,
   IonItem,
+  IonItemOption,
   IonItemOptions,
   IonItemSliding,
   IonLabel,
@@ -27,7 +28,7 @@ import {
   V1ContainerStatus,
   V1EnvVarSource,
 } from '@kubernetes/client-node'
-import { close } from 'ionicons/icons';
+import { close, list } from 'ionicons/icons';
 import yaml from 'js-yaml';
 import React, { useState } from 'react';
 
@@ -63,6 +64,7 @@ interface IContainerProps {
 
 const Container: React.FunctionComponent<IContainerProps> = ({ container, logs, metrics, name, namespace, status }) => {
   const [showModal, setShowModal] = useState(false);
+  const [showLogs, setShowLogs] = useState(false);
 
   const containerState = (state: V1ContainerState): string => {
     if (state.running) {
@@ -123,16 +125,33 @@ const Container: React.FunctionComponent<IContainerProps> = ({ container, logs, 
               CPU: {metrics && metrics.usage && metrics.usage.hasOwnProperty('cpu') ? formatResourceValue('cpu', metrics.usage['cpu']) : '-'} ({container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu') ? formatResourceValue('cpu', container.resources.requests['cpu']) : '-'}/{container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu') ? formatResourceValue('cpu', container.resources.limits['cpu']) : '-'}) | Memory: {metrics && metrics.usage && metrics.usage.hasOwnProperty('memory') ? formatResourceValue('memory', metrics.usage['memory']) : '-'} ({container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('memory') ? formatResourceValue('memory', container.resources.requests['memory']) : '-'}/{container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory') ? formatResourceValue('memory', container.resources.limits['memory']) : '-'})
             </p>
           </IonLabel>
-          {!isPlatform('hybrid') && logs && name && namespace
-            ? <Logs activator="button" name={name} namespace={namespace} container={container.name} /> : null}
+          {!isPlatform('hybrid') && logs && name && namespace ? (
+            <IonButton fill="outline" slot="end" onClick={(e) => { e.stopPropagation(); setShowLogs(true); }}>
+              <IonIcon slot="start" icon={list} />
+              Logs
+            </IonButton>
+          ) : null}
         </IonItem>
 
         {isPlatform('hybrid') && logs && name && namespace ? (
           <IonItemOptions side="end">
-            <Logs activator="item-option" name={name} namespace={namespace} container={container.name} />
+            <IonItemOption color="primary" onClick={() => setShowLogs(true)}>
+              <IonIcon slot="start" icon={list} />
+              Logs
+            </IonItemOption>
           </IonItemOptions>
         ) : null}
       </IonItemSliding>
+
+      {container && name && namespace ? (
+        <Logs
+          showModal={showLogs}
+          setShowModal={setShowLogs}
+          name={name}
+          namespace={namespace}
+          container={container.name}
+        />
+      ) : null}
 
       <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
         <IonHeader>

--- a/src/components/resources/misc/podTemplate/containers/Logs.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Logs.tsx
@@ -6,7 +6,6 @@ import {
   IonHeader,
   IonIcon,
   IonItem,
-  IonItemOption,
   IonLabel,
   IonList,
   IonModal,
@@ -15,26 +14,26 @@ import {
   IonTitle,
   IonToolbar,
 } from '@ionic/react';
-import { close, ellipsisHorizontal, ellipsisVertical, list } from 'ionicons/icons';
+import { close, ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
 import React, { useContext, useEffect, useState } from 'react';
 
-import { IContext, TActivator } from '../../../../../declarations';
+import { IContext } from '../../../../../declarations';
 import { AppContext } from '../../../../../utils/context';
 import Editor from '../../../../misc/Editor';
 
 const TAIL_LINES = 1000;
 
 interface ILogsProps {
-  activator: TActivator;
+  showModal: boolean;
+  setShowModal: (value: boolean) => void;
   name: string;
   namespace: string;
   container: string;
 }
 
-const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace, container }) => {
+const Logs: React.FunctionComponent<ILogsProps> = ({ showModal, setShowModal, name, namespace, container }) => {
   const context = useContext<IContext>(AppContext);
 
-  const [showModal, setShowModal] = useState<boolean>(false);
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [logs, setLogs] = useState<string>('');
@@ -89,32 +88,18 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
         />
       ) : null}
 
-      {activator === 'item-option' ? (
-        <IonItemOption color="primary" onClick={() => setShowModal(true)}>
-          <IonIcon slot="start" icon={list} />
-          Logs
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton fill="outline" slot="end" onClick={(e) => { e.stopPropagation(); setShowModal(true); }}>
-          <IonIcon slot="start" icon={list} />
-          Logs
-        </IonButton>
-      ) : null}
-
       <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
         <IonHeader>
           <IonToolbar>
             <IonButtons slot="start">
-              <IonButton onClick={(e) => { e.stopPropagation(); setShowModal(false); }}>
+              <IonButton onClick={(e) => { setShowModal(false); }}>
                 <IonIcon slot="icon-only" icon={close} />
               </IonButton>
             </IonButtons>
             <IonTitle>{container}</IonTitle>
             <IonButtons slot="primary">
               <IonButton
-                onClick={(e) => { e.stopPropagation(); e.persist(); setPopoverEvent(e); setShowPopover(true); }}
+                onClick={(e) => { e.persist(); setPopoverEvent(e); setShowPopover(true); }}
               >
                 <IonIcon slot="icon-only" ios={ellipsisHorizontal} md={ellipsisVertical} />
               </IonButton>
@@ -125,28 +110,28 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ activator, name, namespace,
                 <IonItem
                   button={true}
                   detail={false}
-                  onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, TAIL_LINES); }}
+                  onClick={() => { setShowPopover(false); load(false, TAIL_LINES); }}
                 >
                   <IonLabel>{`Last ${TAIL_LINES} Log Lines`}</IonLabel>
                 </IonItem>
                 <IonItem
                   button={true}
                   detail={false}
-                  onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(false, 0); }}
+                  onClick={() => { setShowPopover(false); load(false, 0); }}
                 >
                   <IonLabel>All Log Lines</IonLabel>
                 </IonItem>
                 <IonItem
                   button={true}
                   detail={false}
-                  onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, TAIL_LINES); }}
+                  onClick={() => { setShowPopover(false); load(true, TAIL_LINES); }}
                 >
                   <IonLabel>{`Previous Last ${TAIL_LINES} Log Lines`}</IonLabel>
                 </IonItem>
                 <IonItem
                   button={true}
                   detail={false}
-                  onClick={(e) => { e.stopPropagation(); setShowPopover(false); load(true, 0); }}
+                  onClick={() => { setShowPopover(false); load(true, 0); }}
                 >
                   <IonLabel>All Previous Log Lines</IonLabel>
                 </IonItem>

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -3,10 +3,14 @@ import {
   IonContent,
   IonHeader,
   IonItem,
+  IonItemDivider,
+  IonItemGroup,
   IonLabel,
-  IonList, IonListHeader,
+  IonList,
   IonMenuButton,
-  IonPage, IonSelect, IonSelectOption,
+  IonPage,
+  IonSelect,
+  IonSelectOption,
   IonTitle,
   IonToggle,
   IonToolbar,
@@ -45,55 +49,57 @@ const GeneralPage: React.FunctionComponent = () => {
       </IonHeader>
       <IonContent>
         <IonList>
-          <IonListHeader>
-            <IonLabel>Appearance</IonLabel>
-          </IonListHeader>
-          <IonItem>
-            <IonLabel>Dark Mode</IonLabel>
-            <IonToggle checked={context.settings.darkMode} onIonChange={toggleDarkMode} />
-          </IonItem>
-          <IonItem>
-            <IonLabel>Editor Theme</IonLabel>
-            <IonSelect value={context.settings.editorTheme} onIonChange={changeEditorTheme}>
-              <IonSelectOption value="ambiance">Ambiance</IonSelectOption>
-              <IonSelectOption value="chaos">Chaos</IonSelectOption>
-              <IonSelectOption value="chrome">Chrome</IonSelectOption>
-              <IonSelectOption value="clouds">Clouds</IonSelectOption>
-              <IonSelectOption value="clouds_midnight">Clouds Midnight</IonSelectOption>
-              <IonSelectOption value="cobalt">Cobalt</IonSelectOption>
-              <IonSelectOption value="crimson_editor">Crimson Editor</IonSelectOption>
-              <IonSelectOption value="dawn">Dawn</IonSelectOption>
-              <IonSelectOption value="dracula">Dracula</IonSelectOption>
-              <IonSelectOption value="dreamweaver">Dreamweaver</IonSelectOption>
-              <IonSelectOption value="eclipse">Eclipse</IonSelectOption>
-              <IonSelectOption value="github">GitHub</IonSelectOption>
-              <IonSelectOption value="gob">Gob</IonSelectOption>
-              <IonSelectOption value="gruvbox">Gruvbox</IonSelectOption>
-              <IonSelectOption value="idle_fingers">Idle Fingers</IonSelectOption>
-              <IonSelectOption value="iplastic">iPlastic</IonSelectOption>
-              <IonSelectOption value="katzenmilch">Katzenmilch</IonSelectOption>
-              <IonSelectOption value="kr_theme">krTheme</IonSelectOption>
-              <IonSelectOption value="kuroir">Kuroir</IonSelectOption>
-              <IonSelectOption value="merbivore">Merbivore</IonSelectOption>
-              <IonSelectOption value="merbivore_soft">Merbivore Soft</IonSelectOption>
-              <IonSelectOption value="monokai">Monokai</IonSelectOption>
-              <IonSelectOption value="mono_industrial">Mono Industrial</IonSelectOption>
-              <IonSelectOption value="pastel_on_dark">Pastel on Dark</IonSelectOption>
-              <IonSelectOption value="solarized_dark">Solarized Dark</IonSelectOption>
-              <IonSelectOption value="solarized_light">Solarized Light</IonSelectOption>
-              <IonSelectOption value="sqlserver">SQL Server</IonSelectOption>
-              <IonSelectOption value="terminal">Terminal</IonSelectOption>
-              <IonSelectOption value="textmate">TextMate</IonSelectOption>
-              <IonSelectOption value="tomorrow">Tomorrow</IonSelectOption>
-              <IonSelectOption value="tomorrow_night">Tomorrow Night</IonSelectOption>
-              <IonSelectOption value="tomorrow_night_blue">Tomorrow Night Blue</IonSelectOption>
-              <IonSelectOption value="tomorrow_night_bright">Tomorrow Night Bright</IonSelectOption>
-              <IonSelectOption value="tomorrow_night_eighties">Tomorrow Night Eighties</IonSelectOption>
-              <IonSelectOption value="twilight">Twilight</IonSelectOption>
-              <IonSelectOption value="vibrant_ink">Vibrant Ink</IonSelectOption>
-              <IonSelectOption value="xcode">Xcode</IonSelectOption>
-            </IonSelect>
-          </IonItem>
+          <IonItemGroup>
+            <IonItemDivider>
+              <IonLabel>Appearance</IonLabel>
+            </IonItemDivider>
+            <IonItem>
+              <IonLabel>Dark Mode</IonLabel>
+              <IonToggle checked={context.settings.darkMode} onIonChange={toggleDarkMode} />
+            </IonItem>
+            <IonItem>
+              <IonLabel>Editor Theme</IonLabel>
+              <IonSelect value={context.settings.editorTheme} onIonChange={changeEditorTheme}>
+                <IonSelectOption value="ambiance">Ambiance</IonSelectOption>
+                <IonSelectOption value="chaos">Chaos</IonSelectOption>
+                <IonSelectOption value="chrome">Chrome</IonSelectOption>
+                <IonSelectOption value="clouds">Clouds</IonSelectOption>
+                <IonSelectOption value="clouds_midnight">Clouds Midnight</IonSelectOption>
+                <IonSelectOption value="cobalt">Cobalt</IonSelectOption>
+                <IonSelectOption value="crimson_editor">Crimson Editor</IonSelectOption>
+                <IonSelectOption value="dawn">Dawn</IonSelectOption>
+                <IonSelectOption value="dracula">Dracula</IonSelectOption>
+                <IonSelectOption value="dreamweaver">Dreamweaver</IonSelectOption>
+                <IonSelectOption value="eclipse">Eclipse</IonSelectOption>
+                <IonSelectOption value="github">GitHub</IonSelectOption>
+                <IonSelectOption value="gob">Gob</IonSelectOption>
+                <IonSelectOption value="gruvbox">Gruvbox</IonSelectOption>
+                <IonSelectOption value="idle_fingers">Idle Fingers</IonSelectOption>
+                <IonSelectOption value="iplastic">iPlastic</IonSelectOption>
+                <IonSelectOption value="katzenmilch">Katzenmilch</IonSelectOption>
+                <IonSelectOption value="kr_theme">krTheme</IonSelectOption>
+                <IonSelectOption value="kuroir">Kuroir</IonSelectOption>
+                <IonSelectOption value="merbivore">Merbivore</IonSelectOption>
+                <IonSelectOption value="merbivore_soft">Merbivore Soft</IonSelectOption>
+                <IonSelectOption value="monokai">Monokai</IonSelectOption>
+                <IonSelectOption value="mono_industrial">Mono Industrial</IonSelectOption>
+                <IonSelectOption value="pastel_on_dark">Pastel on Dark</IonSelectOption>
+                <IonSelectOption value="solarized_dark">Solarized Dark</IonSelectOption>
+                <IonSelectOption value="solarized_light">Solarized Light</IonSelectOption>
+                <IonSelectOption value="sqlserver">SQL Server</IonSelectOption>
+                <IonSelectOption value="terminal">Terminal</IonSelectOption>
+                <IonSelectOption value="textmate">TextMate</IonSelectOption>
+                <IonSelectOption value="tomorrow">Tomorrow</IonSelectOption>
+                <IonSelectOption value="tomorrow_night">Tomorrow Night</IonSelectOption>
+                <IonSelectOption value="tomorrow_night_blue">Tomorrow Night Blue</IonSelectOption>
+                <IonSelectOption value="tomorrow_night_bright">Tomorrow Night Bright</IonSelectOption>
+                <IonSelectOption value="tomorrow_night_eighties">Tomorrow Night Eighties</IonSelectOption>
+                <IonSelectOption value="twilight">Twilight</IonSelectOption>
+                <IonSelectOption value="vibrant_ink">Vibrant Ink</IonSelectOption>
+                <IonSelectOption value="xcode">Xcode</IonSelectOption>
+              </IonSelect>
+            </IonItem>
+          </IonItemGroup>
         </IonList>
       </IonContent>
     </IonPage>

--- a/src/components/settings/InfoPage.tsx
+++ b/src/components/settings/InfoPage.tsx
@@ -61,7 +61,7 @@ const InfoPage: React.FunctionComponent = () => {
               and desktop implementation.
             </p>
             <IonList>
-              <IonListHeader>
+              <IonListHeader mode="md">
                 <IonLabel>General</IonLabel>
               </IonListHeader>
               <IonItem>
@@ -74,7 +74,7 @@ const InfoPage: React.FunctionComponent = () => {
 
               <License />
 
-              <IonListHeader>
+              <IonListHeader mode="md">
                 <IonLabel>Links</IonLabel>
               </IonListHeader>
               <IonItem href="https://kubenav.io" target="_blank" rel="noopener noreferrer">

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -39,6 +39,11 @@
   margin-bottom: 20px !important;
 }
 
+/* Add top margin for img tag */
+.image-margin-top {
+  margin-top: 20px !important;
+}
+
 /* Table */
 table {
   min-width: 100%;


### PR DESCRIPTION
- There was no space between the top of a card and the shown image. Since we are adding a margin to the last paragraph in a card, we are now also adding this margin to the first image in the card.
- When the user clicked on the log lines in the log modal, the container modal was opened. This is because the modal was shown in the IonItem component. We moved the modal out of the IonItem component and added the activator for the modal directly to the Container component.
- In lists we were using the IonListHeader component, which looks ugly on iOS. We are now using the IonItemGroup for lists. Only for lists which are shown in a card/menu we are using the IonListHeader component, but only with the `md` mode.