### PR TITLE
Add search function for terminal and logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15800,6 +15800,11 @@
       "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.4.0.tgz",
       "integrity": "sha512-p4BESuV/g2L6pZzFHpeNLLnep9mp/DkF3qrPglMiucSFtD8iJxtMufEoEJbN8LZwB4i+8PFpFvVuFrGOSpW05w=="
     },
+    "xterm-addon-search": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-search/-/xterm-addon-search-0.7.0.tgz",
+      "integrity": "sha512-6060evmJJ+tZcjnx33FXaeEHLpuXEa7l9UzUsYfMlCKbu88AbE+5LJocTKCHYd71cwCwb9pjmv/G1o9Rf9Zbcg=="
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "sockjs-client": "^1.4.0",
     "typescript": "^3.8.3",
     "xterm": "^4.6.0",
-    "xterm-addon-fit": "^0.4.0"
+    "xterm-addon-fit": "^0.4.0",
+    "xterm-addon-search": "^0.7.0"
   },
   "devDependencies": {
     "@capacitor/cli": "^2.1.0",

--- a/src/components/terminal/AddLogs.tsx
+++ b/src/components/terminal/AddLogs.tsx
@@ -32,6 +32,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ namespace, pod, conta
       cursorBlink: true,
       disableStdin: true,
       convertEol: true,
+      scrollback: 10000,
       theme: context.settings.darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
     });
 
