### PR TITLE
Fix Kubeconfig validation

### DIFF
--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -72,7 +72,17 @@ const KubeconfigPage: React.FunctionComponent<IKubeconfigPageProps> = ({ history
           const cluster = getKubeconfigCluster(ctx.context.cluster, config.clusters);
           const user = getKubeconfigUser(ctx.context.user, config.users);
 
-          if (ctx.name === '' || cluster === null || user === null || !cluster.server || !((user['client-certificate-data'] && user['client-key-data']) || user.token || !(user.username && user.password))) {
+          if (ctx.name === '' || cluster === null || user === null || !cluster.server) {
+            throw new Error('Invalid kubeconfig');
+          }
+
+          if (
+            !user['client-certificate-data']
+            && !user['client-key-data']
+            && !user.token
+            && !user.username
+            && !user.password
+          ) {
             throw new Error('Invalid kubeconfig');
           }
 


### PR DESCRIPTION
The validation of a given Kubeconfig file wasn't working correctly, so that a valid Kubeconfig was marked as invalid.