### PR TITLE
Add support to stream logs

### DIFF
--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/kubenav/kubenav/pkg/api/middleware"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+type LogSession struct {
+	ClientSet *kubernetes.Clientset
+	URL       string
+}
+
+var LogSessions = make(map[string]LogSession)
+
+// StreamLogsHandler handles the requests to stream the logs of a container.
+func StreamLogsHandler(w http.ResponseWriter, r *http.Request) {
+	params := strings.Split(r.URL.Path, "/")
+	logSession, ok := LogSessions[params[len(params)-1]]
+	if !ok {
+		middleware.Errorf(w, r, nil, http.StatusInternalServerError, fmt.Sprintf("Invalid session id"))
+		return
+	}
+
+	readCloser, err := logSession.ClientSet.RESTClient().Get().RequestURI(logSession.URL).Stream()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not stream logs: %s", err.Error()))
+		return
+	}
+	defer readCloser.Close()
+
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	for {
+		select {
+		case <-r.Context().Done():
+			middleware.Write(w, r, nil)
+			return
+		default:
+			p := make([]byte, 2048)
+			n, err := readCloser.Read(p)
+			if err != nil {
+				if err == io.EOF {
+					middleware.Write(w, r, nil)
+					return
+				}
+
+				middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not stream logs: %s", err.Error()))
+				return
+			}
+
+			if string(p[:n]) != "" {
+				w.Write([]byte(fmt.Sprintf("data: %s\n\n", string(p[:n]))))
+				w.(http.Flusher).Flush()
+			}
+		}
+	}
+}

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -33,13 +32,13 @@ type Response struct {
 
 // KubernetesRequest makes the request to the Kubernetes API server. A request contains a method, url, body and timeout.
 // The API server data is defined in the clientset.
-func KubernetesRequest(method, url, body string, timeout int64, clientset *kubernetes.Clientset) ([]byte, error) {
+func KubernetesRequest(method, url, body string, clientset *kubernetes.Clientset) ([]byte, error) {
 	if method == "GET" {
-		return clientset.RESTClient().Get().RequestURI(url).Timeout(time.Duration(timeout) * time.Second).DoRaw()
+		return clientset.RESTClient().Get().RequestURI(url).DoRaw()
 	} else if method == "DELETE" {
-		return clientset.RESTClient().Delete().RequestURI(url).Timeout(time.Duration(timeout) * time.Second).DoRaw()
+		return clientset.RESTClient().Delete().RequestURI(url).DoRaw()
 	} else if method == "PATCH" {
-		return clientset.RESTClient().Patch(types.JSONPatchType).RequestURI(url).Body([]byte(body)).Timeout(time.Duration(timeout) * time.Second).DoRaw()
+		return clientset.RESTClient().Patch(types.JSONPatchType).RequestURI(url).Body([]byte(body)).DoRaw()
 	}
 
 	return []byte(``), fmt.Errorf("Request method is not implemented")

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -20,4 +20,6 @@ func Register(router *http.ServeMux, kubeClient *kube.Client) {
 	router.HandleFunc("/api/kubernetes/request", middleware.Cors(requestHandler))
 	router.HandleFunc("/api/kubernetes/exec", middleware.Cors(execHandler))
 	router.Handle("/api/kubernetes/sockjs/", api.CreateAttachHandler("/api/kubernetes/sockjs"))
+	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
+	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 }

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -114,7 +115,7 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 }
 
 // ConfigClientset creates the config and clientset for an Kubernetes API call.
-func (c *Client) ConfigClientset(context string) (*rest.Config, *kubernetes.Clientset, error) {
+func (c *Client) ConfigClientset(context string, timeout time.Duration) (*rest.Config, *kubernetes.Clientset, error) {
 	raw, err := c.config.RawConfig()
 	if err != nil {
 		return nil, nil, err
@@ -127,6 +128,8 @@ func (c *Client) ConfigClientset(context string) (*rest.Config, *kubernetes.Clie
 	if err != nil {
 		return nil, nil, err
 	}
+
+	restClient.Timeout = timeout
 
 	clientset, err := kubernetes.NewForConfig(restClient)
 	if err != nil {

--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/kubenav/kubenav/pkg/api"
 	"github.com/kubenav/kubenav/pkg/api/middleware"
@@ -30,13 +31,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, clientset, err := client.ConfigClientset(request.Cluster)
+	_, clientset, err := client.ConfigClientset(request.Cluster, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
 		return
 	}
 
-	result, err := api.KubernetesRequest(request.Method, request.URL, request.Body, request.Timeout, clientset)
+	result, err := api.KubernetesRequest(request.Method, request.URL, request.Body, clientset)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
 		return
@@ -68,7 +69,7 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config, clientset, err := client.ConfigClientset(request.Cluster)
+	config, clientset, err := client.ConfigClientset(request.Cluster, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
 		return
@@ -91,4 +92,102 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
 	return
+}
+
+// logsHandler generates the clientset and an id for streaming logs.
+func logsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.Request
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		return
+	}
+
+	_, clientset, err := client.ConfigClientset(request.Cluster, 1*time.Hour)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		return
+	}
+
+	sessionID, err := api.GenTerminalSessionID()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		return
+	}
+
+	api.LogSessions[sessionID] = api.LogSession{
+		ClientSet: clientset,
+		URL:       request.URL,
+	}
+
+	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
+	return
+
+	/*if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.Request
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		return
+	}
+
+	_, clientset, err := client.ConfigClientset(request.Cluster, 1*time.Hour)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		return
+	}
+
+	readCloser, err := clientset.RESTClient().Get().RequestURI(request.URL).Stream()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not stream logs: %s", err.Error()))
+		return
+	}
+	defer readCloser.Close()
+
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	for {
+		select {
+		case <-r.Context().Done():
+			fmt.Println("close sse")
+			middleware.Write(w, r, nil)
+			return
+		default:
+			p := make([]byte, 2048)
+			n, err := readCloser.Read(p)
+			if err != nil {
+				if err == io.EOF {
+					middleware.Write(w, r, nil)
+					return
+				}
+
+				middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not stream logs: %s", err.Error()))
+				return
+			}
+
+			if string(p[:n]) != "" {
+				w.Write([]byte(fmt.Sprintf("data: %s\n\n", string(p[:n]))))
+				w.(http.Flusher).Flush()
+			}
+		}
+	}*/
 }

--- a/pkg/mobile/kube/kube.go
+++ b/pkg/mobile/kube/kube.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -11,7 +12,7 @@ import (
 
 // ConfigClientset can be used to create an config and clientset for an Kubernetes API call from the fields from an
 // API request.
-func ConfigClientset(server, certificateAuthorityData, clientCertificateData, clientKeyData, token, username, password string, insecureSkipTLSVerify bool) (*rest.Config, *kubernetes.Clientset, error) {
+func ConfigClientset(server, certificateAuthorityData, clientCertificateData, clientKeyData, token, username, password string, insecureSkipTLSVerify bool, timeout time.Duration) (*rest.Config, *kubernetes.Clientset, error) {
 	config, err := clientcmd.NewClientConfigFromBytes([]byte(`apiVersion: v1
 clusters:
 - cluster:
@@ -43,6 +44,8 @@ users:
 	if err != nil {
 		return nil, nil, err
 	}
+
+	restClient.Timeout = timeout
 
 	clientset, err := kubernetes.NewForConfig(restClient)
 	if err != nil {

--- a/pkg/mobile/kubernetes.go
+++ b/pkg/mobile/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/kubenav/kubenav/pkg/api"
 	"github.com/kubenav/kubenav/pkg/api/middleware"
@@ -31,13 +32,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify)
+	_, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create Kubernetes API client")
 		return
 	}
 
-	result, err := api.KubernetesRequest(request.Method, request.URL, request.Body, request.Timeout, clientset)
+	result, err := api.KubernetesRequest(request.Method, request.URL, request.Body, clientset)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
 		return
@@ -69,7 +70,7 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify)
+	config, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
 		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create Kubernetes API client")
 		return
@@ -89,6 +90,45 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 
 	shell := ""
 	go api.WaitForTerminal(config, clientset, &request, shell, sessionID)
+
+	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
+	return
+}
+
+// logsHandler handles the requests to stream the logs of a container.
+func logsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.Request
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		return
+	}
+
+	_, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		return
+	}
+
+	sessionID, err := api.GenTerminalSessionID()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		return
+	}
+
+	api.LogSessions[sessionID] = api.LogSession{
+		ClientSet: clientset,
+		URL:       request.URL,
+	}
 
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
 	return

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -19,6 +19,8 @@ func StartServer() {
 	router.HandleFunc("/api/kubernetes/request", middleware.Cors(requestHandler))
 	router.HandleFunc("/api/kubernetes/exec", middleware.Cors(execHandler))
 	router.Handle("/api/kubernetes/sockjs/", api.CreateAttachHandler("/api/kubernetes/sockjs"))
+	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
+	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 
 	router.HandleFunc("/api/oidc/link", middleware.Cors(oidcGetLinkHandler))
 	router.HandleFunc("/api/oidc/refreshtoken", middleware.Cors(oidcGetRefreshTokenHandler))

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -246,6 +246,7 @@ export interface ITerminal {
   type: TTerminal;
   shell?: Terminal;
   logs?: string;
+  eventSource?: EventSource;
 }
 
 export interface ITerminalContext {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -362,8 +362,41 @@ export const kubernetesRequest = async (
   }
 };
 
+// execRequest initialize the request to get a shell into a container. The generated session id is returned and can be
+// used to get the shell into the container.
 export const execRequest = async (url: string, cluster: ICluster): Promise<ITerminalResponse> => {
   const response = await fetch(`${SERVER}/api/kubernetes/exec`, {
+    method: 'post',
+    body: JSON.stringify({
+      server: SERVER,
+      cluster: cluster ? cluster.id : '',
+      url: cluster ? cluster.url + url : '',
+      certificateAuthorityData: cluster ? cluster.certificateAuthorityData : '',
+      clientCertificateData: cluster ? cluster.clientCertificateData : '',
+      clientKeyData: cluster ? cluster.clientKeyData : '',
+      token: cluster ? cluster.token : '',
+      username: cluster ? cluster.username : '',
+      password: cluster ? cluster.password : '',
+      insecureSkipTLSVerify: cluster ? cluster.insecureSkipTLSVerify : false,
+    }),
+  });
+
+  const json = await response.json();
+
+  if (response.status >= 200 && response.status < 300) {
+    return json;
+  } else {
+    if (json.error) {
+      throw new Error(json.message);
+    } else {
+      throw new Error('An unknown error occured');
+    }
+  }
+};
+
+// logsRequest returns the session id to stream the log files of a container via server sent events.
+export const logsRequest = async (url: string, cluster: ICluster): Promise<ITerminalResponse> => {
+  const response = await fetch(`${SERVER}/api/kubernetes/logs`, {
     method: 'post',
     body: JSON.stringify({
       server: SERVER,

--- a/src/utils/terminal.tsx
+++ b/src/utils/terminal.tsx
@@ -38,6 +38,10 @@ export const TerminalContextProvider: React.FunctionComponent<ITerminalContextPr
   };
 
   const remove = (index: number) => {
+    if (terminals[index].eventSource) {
+      terminals[index].eventSource?.close();
+    }
+
     if (terminals.length > 1) {
       setActiveTerminal('term_0');
       const copy = [...terminals];


### PR DESCRIPTION
Add a new options to the logs popover to stream log files. If the streaming option is selected a request is made to generate a session id. This session id can be used to retrieve the logs via Server Sent Events.

Unlike the other options, the stream logs option uses xterm to show the logs (for the other options we use Ace), because the editor would be rendered when retrieving a log line.

```sh
curl -i -H 'Content-Type: application/json' -X POST -d @api.json http://localhost:14122/api/kubernetes/logs
curl -i http://localhost:14122/api/kubernetes/logs/<ID>
```

```json
{
  "server": "http://localhost:14122",
  "cluster": "<CONTEXT>",
  "method": "GET",
  "url": "https://<SERVER>/api/v1/namespaces/vault-secrets-operator/pods/vault-secrets-operator-54747b55df-697ct/log?container=vault-secrets-operator&follow=true&tailLines=10",
  "timeout": 60
}
```

Closes #60.