### PR TITLE
Sync changes back to loaded Kubeconfig file

### DIFF
--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -61,7 +61,7 @@ var rootCmd = &cobra.Command{
 
 		go func() {
 			router := http.NewServeMux()
-			electron.Register(router, client)
+			electron.Register(router, sync, client)
 
 			router.HandleFunc("/api/electron", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Connection", "keep-alive")
@@ -169,7 +169,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Optional Kubeconfig file.")
-	rootCmd.PersistentFlags().BoolVar(&sync, "sync", "", "Sync the changes from kubenav with the used Kubeconfig file.")
+	rootCmd.PersistentFlags().BoolVar(&sync, "sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
 }
 
 func main() {

--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -28,6 +28,7 @@ var (
 var (
 	debug      bool
 	kubeconfig string
+	sync       bool
 )
 
 type Message struct {
@@ -114,7 +115,7 @@ var rootCmd = &cobra.Command{
 		}()
 
 		updateAvailable := checkVersion(version.Version, log)
-		menuOptions, err := getMenuOptions(updateAvailable, client, log)
+		menuOptions, err := getMenuOptions(sync, updateAvailable, client, log)
 		if err != nil {
 			log.WithError(err).Fatalf("Could not create menu")
 		}
@@ -168,6 +169,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Optional Kubeconfig file.")
+	rootCmd.PersistentFlags().BoolVar(&sync, "sync", "", "Sync the changes from kubenav with the used Kubeconfig file.")
 }
 
 func main() {

--- a/cmd/electron/menu.go
+++ b/cmd/electron/menu.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os/exec"
 	"runtime"
+	"sort"
 
 	"github.com/kubenav/kubenav/pkg/electron/kube"
 
@@ -135,14 +136,22 @@ func createFileMenu(updateAvailable bool, log *logrus.Logger) *astilectron.MenuI
 func getMenuOptions(sync bool, updateAvailable bool, client *kube.Client, log *logrus.Logger) ([]*astilectron.MenuItemOptions, error) {
 	fileMenu := createFileMenu(updateAvailable, log)
 
+	// Load all clusters from the Kubeconfig file and sort the clusters alphabetical. Then iterate over the clusters and
+	// create a menu entry for each cluster.
 	clusters, err := client.Clusters()
 	if err != nil {
 		return nil, err
 	}
 
+	contexts := make([]string, 0, len(clusters))
+	for c := range clusters {
+		contexts = append(contexts, c)
+	}
+	sort.Strings(contexts)
+
 	var clusterSubMenu []*astilectron.MenuItemOptions
-	for cluster := range clusters {
-		item := createClusterMenuItem(cluster, sync, client, log)
+	for _, context := range contexts {
+		item := createClusterMenuItem(context, sync, client, log)
 		clusterSubMenu = append(clusterSubMenu, &item)
 	}
 

--- a/cmd/electron/menu.go
+++ b/cmd/electron/menu.go
@@ -35,11 +35,17 @@ func openBrowser(url string) {
 
 // createClusterMenuItem creates a new menu item for a given context from the Kubeconfig file.
 // When the cluster is selected an "cluster" event will be send to the frontend via SSE.
-func createClusterMenuItem(cluster string, log *logrus.Logger) astilectron.MenuItemOptions {
+func createClusterMenuItem(cluster string, sync bool, client *kube.Client, log *logrus.Logger) astilectron.MenuItemOptions {
 	return astilectron.MenuItemOptions{
 		Label: astikit.StrPtr(cluster),
 		OnClick: func(e astilectron.Event) (deleteListener bool) {
 			log.Debugf("Menu item '%s' has been clicked", cluster)
+			if sync {
+				err := client.ChangeContext(cluster)
+				if err != nil {
+					log.WithError(err).Errorf("Could not save selected context")
+				}
+			}
 			messageChannel <- Message{Event: "cluster", Data: cluster}
 			return
 		},
@@ -126,7 +132,7 @@ func createFileMenu(updateAvailable bool, log *logrus.Logger) *astilectron.MenuI
 }
 
 // getMenuOptions returns the menu for the Electron app.
-func getMenuOptions(updateAvailable bool, client *kube.Client, log *logrus.Logger) ([]*astilectron.MenuItemOptions, error) {
+func getMenuOptions(sync bool, updateAvailable bool, client *kube.Client, log *logrus.Logger) ([]*astilectron.MenuItemOptions, error) {
 	fileMenu := createFileMenu(updateAvailable, log)
 
 	clusters, err := client.Clusters()
@@ -136,7 +142,7 @@ func getMenuOptions(updateAvailable bool, client *kube.Client, log *logrus.Logge
 
 	var clusterSubMenu []*astilectron.MenuItemOptions
 	for cluster := range clusters {
-		item := createClusterMenuItem(cluster, log)
+		item := createClusterMenuItem(cluster, sync, client, log)
 		clusterSubMenu = append(clusterSubMenu, &item)
 	}
 

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -9,13 +9,18 @@ import (
 )
 
 var client *kube.Client
+var syncKubeconfig bool
 
 // Register registers the needed API routes for the Electron version of kubenav.
-func Register(router *http.ServeMux, kubeClient *kube.Client) {
+func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
+	syncKubeconfig = sync
 	client = kubeClient
 
 	router.HandleFunc("/api/cluster", middleware.Cors(clusterHandler))
 	router.HandleFunc("/api/clusters", middleware.Cors(clustersHandler))
+
+	router.HandleFunc("/api/sync/context", middleware.Cors(syncContextHandler))
+	router.HandleFunc("/api/sync/namespace", middleware.Cors(syncNamespaceHandler))
 
 	router.HandleFunc("/api/kubernetes/request", middleware.Cors(requestHandler))
 	router.HandleFunc("/api/kubernetes/exec", middleware.Cors(execHandler))

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -110,6 +110,8 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 }
 
 // ChangeContext is used to modify the current-context value in the used Kubeconfig file and to persist these changes.
+// Note: We modify the raw config directly and do not use the logic of the ConfigClientset function, because the
+// override has no effect to the raw config. See: https://github.com/kubernetes/client-go/issues/735
 func (c *Client) ChangeContext(context string) error {
 	raw, err := c.config.RawConfig()
 	if err != nil {
@@ -124,6 +126,10 @@ func (c *Client) ChangeContext(context string) error {
 // ChangeNamespace is used to modify the namespace of the currently selected context and to persist these changes in the
 // Kubeconfig file.
 func (c *Client) ChangeNamespace(context, namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+
 	raw, err := c.config.RawConfig()
 	if err != nil {
 		return err

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -125,6 +125,8 @@ func (c *Client) ChangeContext(context string) error {
 
 // ChangeNamespace is used to modify the namespace of the currently selected context and to persist these changes in the
 // Kubeconfig file.
+// In the frontend it is possible to select "" as namespace, which is used for the all namespaces selection. This isn't
+// a valid value for the Kubeconfig file. Therefor we don't write these value back to the Kubeconfig file.
 func (c *Client) ChangeNamespace(context, namespace string) error {
 	if namespace == "" {
 		return nil

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -18,14 +18,15 @@ var (
 
 // Client implements an API client for a Kubernetes cluster.
 type Client struct {
-	config clientcmd.ClientConfig
+	config     clientcmd.ClientConfig
+	kubeconfig string
 }
 
 // Cluster implements the cluster type used in the React app.
 type Cluster struct {
 	ID                       string `json:"id"`
 	Name                     string `json:"name"`
-	Url                      string `json:"url"`
+	URL                      string `json:"url"`
 	CertificateAuthorityData string `json:"certificateAuthorityData"`
 	ClientCertificateData    string `json:"clientCertificateData"`
 	ClientKeyData            string `json:"clientKeyData"`
@@ -34,13 +35,6 @@ type Cluster struct {
 	Password                 string `json:"password"`
 	AuthProvider             string `json:"authProvider"`
 	Namespace                string `json:"namespace"`
-}
-
-// JSONPatch is the json patch formate to update the machine deployment
-type JSONPatch struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value int32  `json:"value"`
 }
 
 // homeDir returns the users home directory, where the '.kube' directory is located.
@@ -76,7 +70,8 @@ func NewClient(kubeconfig string) (*Client, error) {
 	)
 
 	return &Client{
-		config: config,
+		config:     config,
+		kubeconfig: kubeconfig,
 	}, nil
 }
 
@@ -106,12 +101,37 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 		clusters[context] = Cluster{
 			ID:        context,
 			Name:      context,
-			Url:       cluster.Server,
+			URL:       cluster.Server,
 			Namespace: details.Namespace,
 		}
 	}
 
 	return clusters, nil
+}
+
+// ChangeContext is used to modify the current-context value in the used Kubeconfig file and to persist these changes.
+func (c *Client) ChangeContext(context string) error {
+	raw, err := c.config.RawConfig()
+	if err != nil {
+		return err
+	}
+
+	raw.CurrentContext = context
+
+	return clientcmd.WriteToFile(raw, c.kubeconfig)
+}
+
+// ChangeNamespace is used to modify the namespace of the currently selected context and to persist these changes in the
+// Kubeconfig file.
+func (c *Client) ChangeNamespace(context, namespace string) error {
+	raw, err := c.config.RawConfig()
+	if err != nil {
+		return err
+	}
+
+	raw.Contexts[context].Namespace = namespace
+
+	return clientcmd.WriteToFile(raw, c.kubeconfig)
 }
 
 // ConfigClientset creates the config and clientset for an Kubernetes API call.

--- a/pkg/electron/sync.go
+++ b/pkg/electron/sync.go
@@ -1,0 +1,78 @@
+package electron
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/kubenav/kubenav/pkg/api/middleware"
+)
+
+// Sync is the structure for a sync request and contains the context or namespace as values.
+type Sync struct {
+	Context   string `json:"context"`
+	Namespace string `json:"namespace"`
+}
+
+// syncContextHandler applies the changes of the current context to the loaded Kubeconfig.
+func syncContextHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+	}
+
+	if !syncKubeconfig {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var sync Sync
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Sync body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&sync)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode sync body")
+		return
+	}
+
+	err = client.ChangeContext(sync.Context)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not change context")
+		return
+	}
+
+	middleware.Write(w, r, nil)
+	return
+}
+
+// syncContextHandler applies the changes of the current namespace to the loaded Kubeconfig.
+func syncNamespaceHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+	}
+
+	if !syncKubeconfig {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var sync Sync
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Sync body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&sync)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode sync body")
+		return
+	}
+
+	err = client.ChangeNamespace(sync.Context, sync.Namespace)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not change namespace")
+		return
+	}
+
+	middleware.Write(w, r, nil)
+	return
+}

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -271,4 +271,6 @@ export type TCondition =
   | V1ReplicationControllerCondition
   | V1StatefulSetCondition;
 
+export type TSyncType = 'context' | 'namespace';
+
 export type TTerminal = 'shell' | 'logs';

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -10,6 +10,7 @@ import {
   IOIDCProvider,
   IOIDCProviderToken,
   ITerminalResponse,
+  TSyncType,
 } from '../declarations';
 import { GOOGLE_REDIRECT_URI, OIDC_REDIRECT_URL_WEB, SERVER } from './constants';
 import { isJSON } from './helpers';
@@ -523,6 +524,33 @@ export const getOIDCRefreshToken = async (
     if (response.status >= 200 && response.status < 300) {
       return json;
     } else {
+      if (json.error) {
+        throw new Error(json.message);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+// syncKubeconfig is used to applie the changes to the current context or namespace to the loaded Kubeconfig file.
+export const syncKubeconfig = async (context: string, namespace: string, syncType: TSyncType): Promise<boolean> => {
+  try {
+    const response = await fetch(`${SERVER}/api/sync/${syncType}`, {
+      method: 'post',
+      body: JSON.stringify({
+        context: context,
+        namespace: namespace,
+      }),
+    });
+
+    if (response.status >= 200 && response.status < 300) {
+      return true;
+    } else {
+      const json = await response.json();
+
       if (json.error) {
         throw new Error(json.message);
       } else {


### PR DESCRIPTION
When the new `sync` flag is activated and a cluster is selected via the **Clusters** menu, the **current-context** value in the used Kubeconfig is also modified. When a cluster or namespace is selected in the frontend the loaded Kubeconfig is also adjusted. The cluster menu is now sorted alphabetical again.

Closes #50.