### PR TITLE
Add version check

### DIFF
--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/asticode/go-astikit"
 	"github.com/asticode/go-astilectron"
 	bootstrap "github.com/asticode/go-astilectron-bootstrap"
-	"github.com/elazarl/go-bindata-assetfs"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -115,7 +115,8 @@ var rootCmd = &cobra.Command{
 			}
 		}()
 
-		menuOptions, err := getMenuOptions(client, log)
+		updateAvailable := checkVersion(version.Version, log)
+		menuOptions, err := getMenuOptions(updateAvailable, client, log)
 		if err != nil {
 			log.WithError(err).Fatalf("Could not create menu")
 		}

--- a/cmd/electron/version.go
+++ b/cmd/electron/version.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Release struct {
+	TagName string `json:"tag_name"`
+}
+
+// checkVersion compares the given version string, which is set during the build time with the latest version tag from
+// GitHub. If the tags differ the function returns true. In case of an error or if the tags are equal the function
+// returns false.
+// NOTE: This only works for the official releases. If a beta version is used this function always returns true, also
+// when the beta release is newer then the last production release.
+func checkVersion(currentVersion string, log *logrus.Logger) bool {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/kubenav/kubenav/releases/latest", nil)
+	if err != nil {
+		log.WithError(err).Errorf("Could not create GitHub release request")
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Errorf("Could not do GitHub release request")
+		return false
+	}
+
+	defer resp.Body.Close()
+
+	var release Release
+	err = json.NewDecoder(resp.Body).Decode(&release)
+	if err != nil {
+		log.WithError(err).Errorf("Could not decode GitHub response body")
+		return false
+	}
+
+	log.Infof("Version Check: Current %s, Available %s", currentVersion, release.TagName)
+
+	if release.TagName != currentVersion {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Add a version check which compares the currently running version of kubenav with the latest version tag from the GitHub releases. When the tags are different a menu item **"Update Available"** is added. When the item is clicked the GitHub release pages is opened in the browser.

Note: This only works for the production releases. If a beta release is used the **"Update Available"** item is always shown in the menu.