@@ -167,7 +168,15 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ namespace, pod, conta
       </IonPopover>
 
       {mobile ? (
-        <IonItemOption color="primary" onClick={() => setShowPopover(true)}>
+        <IonItemOption
+          color="primary"
+          onClick={(e) => {
+            e.persist();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setPopoverEvent(e as any);
+            setShowPopover(true);
+          }}
+        >
           <IonIcon slot="start" icon={list} />
           Logs
         </IonItemOption>

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -26,6 +26,7 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({ namespace, pod, con
       fontSize: 12,
       bellStyle: 'sound',
       cursorBlink: true,
+      scrollback: 10000,
       theme: context.settings.darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
     });
 

--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -1,8 +1,10 @@
 import { Plugins } from '@capacitor/core';
-import { isPlatform } from '@ionic/react';
+import { IonButton, IonButtons, IonIcon, IonSearchbar, IonToolbar, isPlatform } from '@ionic/react';
+import { arrowBack, arrowForward } from 'ionicons/icons';
 import React, { useRef, useEffect, useState } from 'react';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
+import { SearchAddon } from 'xterm-addon-search';
 
 import 'xterm/css/xterm.css';
 
@@ -11,19 +13,27 @@ import { ITerminal } from '../../declarations';
 const { Keyboard } = Plugins;
 
 interface IShellProps {
+  showSearch: boolean;
   terminal: ITerminal;
 }
 
-const Shell: React.FunctionComponent<IShellProps> = ({ terminal }: IShellProps) => {
+const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, terminal }: IShellProps) => {
   const termRef = useRef<HTMLDivElement>(null);
   const [term, setTerm] = useState<Terminal>();
+  const [searchText, setSearchText] = useState<string>('');
 
   const fitAddon = new FitAddon();
+  const searchAddon = new SearchAddon();
 
   useEffect(() => {
     setTerm(terminal.shell);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    updateTerminalSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSearch]);
 
   useEffect(() => {
     return () => {
@@ -36,6 +46,7 @@ const Shell: React.FunctionComponent<IShellProps> = ({ terminal }: IShellProps) 
       setTimeout(() => {
         if (termRef.current && term) {
           term.loadAddon(fitAddon);
+          term.loadAddon(searchAddon);
           term.open(termRef.current);
           fitAddon.fit();
 
@@ -64,9 +75,63 @@ const Shell: React.FunctionComponent<IShellProps> = ({ terminal }: IShellProps) 
 
   const updateTerminalSize = () => {
     fitAddon.fit();
+
+    if (showSearch) {
+      term?.resize(term.cols, term.rows - 4);
+    } else {
+      term?.resize(term.cols, term.rows + 4);
+    }
   };
 
-  return <div className="terminal-container" ref={termRef}></div>;
+  const search = (event) => {
+    const text = event.detail.value ? event.detail.value : '';
+    setSearchText(text);
+
+    if (term && text !== '') {
+      term?.loadAddon(searchAddon);
+      searchAddon.findNext(text);
+    }
+  };
+
+  const searchNext = () => {
+    if (term && searchText !== '') {
+      term?.loadAddon(searchAddon);
+      searchAddon.findNext(searchText);
+    }
+  };
+
+  const searchPrevious = () => {
+    if (term && searchText !== '') {
+      term?.loadAddon(searchAddon);
+      searchAddon.findPrevious(searchText);
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {showSearch ? (
+        <IonToolbar>
+          <IonSearchbar
+            // Add padding to the top on iOS, because this is null when the searchbar is placed in a toolbar
+            // See: https://github.com/ionic-team/ionic/blob/acaa1d9ef7e4037913159c0d32829183ddc1860b/core/src/components/searchbar/searchbar.ios.scss#L160
+            style={showSearch && isPlatform('ios') ? { paddingTop: '15px' } : {}}
+            inputmode="search"
+            value={searchText}
+            onIonChange={search}
+          />
+          <IonButtons style={showSearch && isPlatform('ios') ? { paddingTop: '10px' } : {}} slot="end">
+            <IonButton onClick={searchPrevious}>
+              <IonIcon slot="icon-only" icon={arrowBack} />
+            </IonButton>
+            <IonButton onClick={searchNext}>
+              <IonIcon slot="icon-only" icon={arrowForward} />
+            </IonButton>
+          </IonButtons>
+        </IonToolbar>
+      ) : null}
+      <div style={{ width: '100%', height: showSearch ? 'calc(100% - 56px)' : '100%' }} ref={termRef}></div>
+    </React.Fragment>
+  );
 };
 
 export default Shell;

--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -19,6 +19,7 @@ interface IShellProps {
 
 const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, terminal }: IShellProps) => {
   const termRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLIonSearchbarElement>(null);
   const [term, setTerm] = useState<Terminal>();
   const [searchText, setSearchText] = useState<string>('');
 
@@ -29,11 +30,6 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, terminal }: I
     setTerm(terminal.shell);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    updateTerminalSize();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showSearch]);
 
   useEffect(() => {
     return () => {
@@ -72,6 +68,15 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, terminal }: I
     handleTerminalInit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [termRef, term]);
+
+  useEffect(() => {
+    if (showSearch && searchRef) {
+      searchRef.current?.setFocus();
+    }
+
+    updateTerminalSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSearch]);
 
   const updateTerminalSize = () => {
     fitAddon.fit();
@@ -118,6 +123,7 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, terminal }: I
             inputmode="search"
             value={searchText}
             onIonChange={search}
+            ref={searchRef}
           />
           <IonButtons style={showSearch && isPlatform('ios') ? { paddingTop: '10px' } : {}} slot="end">
             <IonButton onClick={searchPrevious}>

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -5,6 +5,8 @@ import {
   IonHeader,
   IonIcon,
   IonItem,
+  IonItemDivider,
+  IonItemGroup,
   IonLabel,
   IonList,
   IonModal,
@@ -15,7 +17,7 @@ import {
   IonToolbar,
 } from '@ionic/react';
 import { close, ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { ITerminal } from '../../declarations';
 import Shell from './Shell';
@@ -38,7 +40,12 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
   removeTerminal,
 }: ITerminalsProps) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [showSearch, setShowSearch] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
+
+  useEffect(() => {
+    setShowSearch(false);
+  }, [activeTerminal, showModal]);
 
   return (
     <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
@@ -71,21 +78,38 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
 
           <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
             <IonList>
-              {terminals.map((terminal, index) => {
-                return (
-                  <IonItem
-                    key={index}
-                    button={true}
-                    detail={false}
-                    onClick={() => {
-                      setShowPopover(false);
-                      removeTerminal(index);
-                    }}
-                  >
-                    <IonLabel>{terminal.name}</IonLabel>
-                  </IonItem>
-                );
-              })}
+              <IonItemGroup>
+                <IonItem
+                  button={true}
+                  detail={false}
+                  onClick={() => {
+                    setShowSearch(!showSearch);
+                    setShowPopover(false);
+                  }}
+                >
+                  <IonLabel>Search</IonLabel>
+                </IonItem>
+              </IonItemGroup>
+              <IonItemGroup>
+                <IonItemDivider>
+                  <IonLabel>Close</IonLabel>
+                </IonItemDivider>
+                {terminals.map((terminal, index) => {
+                  return (
+                    <IonItem
+                      key={index}
+                      button={true}
+                      detail={false}
+                      onClick={() => {
+                        setShowPopover(false);
+                        removeTerminal(index);
+                      }}
+                    >
+                      <IonLabel>{terminal.name}</IonLabel>
+                    </IonItem>
+                  );
+                })}
+              </IonItemGroup>
             </IonList>
           </IonPopover>
         </IonToolbar>
@@ -110,7 +134,9 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
 
       <IonContent>
         {terminals.map((terminal, index) => {
-          return activeTerminal === `term_${index}` ? <Shell key={index} terminal={terminal} /> : null;
+          return activeTerminal === `term_${index}` ? (
+            <Shell key={index} showSearch={showSearch} terminal={terminal} />
+          ) : null;
         })}
       </IonContent>
     </IonModal>

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -111,9 +111,3 @@ ion-avatar {
 .card-header-image img {
   margin: auto;
 }
-
-/* Terminal */
-.terminal-container {
-  width: 100%;
-  height: 100%;
-}


### PR DESCRIPTION
- It is now possible to search throw the terminal and logs. The searchbar can be open via the popover in the upper right corner in the modal.
- Increase the scrollback buffer to 10000 lines.
- Fix the positioning of the logs popover on modal. The modal wasn't placed next to the button, instead it was centered at the screen.