### PR TITLE
Add searchbar for list views

### DIFF
--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -12,6 +12,7 @@ import {
   IonPage,
   IonProgressBar,
   IonRefresher,
+  IonSearchbar,
   IonTitle,
   IonToolbar,
   isPlatform,
@@ -58,6 +59,7 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }) => {
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [items, setItems] = useState<any>();
   const [url, setUrl] = useState<string>('');
+  const [searchText, setSearchText] = useState<string>('');
 
   // When the component is rendered the first time and on every change route change or a modification to the context
   // object we are loading all items for the corresponding resource.
@@ -123,36 +125,43 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }) => {
         <IonRefresher slot="fixed" onIonRefresh={doRefresh} />
 
         {error === '' && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? (
-          <IonList>
-            {match.url === url && items ? items.map((item, index) => {
-              if (isNamespaced(match.params.type) && item.metadata && item.metadata.namespace
-                && item.metadata.namespace !== namespace) {
-                namespace = item.metadata.namespace;
-                showNamespace = true;
-              } else {
-                showNamespace = false;
-              }
+          <React.Fragment>
+            <IonSearchbar inputmode="search" value={searchText} onIonChange={e => setSearchText(e.detail.value!)} />
 
-              return (
-                <IonItemGroup key={index}>
-                  {showNamespace ? (
-                    <IonItemDivider>
-                      <IonLabel>{namespace}</IonLabel>
-                    </IonItemDivider>
-                  ) : null}
-                  <ItemOptions
-                    item={item}
-                    url={page.detailsURL(
-                      item.metadata ? item.metadata.namespace : '',
-                      item.metadata ? item.metadata.name : ''
-                    )}
-                  >
-                    <Component key={index} item={item} section={match.params.section} type={match.params.type} />
-                  </ItemOptions>
-                </IonItemGroup>
-              )
-            }) : null}
-          </IonList>
+            <IonList>
+              {match.url === url && items ? items.filter((item) => {
+                const regex = new RegExp(searchText, 'gi');
+                return item.metadata && item.metadata.name && item.metadata.name.match(regex);
+              }).map((item, index) => {
+                if (isNamespaced(match.params.type) && item.metadata && item.metadata.namespace
+                  && item.metadata.namespace !== namespace) {
+                  namespace = item.metadata.namespace;
+                  showNamespace = true;
+                } else {
+                  showNamespace = false;
+                }
+
+                return (
+                  <IonItemGroup key={index}>
+                    {showNamespace ? (
+                      <IonItemDivider>
+                        <IonLabel>{namespace}</IonLabel>
+                      </IonItemDivider>
+                    ) : null}
+                    <ItemOptions
+                      item={item}
+                      url={page.detailsURL(
+                        item.metadata ? item.metadata.namespace : '',
+                        item.metadata ? item.metadata.name : ''
+                      )}
+                    >
+                      <Component key={index} item={item} section={match.params.section} type={match.params.type} />
+                    </ItemOptions>
+                  </IonItemGroup>
+                )
+              }) : null}
+            </IonList>
+          </React.Fragment>
         ) : (
           <LoadingErrorCard
             cluster={context.cluster}

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -1,12 +1,15 @@
 import {
-  IonBackButton, IonButton,
+  IonBackButton,
+  IonButton,
   IonButtons,
   IonContent,
-  IonHeader, IonIcon,
+  IonHeader,
+  IonIcon,
   IonList,
   IonPage,
   IonProgressBar,
   IonRefresher,
+  IonSearchbar,
   IonTitle,
   IonToolbar,
   isPlatform,
@@ -41,6 +44,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [items, setItems] = useState<any>();
   const [url, setUrl] = useState<string>('');
+  const [searchText, setSearchText] = useState<string>('');
 
   useEffect(() => {
     (async() => {
@@ -103,15 +107,22 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
         <IonRefresher slot="fixed" onIonRefresh={doRefresh} />
 
         {error === '' && context.clusters && context.cluster && context.clusters.hasOwnProperty(context.cluster) ? (
-          <IonList>
-            {match.url === url && items ? items.map((item, index) => {
-              return (
-                <ItemOptions key={index} item={item} url={`${getURL(item.metadata ? item.metadata.namespace : '', match.params.group, match.params.version, match.params.name)}/${item.metadata ? item.metadata.name : ''}`}>
-                  <CustomResourceItem item={item} />
-                </ItemOptions>
-              )
-            }) : null}
-          </IonList>
+          <React.Fragment>
+            <IonSearchbar inputmode="search" value={searchText} onIonChange={e => setSearchText(e.detail.value!)} />
+
+            <IonList>
+              {match.url === url && items ? items.filter((item) => {
+                const regex = new RegExp(searchText, 'gi');
+                return item.metadata && item.metadata.name && item.metadata.name.match(regex);
+              }).map((item, index) => {
+                return (
+                  <ItemOptions key={index} item={item} url={`${getURL(item.metadata ? item.metadata.namespace : '', match.params.group, match.params.version, match.params.name)}/${item.metadata ? item.metadata.name : ''}`}>
+                    <CustomResourceItem item={item} />
+                  </ItemOptions>
+                )
+              }) : null}
+            </IonList>
+          </React.Fragment>
         ) : <LoadingErrorCard cluster={context.cluster} clusters={context.clusters} error={error} icon="/assets/icons/kubernetes/crd.png" text={`Could not get Custom Resource "${match.params.name}"`} />}
       </IonContent>
     </IonPage>


### PR DESCRIPTION
With a lots of resources in the list view, endless scrolling can be a little bit annoying. To solve this problem we add a searchbar to the list views.

Only the name of the resource is included in the search. It is not possible to search for resources by other properties.

Closes #49.

![Bildschirmfoto 2020-03-19 um 20 24 00](https://user-images.githubusercontent.com/18552168/77106567-98e69480-6a1f-11ea-8f60-3bed1c60c4ec.png)
