### PR TITLE
Improve CRD Support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import '@ionic/react/css/typography.css';
 
 import HomePage from './components/HomePage';
 import Menu from './components/menu/Menu';
+import CustomResourcesDetailsPage from './components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage';
 import CustomResourcesListPage from './components/resources/cluster/customResourceDefinitions/CustomResourcesListPage';
 import DetailsPage from './components/resources/DetailsPage';
 import ListPage from './components/resources/ListPage';
@@ -49,6 +50,11 @@ const App: React.FunctionComponent = () => (
               <Route path="/resources/:section/:type" component={ListPage} exact={true} />
               <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />
               <Route path="/customresources/:group/:version/:name" component={CustomResourcesListPage} exact={true} />
+              <Route
+                path="/customresources/:group/:version/:name/:crnamespace/:crname"
+                component={CustomResourcesDetailsPage}
+                exact={true}
+              />
               <Route path="/settings/clusters" component={ClustersPage} exact={true} />
               <Route path="/settings/clusters/aws/:region" component={ClustersAWSPage} exact={true} />
               <Route path="/settings/clusters/azure" component={ClustersAzurePage} exact={true} />

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourceItem.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourceItem.tsx
@@ -1,50 +1,29 @@
-import {
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonIcon,
-  IonItem,
-  IonLabel,
-  IonModal,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/react';
-import { close } from 'ionicons/icons';
-import yaml from 'js-yaml';
-import React, { useState } from 'react';
-
-import Editor from '../../../misc/Editor';
+import { IonItem, IonLabel } from '@ionic/react';
+import React from 'react';
 
 interface ICustomResourceItemProps {
+  group: string;
+  version: string;
+  name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any;
 }
 
-const CustomResourceItem: React.FunctionComponent<ICustomResourceItemProps> = ({ item }: ICustomResourceItemProps) => {
-  const [showModal, setShowModal] = useState<boolean>(false);
-
+const CustomResourceItem: React.FunctionComponent<ICustomResourceItemProps> = ({
+  group,
+  version,
+  name,
+  item,
+}: ICustomResourceItemProps) => {
   return (
-    <React.Fragment>
-      <IonItem button={true} onClick={() => setShowModal(true)}>
-        <IonLabel>
-          <h2>{item.metadata ? item.metadata.name : ''}</h2>
-        </IonLabel>
-      </IonItem>
-
-      <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
-        <IonHeader>
-          <IonToolbar>
-            <IonButtons slot="start" onClick={() => setShowModal(false)}>
-              <IonIcon slot="icon-only" icon={close} />
-            </IonButtons>
-            <IonTitle>{item.metadata ? item.metadata.name : ''}</IonTitle>
-          </IonToolbar>
-        </IonHeader>
-        <IonContent>
-          <Editor readOnly={true} value={yaml.safeDump(item)} fullHeight={true} />
-        </IonContent>
-      </IonModal>
-    </React.Fragment>
+    <IonItem
+      routerLink={`/customresources/${group}/${version}/${name}/${item.metadata.namespace}/${item.metadata.name}`}
+      routerDirection="forward"
+    >
+      <IonLabel>
+        <h2>{item.metadata ? item.metadata.name : ''}</h2>
+      </IonLabel>
+    </IonItem>
   );
 };
 

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
@@ -1,0 +1,213 @@
+import { RefresherEventDetail } from '@ionic/core';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonCol,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonGrid,
+  IonPage,
+  IonProgressBar,
+  IonRefresher,
+  IonRow,
+  IonTitle,
+  IonToolbar,
+  isPlatform,
+} from '@ionic/react';
+import { refresh } from 'ionicons/icons';
+import yaml from 'js-yaml';
+import React, { useContext, useEffect, useState } from 'react';
+import { RouteComponentProps } from 'react-router';
+
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import Editor from '../../../misc/Editor';
+import LoadingErrorCard from '../../../misc/LoadingErrorCard';
+import List from '../../misc/List';
+import DeleteItem from '../../misc/modify/DeleteItem';
+import EditItem from '../../misc/modify/EditItem';
+import Conditions from '../../misc/template/Conditions';
+import Metadata from '../../misc/template/Metadata';
+
+interface IMatchParams {
+  group: string;
+  version: string;
+  name: string;
+  crnamespace: string;
+  crname: string;
+}
+
+type ICustomResourcesDetailsPageProps = RouteComponentProps<IMatchParams>;
+
+const getURL = (namespace: string, group: string, version: string, name: string, crname: string): string => {
+  return namespace && namespace !== 'undefined'
+    ? `/apis/${group}/${version}/namespaces/${namespace}/${name}/${crname}`
+    : `/apis/${group}/${version}/${name}/${crname}`;
+};
+
+const CustomResourcesDetailsPage: React.FunctionComponent<ICustomResourcesDetailsPageProps> = ({
+  match,
+}: ICustomResourcesDetailsPageProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [error, setError] = useState<string>('');
+  const [showLoading, setShowLoading] = useState<boolean>(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [item, setItem] = useState<any>();
+  const [url, setUrl] = useState<string>('');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setItem(undefined);
+      setUrl(match.url);
+      await load();
+    };
+
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [match, context.clusters, context.cluster]);
+
+  const doRefresh = async (event: CustomEvent<RefresherEventDetail>) => {
+    event.detail.complete();
+    await load();
+  };
+
+  const load = async () => {
+    setShowLoading(true);
+
+    try {
+      if (!context.clusters || !context.cluster) {
+        throw new Error('Select an active cluster');
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data: any = await context.request(
+        'GET',
+        getURL(
+          match.params.crnamespace,
+          match.params.group,
+          match.params.version,
+          match.params.name,
+          match.params.crname,
+        ),
+        '',
+      );
+      setError('');
+      setItem(data);
+    } catch (err) {
+      setError(err.message);
+    }
+
+    setShowLoading(false);
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton
+              defaultHref={`/customresources/${match.params.group}/${match.params.group}/${match.params.name}`}
+            />
+          </IonButtons>
+          <IonTitle>{match.params.crname}</IonTitle>
+          {!isPlatform('hybrid') ? (
+            <IonButtons slot="primary">
+              <IonButton onClick={() => load()}>
+                <IonIcon slot="icon-only" icon={refresh} />
+              </IonButton>
+              {item ? (
+                <EditItem
+                  activator="button"
+                  item={item}
+                  url={getURL(
+                    match.params.crnamespace,
+                    match.params.group,
+                    match.params.version,
+                    match.params.name,
+                    match.params.crname,
+                  )}
+                />
+              ) : null}
+              {item ? (
+                <DeleteItem
+                  activator="button"
+                  item={item}
+                  url={getURL(
+                    match.params.crnamespace,
+                    match.params.group,
+                    match.params.version,
+                    match.params.name,
+                    match.params.crname,
+                  )}
+                />
+              ) : null}
+            </IonButtons>
+          ) : null}
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        {showLoading ? <IonProgressBar slot="fixed" type="indeterminate" color="primary" /> : null}
+        <IonRefresher slot="fixed" onIonRefresh={doRefresh} />
+
+        {error === '' &&
+        context.clusters &&
+        context.cluster &&
+        context.clusters.hasOwnProperty(context.cluster) &&
+        match.url === url &&
+        item ? (
+          <IonGrid>
+            {item.metadata ? <Metadata metadata={item.metadata} type="customresource" /> : null}
+
+            {item.status && item.status.conditions ? (
+              <IonRow>
+                <Conditions conditions={item.status.conditions} forceFullWidth={true} />
+              </IonRow>
+            ) : null}
+
+            {item.metadata && item.metadata.name && item.metadata.namespace ? (
+              <IonRow>
+                <List
+                  name="Events"
+                  section="cluster"
+                  type="events"
+                  namespace={item.metadata.namespace}
+                  selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
+                />
+              </IonRow>
+            ) : null}
+
+            <IonRow>
+              <IonCol>
+                <IonCard>
+                  <IonCardHeader>
+                    <IonCardTitle>YAML</IonCardTitle>
+                  </IonCardHeader>
+                  <IonCardContent>
+                    <Editor readOnly={true} value={yaml.safeDump(item)} />
+                  </IonCardContent>
+                </IonCard>
+              </IonCol>
+            </IonRow>
+          </IonGrid>
+        ) : (
+          <LoadingErrorCard
+            cluster={context.cluster}
+            clusters={context.clusters}
+            error={error}
+            icon="/assets/icons/kubernetes/crd.png"
+            text={`Could not get Custom Resource "${match.params.crname}"`}
+          />
+        )}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default CustomResourcesDetailsPage;

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -139,7 +139,12 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
                             match.params.name,
                           )}/${item.metadata ? item.metadata.name : ''}`}
                         >
-                          <CustomResourceItem item={item} />
+                          <CustomResourceItem
+                            group={match.params.group}
+                            version={match.params.version}
+                            name={match.params.name}
+                            item={item}
+                          />
                         </ItemOptions>
                       );
                     })
@@ -152,7 +157,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
             clusters={context.clusters}
             error={error}
             icon="/assets/icons/kubernetes/crd.png"
-            text={`Could not get Custom Resource "${match.params.name}"`}
+            text={`Could not get Custom Resources "${match.params.name}"`}
           />
         )}
       </IonContent>

--- a/src/components/resources/misc/template/Conditions.tsx
+++ b/src/components/resources/misc/template/Conditions.tsx
@@ -7,11 +7,21 @@ import IonCardEqualHeight from '../../../misc/IonCardEqualHeight';
 
 interface IPodConditionsProps {
   conditions: TCondition[];
+  forceFullWidth?: boolean;
 }
 
-const Conditions: React.FunctionComponent<IPodConditionsProps> = ({ conditions }: IPodConditionsProps) => {
+const Conditions: React.FunctionComponent<IPodConditionsProps> = ({
+  conditions,
+  forceFullWidth,
+}: IPodConditionsProps) => {
   return (
-    <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="6" sizeXl="6">
+    <IonCol
+      sizeXs="12"
+      sizeSm="12"
+      sizeMd="12"
+      sizeLg={forceFullWidth ? '12' : '6'}
+      sizeXl={forceFullWidth ? '12' : '6'}
+    >
       <IonCardEqualHeight>
         <IonCardHeader>
           <IonCardTitle>Conditions</IonCardTitle>


### PR DESCRIPTION
Each CR for a CRD is now shown on a separate page. This pages includes metadata information, events and the conditions if provided. The modal view for the CR was removed, instead the manifest file is shown in a YAML field on the new page.