### PR TITLE
Support multiple Kubeconfig files

### DIFF
--- a/cmd/devserver/main.go
+++ b/cmd/devserver/main.go
@@ -12,20 +12,29 @@ import (
 )
 
 var (
-	debug      = flag.Bool("debug", false, "Enable debug mode.")
-	kubeconfig = flag.String("kubeconfig", "", "Optional Kubeconfig file.")
-	sync       = flag.Bool("sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
+	debugFlag             = flag.Bool("debug", false, "Enable debug mode.")
+	kubeconfigFlag        = flag.String("kubeconfig", "", "Optional Kubeconfig file.")
+	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig. When this option is used the '-kubeconfig' and '-sync' flag is ignored.")
+	kubeconfigExcludeFlag = flag.String("kubeconfig-exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '-kubeconfig-include' flag.")
+	syncFlag              = flag.Bool("sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
 )
 
 func main() {
 	// Parse command-line flags.
+	// When the "-kubeconfig-includ" flag is used the sync flag is ignored. Therefor we set the sync value always to
+	// false. The same applies for the "-kubeconfig" flag, but this is handled by the Kubernetes client.
 	flag.Parse()
+
+	sync := *syncFlag
+	if *kubeconfigIncludeFlag != "" {
+		sync = false
+	}
 
 	// Setup the logger and print the version information.
 	log := logrus.StandardLogger()
 
 	logLevel := logrus.InfoLevel
-	if *debug {
+	if *debugFlag {
 		logLevel = logrus.DebugLevel
 	}
 
@@ -34,14 +43,14 @@ func main() {
 	log.Infof(version.BuildContext())
 
 	// Create the client for the interaction with the Kubernetes API.
-	client, err := kube.NewClient(*kubeconfig)
+	client, err := kube.NewClient(*kubeconfigFlag, *kubeconfigIncludeFlag, *kubeconfigExcludeFlag)
 	if err != nil {
 		log.WithError(err).Fatalf("Could not create Kubernetes client")
 	}
 
 	// Register the API for the Electron app and start the server.
 	router := http.NewServeMux()
-	electron.Register(router, *sync, client)
+	electron.Register(router, sync, client)
 
 	if err := http.ListenAndServe(":14122", router); err != nil {
 		log.WithError(err).Fatalf("kubenav server died")

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -47,8 +46,6 @@ func loadConfigFile(kubeconfig string) (clientcmd.ClientConfig, error) {
 func loadConfigFiles(includeKubeconfig, excludeKubeconfig string) (clientcmd.ClientConfig, error) {
 	includes := getFilesFromString(includeKubeconfig)
 	excludes := getFilesFromString(excludeKubeconfig)
-
-	fmt.Println(includes, excludes)
 
 	includeFiles, err := getFilesForGlobs(includes)
 	if err != nil {

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -1,0 +1,97 @@
+package kube
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// homeDir returns the users home directory, where the '.kube' directory is located.
+// The '.kube' directory contains the configuration file for a Kubernetes cluster.
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+
+	// Get the home directory on windows.
+	return os.Getenv("USERPROFILE")
+}
+
+// loadConfigFile loads a single Kubeconfig file. If the "-kubeconfig" flag is set the provided file will be used. If
+// the value is empty the "KUBECONFIG" environment variable or the "~/.kube/config" file is used.
+func loadConfigFile(kubeconfig string) (clientcmd.ClientConfig, error) {
+	if kubeconfig == "" {
+		if os.Getenv("KUBECONFIG") == "" {
+			if home := homeDir(); home != "" {
+				kubeconfig = filepath.Join(home, ".kube", "config")
+			} else {
+				return nil, ErrConfigNotFound
+			}
+		} else {
+			kubeconfig = os.Getenv("KUBECONFIG")
+		}
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{},
+	), nil
+}
+
+// loadConfigFiles loads and merged multiple Kubeconfig file by the provided glob. If a file matches the exlude glob the
+// file isn't included in the final config object.
+func loadConfigFiles(includeKubeconfig, excludeKubeconfig string) (clientcmd.ClientConfig, error) {
+	includes := strings.Split(includeKubeconfig, ",")
+	excludes := strings.Split(excludeKubeconfig, ",")
+
+	includeFiles, err := getFilesForGlobs(includes)
+	if err != nil {
+		return nil, err
+	}
+
+	excludeFiles, err := getFilesForGlobs(excludes)
+	if err != nil {
+		return nil, err
+	}
+
+	var kubeconfigFiles []string
+	for _, file := range includeFiles {
+		if !fileExistsInFiles(file, excludeFiles) {
+			kubeconfigFiles = append(kubeconfigFiles, file)
+		}
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{Precedence: kubeconfigFiles},
+		&clientcmd.ConfigOverrides{},
+	), nil
+}
+
+// getFilesForGlobs returns a list of files for a list of globs using the filepath.Glob function. The accepted pattern
+// for a glob can be found here: https://golang.org/pkg/path/filepath/#Match
+func getFilesForGlobs(globs []string) ([]string, error) {
+	var files []string
+	for _, glob := range globs {
+		f, err := filepath.Glob(glob)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, f...)
+	}
+
+	return files, nil
+}
+
+// fileExistsInFiles returns true when a file exists in a slice of files. When the file doesn't exists in the slice the
+// function returns false.
+func fileExistsInFiles(file string, files []string) bool {
+	for _, f := range files {
+		if f == file {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
To support multiple Kubeconfig files we are adding two new flags: `-kubeconfig-include` and `-kubeconfig-exclude`. These flags can be used to provide paths were kubenav should look for Kubeconfig files.

When the `-kubeconfig-include` flag is provided the `-kubeconfig` and `-sync` flag is ignored, because the flags are used to provide an explicit path to a Kubeconfig file and we couldn't wrote the changes back to an explicit file.

Example:

```sh
# Load all config files from the ~/Documents/kubeconfig which starts with kubeconfig.
# Ignore all config files which contains the word dev.
kubenav -kubeconfig-include "~/.kube/config,~/Documents/kubeconfig/kubeconfig-*" -kubeconfig-exclude "~/Documents/kubeconfig/kubeconfig-*dev*"
```

Closes #52.