### PR TITLE
Support insecure-skip-tls-verify and timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,9 +1628,9 @@
       }
     },
     "@kubenav/kubenav-plugin": {
-      "version": "1.6.1",
-      "resolved": "https://npm.pkg.github.com/download/@kubenav/kubenav-plugin/1.6.1/274c64707050d516088c8613c0c1ea3ca3a9986cbbe020aa342e59b70407085b",
-      "integrity": "sha512-txND10G6tig8MGTv2NgQxLVeoue8DoF6cRtgJBsjtKndIvD4AYXNbBbq3QinAcE3hRLh5rntlvP0/LRoa9Qedg==",
+      "version": "1.7.0",
+      "resolved": "https://npm.pkg.github.com/download/@kubenav/kubenav-plugin/1.7.0/8da1a595c33f31893cb4d17929344559fd72e916f40196b67f6a6be0fe92089f",
+      "integrity": "sha512-azHd/qCB2RMtoxMCkYzqslCKyW9VwWWI5t1PrtJVP9UfDmNEQ4pKmQ3wD9BJ3fvQlDew7h3Lk6EdnjgRMQyn1w==",
       "requires": {
         "@capacitor/core": "^1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ionic/react": "^5.0.7",
     "@ionic/react-hooks": "0.0.6",
     "@ionic/react-router": "^5.0.7",
-    "@kubenav/kubenav-plugin": "1.6.1",
+    "@kubenav/kubenav-plugin": "1.7.0",
     "@kubernetes/client-node": "^0.11.1",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.11.1",

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -1,7 +1,7 @@
 import {
   IonButtons,
   IonContent,
-  IonHeader,
+  IonHeader, IonInput,
   IonItem,
   IonItemDivider,
   IonItemGroup,
@@ -29,13 +29,23 @@ const GeneralPage: React.FunctionComponent = () => {
     context.editSettings({
       darkMode: context.settings.darkMode,
       editorTheme: event.target.value,
+      timeout: context.settings.timeout,
     })
+  };
+
+  const changeTimeout = (event) => {
+    context.editSettings({
+      darkMode: context.settings.darkMode,
+      editorTheme: context.settings.editorTheme,
+      timeout: parseInt(event.target.value),
+    });
   };
 
   const toggleDarkMode = (event) => {
     context.editSettings({
       darkMode: event.detail.checked,
       editorTheme: context.settings.editorTheme,
+      timeout: context.settings.timeout,
     });
   };
 
@@ -100,6 +110,10 @@ const GeneralPage: React.FunctionComponent = () => {
                 <IonSelectOption value="vibrant_ink">Vibrant Ink</IonSelectOption>
                 <IonSelectOption value="xcode">Xcode</IonSelectOption>
               </IonSelect>
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Timeout (in seconds)</IonLabel>
+              <IonInput type="number" required={true} value={context.settings.timeout} onInput={changeTimeout} />
             </IonItem>
           </IonItemGroup>
 

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -13,6 +13,7 @@ import {
   IonModal,
   IonTextarea,
   IonTitle,
+  IonToggle,
   IonToolbar,
 } from '@ionic/react';
 import { close, create } from 'ionicons/icons';
@@ -38,6 +39,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
   const [token, setToken] = useState<string>(cluster.token);
   const [username, setUsername] = useState<string>(cluster.username);
   const [password, setPassword] = useState<string>(cluster.password);
+  const [insecureSkipTLSVerify, setInsecureSkipTLSVerify] = useState<boolean>(cluster.insecureSkipTLSVerify);
 
   const handleName = (event) => {
     setName(event.target.value);
@@ -71,6 +73,10 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
     setPassword(event.target.value);
   };
 
+  const handleInsecureSkipTLSVerify = (event) => {
+    setInsecureSkipTLSVerify(event.detail.checked);
+  };
+
   const editCluster = () => {
     if (name === '') {
       setError('Name is required')
@@ -78,8 +84,6 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
       setError('URL is required')
     } else if (!url.startsWith('https://')) {
       setError('Invalid URL')
-    } else if (certificateAuthorityData === '') {
-      setError('Certificate Authority Data is required')
     } else if (clientCertificateData === '' && clientKeyData === '' && token === '' && username === '' && password === '') {
       setError('Client Certificate Data and Client Key Data or Token or Username and Password is required')
     } else {
@@ -93,6 +97,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
         token: token,
         username: username,
         password: password,
+        insecureSkipTLSVerify: insecureSkipTLSVerify,
         authProvider: cluster.authProvider,
         namespace: cluster.namespace,
       });
@@ -148,6 +153,10 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }) =>
             <IonItem>
               <IonLabel position="stacked">Certificate Authority Data</IonLabel>
               <IonTextarea autoGrow={true} value={certificateAuthorityData} onInput={handleCertificateAuthorityData} />
+            </IonItem>
+            <IonItem>
+              <IonLabel>Insecure Skip TLS Verify</IonLabel>
+              <IonToggle checked={insecureSkipTLSVerify} onIonChange={handleInsecureSkipTLSVerify} />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Client Certificate Data</IonLabel>

--- a/src/components/settings/clusters/aws/AWSPage.tsx
+++ b/src/components/settings/clusters/aws/AWSPage.tsx
@@ -77,6 +77,7 @@ const AWSPage: React.FunctionComponent<IAWSPageProps> = ({ match, history }) => 
               token: '',
               username: '',
               password: '',
+              insecureSkipTLSVerify: false,
               authProvider: 'aws',
               namespace: 'default',
             });

