### PR TITLE
Check if authProvider property exists on cluster

### DIFF
--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -250,7 +250,7 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
   // token as token to the API request.
   const oidcRequestWrapper = async (method: string, url: string, body: string, c: ICluster): Promise<any> => {
     try {
-      if (c.authProvider.startsWith('oidc__')) {
+      if (c.authProvider && c.authProvider.startsWith('oidc__')) {
         const authProvider = c.authProvider.replace('oidc__', '');
 
         if (!oidcProviders || !oidcProviders.hasOwnProperty(authProvider)) {


### PR DESCRIPTION
The `authProvider` was introduced in a later version of kubenav. Therefor it is possible that the property doesn't exists on old cluster configurations. This results in an error, which can only be fixed by readding the cluster.

This PR fixes the check for the `authProvider` property and applies the OIDC configuration only if the property exists.