--- a/src/components/settings/clusters/azure/AzurePage.tsx
+++ b/src/components/settings/clusters/azure/AzurePage.tsx
@@ -107,6 +107,7 @@ const AzurePage: React.FunctionComponent<IAzurePageProps> = ({ location, history
                 token: kubeconfigUser && kubeconfigUser.token ? kubeconfigUser.token : '',
                 username: kubeconfigUser && kubeconfigUser.username ? kubeconfigUser.username : '',
                 password: kubeconfigUser && kubeconfigUser.password ? kubeconfigUser.password : '',
+                insecureSkipTLSVerify: false,
                 authProvider: 'azure',
                 namespace: 'default',
               });

--- a/src/components/settings/clusters/google/GooglePage.tsx
+++ b/src/components/settings/clusters/google/GooglePage.tsx
@@ -75,6 +75,7 @@ const GooglePage: React.FunctionComponent<IGooglePageProps> = ({ location, histo
                   token: '',
                   username: cluster.masterAuth.username ? cluster.masterAuth.username : '',
                   password: cluster.masterAuth.password ? cluster.masterAuth.password : '',
+                  insecureSkipTLSVerify: false,
                   authProvider: 'google',
                   namespace: 'default',
                 });

--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -90,12 +90,14 @@ const KubeconfigPage: React.FunctionComponent<IKubeconfigPageProps> = ({ history
             id: '',
             name: ctx.name,
             url: cluster.server,
-            certificateAuthorityData: cluster['certificate-authority-data'],
+            certificateAuthorityData: cluster['certificate-authority-data'] ?
+              cluster['certificate-authority-data'] : '',
             clientCertificateData: user['client-certificate-data'] ? user['client-certificate-data'] : '',
             clientKeyData: user['client-key-data'] ? user['client-key-data'] : '',
             token: user.token ? user.token : '',
             username: user.username ? user.username : '',
             password: user.password ? user.password : '',
+            insecureSkipTLSVerify: cluster['insecure-skip-tls-verify'] ? cluster['insecure-skip-tls-verify'] : false,
             authProvider: '',
             namespace: 'default',
           });

--- a/src/components/settings/clusters/manual/ManualPage.tsx
+++ b/src/components/settings/clusters/manual/ManualPage.tsx
@@ -4,13 +4,15 @@ import {
   IonButton,
   IonButtons,
   IonContent,
-  IonHeader, IonInput,
+  IonHeader,
+  IonInput,
   IonItem,
   IonLabel,
   IonList,
   IonPage,
   IonTextarea,
   IonTitle,
+  IonToggle,
   IonToolbar,
 } from '@ionic/react';
 import React, { useContext, useState } from 'react';
@@ -33,6 +35,7 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }) => {
   const [token, setToken] = useState<string>('');
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
+  const [insecureSkipTLSVerify, setInsecureSkipTLSVerify] = useState<boolean>(false);
 
   const handleName = (event) => {
     setName(event.target.value);
@@ -66,6 +69,10 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }) => {
     setPassword(event.target.value);
   };
 
+  const handleInsecureSkipTLSVerify = (event) => {
+    setInsecureSkipTLSVerify(event.detail.checked);
+  };
+
   const addClusters = () => {
     if (name === '') {
       setError('Name is required')
@@ -87,6 +94,7 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }) => {
           token: token,
           username: username,
           password: password,
+          insecureSkipTLSVerify: insecureSkipTLSVerify,
           authProvider: '',
           namespace: 'default',
         }]);
@@ -129,6 +137,10 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }) => {
           <IonItem>
             <IonLabel position="stacked">Certificate Authority Data</IonLabel>
             <IonTextarea autoGrow={true} value={certificateAuthorityData} onInput={handleCertificateAuthorityData} />
+          </IonItem>
+          <IonItem>
+            <IonLabel>Insecure Skip TLS Verify</IonLabel>
+            <IonToggle checked={insecureSkipTLSVerify} onIonChange={handleInsecureSkipTLSVerify} />
           </IonItem>
           <IonItem>
             <IonLabel position="stacked">Client Certificate Data</IonLabel>

--- a/src/components/settings/clusters/oidc/OIDCPage.tsx
+++ b/src/components/settings/clusters/oidc/OIDCPage.tsx
@@ -67,6 +67,7 @@ const OIDCPage: React.FunctionComponent<IOIDCPageProps> = ({ history }) => {
           token: '',
           username: '',
           password: '',
+          insecureSkipTLSVerify: false,
           authProvider: `oidc__${provider}`,
           namespace: 'default',
         }]);

--- a/src/components/settings/clusters/oidc/OIDCRedirectPage.tsx
+++ b/src/components/settings/clusters/oidc/OIDCRedirectPage.tsx
@@ -112,6 +112,7 @@ const OIDCRedirectPage: React.FunctionComponent<IOIDCRedirectPageProps> = ({ loc
           token: '',
           username: '',
           password: '',
+          insecureSkipTLSVerify: false,
           authProvider: `oidc__${readOIDCLastProvider()}`,
           namespace: 'default',
         }]);

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -38,6 +38,7 @@ export interface IAppSections {
 export interface IAppSettings {
   darkMode: boolean;
   editorTheme: string;
+  timeout: number;
 }
 
 export interface IAWSCluster {
@@ -83,6 +84,7 @@ export interface ICluster {
   token: string;
   username: string;
   password: string;
+  insecureSkipTLSVerify: boolean;
   authProvider: string;
   namespace: string;
 }
@@ -148,6 +150,7 @@ export interface IKubeconfig {
 
 export interface IKubeconfigCluster {
   'certificate-authority-data': string;
+  'insecure-skip-tls-verify': boolean;
   server: string;
 }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -282,7 +282,13 @@ export const getGoogleTokens = async (code: string): Promise<IGoogleTokens> => {
 // username and password are not configured, an valid access token is requested. If the authentication provider is AWS,
 // an valid access token is requested. The region and name for the selected cluster is saved in the cluster id, so we
 // can reuse it to get a access token for the Kubernetes API server.
-export const kubernetesRequest = async (method: string, url: string, body: string, cluster: ICluster): Promise<any> => {
+export const kubernetesRequest = async (
+  method: string,
+  url: string,
+  body: string,
+  timeout: number,
+  cluster: ICluster
+): Promise<any> => {
   let plugin: any;
 
   if (isPlatform('hybrid')) {
@@ -320,6 +326,8 @@ export const kubernetesRequest = async (method: string, url: string, body: strin
       );
     }
 
+    console.log('TIMEOUT', timeout ? timeout : 60);
+
     let data = await plugin.request({
       server: SERVER,
       cluster: cluster ? cluster.id : '',
@@ -332,6 +340,8 @@ export const kubernetesRequest = async (method: string, url: string, body: strin
       token: cluster ? cluster.token : '',
       username: cluster ? cluster.username : '',
       password: cluster ? cluster.password : '',
+      insecureSkipTLSVerify: cluster ? cluster.insecureSkipTLSVerify : false,
+      timeout: timeout ? timeout : 60,
     });
 
     if (isJSON(data.data)) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,7 @@ export const VERSION = process.env.REACT_APP_VERSION;
 export const DEFAULT_SETTINGS: IAppSettings = {
   darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
   editorTheme: 'solarized_dark',
+  timeout: 60,
 };
 
 export const GOOGLE_OAUTH2_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -269,7 +269,7 @@ export const AppContextProvider: React.FunctionComponent = ({ children }) => {
         c.token = oidcProviders[authProvider].idToken;
       }
 
-      return await kubernetesRequest(method, url, body, c);
+      return await kubernetesRequest(method, url, body, settings.timeout, c);
     } catch (err) {
       throw err
     }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -81,11 +81,21 @@ export const readOIDCProviders = (): IOIDCProviders|undefined => {
 };
 
 // readSettings returns the settings set by the user. If the user had not modified the settings yet, return the default
-// settings.
+// settings. We have to check the parsed settings from localStorage key by key, because on older version it is possible,
+// that a key is missing.
 export const readSettings = (): IAppSettings => {
-  const settings = localStorage.getItem(STORAGE_SETTINGS);
+  const settingsFromStorage = localStorage.getItem(STORAGE_SETTINGS);
 
-  return settings ? JSON.parse(settings) : DEFAULT_SETTINGS;
+  if (settingsFromStorage) {
+    const settings = JSON.parse(settingsFromStorage)
+    return {
+      darkMode: settings.darkMode ? settings.darkMode : DEFAULT_SETTINGS.darkMode,
+      editorTheme: settings.editorTheme ? settings.editorTheme : DEFAULT_SETTINGS.editorTheme,
+      timeout: settings.timeout ? settings.timeout : DEFAULT_SETTINGS.timeout,
+    };
+  }
+
+  return DEFAULT_SETTINGS;
 };
 
 // removeCluster removes the saved cluster from localStorage.


### PR DESCRIPTION
Add Support for the `insecure-skip-tls-verify` parameter for the Kubeconfig and custom timeouts for Kubernetes API requests. The default timeout is 60 seconds and can be adjusted in the General section of the Settings.

Closes #58 