### PR TITLE
Add menu for details page

### DIFF
--- a/src/components/resources/DetailsPage.tsx
+++ b/src/components/resources/DetailsPage.tsx
@@ -21,9 +21,8 @@ import { IContext } from '../../declarations';
 import { AppContext } from '../../utils/context';
 import { resources } from '../../utils/resources';
 import useAsyncFn from '../../utils/useAsyncFn';
+import DetailsPopover from './misc/DetailsPopover';
 import LoadingErrorCard from '../misc/LoadingErrorCard';
-import DeleteItem from './misc/modify/DeleteItem';
-import EditItem from './misc/modify/EditItem';
 
 interface IMatchParams {
   section: string;
@@ -69,33 +68,23 @@ const DetailsPage: React.FunctionComponent<IDetailsPageProps> = ({ match }: IDet
             <IonBackButton defaultHref={`/resources/${match.params.section}/${match.params.type}`} />
           </IonButtons>
           <IonTitle>{state.value && state.value.metadata ? state.value.metadata.name : ''}</IonTitle>
-          {!isPlatform('hybrid') ? (
-            <IonButtons slot="primary">
+          <IonButtons slot="primary">
+            {!isPlatform('hybrid') ? (
               <IonButton onClick={() => fetch()}>
                 <IonIcon slot="icon-only" icon={refresh} />
               </IonButton>
-              {state.value ? (
-                <EditItem
-                  activator="button"
-                  item={state.value}
-                  url={page.detailsURL(
-                    state.value.metadata ? state.value.metadata.namespace : '',
-                    state.value.metadata ? state.value.metadata.name : '',
-                  )}
-                />
-              ) : null}
-              {state.value ? (
-                <DeleteItem
-                  activator="button"
-                  item={state.value}
-                  url={page.detailsURL(
-                    state.value.metadata ? state.value.metadata.namespace : '',
-                    state.value.metadata ? state.value.metadata.name : '',
-                  )}
-                />
-              ) : null}
-            </IonButtons>
-          ) : null}
+            ) : null}
+            {state.value ? (
+              <DetailsPopover
+                type={match.params.type}
+                item={state.value}
+                url={page.detailsURL(
+                  state.value.metadata ? state.value.metadata.namespace : '',
+                  state.value.metadata ? state.value.metadata.name : '',
+                )}
+              />
+            ) : null}
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
@@ -31,8 +31,7 @@ import useAsyncFn from '../../../../utils/useAsyncFn';
 import Editor from '../../../misc/Editor';
 import LoadingErrorCard from '../../../misc/LoadingErrorCard';
 import List from '../../misc/List';
-import DeleteItem from '../../misc/modify/DeleteItem';
-import EditItem from '../../misc/modify/EditItem';
+import DetailsPopover from '../../misc/DetailsPopover';
 import Conditions from '../../misc/template/Conditions';
 import Metadata from '../../misc/template/Metadata';
 
@@ -99,39 +98,26 @@ const CustomResourcesDetailsPage: React.FunctionComponent<ICustomResourcesDetail
             />
           </IonButtons>
           <IonTitle>{match.params.crname}</IonTitle>
-          {!isPlatform('hybrid') ? (
-            <IonButtons slot="primary">
+          <IonButtons slot="primary">
+            {!isPlatform('hybrid') ? (
               <IonButton onClick={() => fetch()}>
                 <IonIcon slot="icon-only" icon={refresh} />
               </IonButton>
-              {state.value ? (
-                <EditItem
-                  activator="button"
-                  item={state.value}
-                  url={getURL(
-                    match.params.crnamespace,
-                    match.params.group,
-                    match.params.version,
-                    match.params.name,
-                    match.params.crname,
-                  )}
-                />
-              ) : null}
-              {state.value ? (
-                <DeleteItem
-                  activator="button"
-                  item={state.value}
-                  url={getURL(
-                    match.params.crnamespace,
-                    match.params.group,
-                    match.params.version,
-                    match.params.name,
-                    match.params.crname,
-                  )}
-                />
-              ) : null}
-            </IonButtons>
-          ) : null}
+            ) : null}
+            {state.value ? (
+              <DetailsPopover
+                type="customresources"
+                item={state.value}
+                url={getURL(
+                  match.params.crnamespace,
+                  match.params.group,
+                  match.params.version,
+                  match.params.name,
+                  match.params.crname,
+                )}
+              />
+            ) : null}
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import DeleteItem from './modify/DeleteItem';
 import EditItem from './modify/EditItem';
+import ScaleItem from './modify/ScaleItem';
 
 interface IDetailsPopoverProps {
   type: string;
@@ -20,6 +21,12 @@ const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, i
     <React.Fragment>
       <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
         <IonList>
+          {type === 'deployments' ||
+          type === 'statefulsets' ||
+          type === 'replicationcontrollers' ||
+          type === 'replicasets' ? (
+            <ScaleItem activator="item" item={item} url={url} />
+          ) : null}
           <EditItem activator="item" item={item} url={url} />
           <DeleteItem activator="item" item={item} url={url} />
         </IonList>

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import DeleteItem from './modify/DeleteItem';
 import EditItem from './modify/EditItem';
+import RestartItem from './modify/RestartItem';
 import ScaleItem from './modify/ScaleItem';
 
 interface IDetailsPopoverProps {
@@ -26,6 +27,9 @@ const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, i
           type === 'replicationcontrollers' ||
           type === 'replicasets' ? (
             <ScaleItem activator="item" item={item} url={url} />
+          ) : null}
+          {type === 'deployments' || type === 'statefulsets' || type === 'daemonsets' ? (
+            <RestartItem activator="item" item={item} url={url} />
           ) : null}
           <EditItem activator="item" item={item} url={url} />
           <DeleteItem activator="item" item={item} url={url} />

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -1,0 +1,42 @@
+import { IonButton, IonIcon, IonList, IonPopover } from '@ionic/react';
+import { ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
+import React, { useState } from 'react';
+
+import DeleteItem from './modify/DeleteItem';
+import EditItem from './modify/EditItem';
+
+interface IDetailsPopoverProps {
+  type: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+  url: string;
+}
+
+const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, item, url }: IDetailsPopoverProps) => {
+  const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [popoverEvent, setPopoverEvent] = useState();
+
+  return (
+    <React.Fragment>
+      <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
+        <IonList>
+          <EditItem activator="item" item={item} url={url} />
+          <DeleteItem activator="item" item={item} url={url} />
+        </IonList>
+      </IonPopover>
+
+      <IonButton
+        onClick={(e) => {
+          e.persist();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          setPopoverEvent(e as any);
+          setShowPopover(true);
+        }}
+      >
+        <IonIcon slot="icon-only" ios={ellipsisHorizontal} md={ellipsisVertical} />
+      </IonButton>
+    </React.Fragment>
+  );
+};
+
+export default DetailsPopover;

--- a/src/components/resources/misc/modify/DeleteItem.tsx
+++ b/src/components/resources/misc/modify/DeleteItem.tsx
@@ -1,4 +1,4 @@
-import { IonAlert, IonButton, IonIcon, IonItemOption } from '@ionic/react';
+import { IonAlert, IonButton, IonIcon, IonItem, IonItemOption, IonLabel } from '@ionic/react';
 import { trash } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
@@ -39,6 +39,13 @@ const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ activator, item
         <IonButton onClick={() => setShowAlert(true)}>
           <IonIcon slot="icon-only" icon={trash} />
         </IonButton>
+      ) : null}
+
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
+          <IonIcon slot="end" color="primary" icon={trash} />
+          <IonLabel>Delete</IonLabel>
+        </IonItem>
       ) : null}
 
       {error !== '' ? (

--- a/src/components/resources/misc/modify/EditItem.tsx
+++ b/src/components/resources/misc/modify/EditItem.tsx
@@ -5,7 +5,9 @@ import {
   IonContent,
   IonHeader,
   IonIcon,
+  IonItem,
   IonItemOption,
+  IonLabel,
   IonModal,
   IonTitle,
   IonToolbar,
@@ -66,6 +68,13 @@ const EditItem: React.FunctionComponent<IEditItemProps> = ({ activator, item, ur
         <IonButton onClick={() => setShowModal(true)}>
           <IonIcon slot="icon-only" icon={create} />
         </IonButton>
+      ) : null}
+
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowModal(true)}>
+          <IonIcon slot="end" color="primary" icon={create} />
+          <IonLabel>Edit</IonLabel>
+        </IonItem>
       ) : null}
 
       <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>

--- a/src/components/resources/misc/modify/RestartItem.tsx
+++ b/src/components/resources/misc/modify/RestartItem.tsx
@@ -1,0 +1,91 @@
+import * as jsonpatch from 'fast-json-patch';
+import { IonAlert, IonButton, IonIcon, IonItem, IonItemOption, IonLabel } from '@ionic/react';
+import { reload } from 'ionicons/icons';
+import { V1DaemonSet, V1Deployment, V1StatefulSet } from '@kubernetes/client-node';
+import React, { useContext, useState } from 'react';
+
+import { IContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+
+interface IRestartItemProps {
+  activator: TActivator;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: V1DaemonSet | V1Deployment | V1StatefulSet;
+  url: string;
+}
+
+const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, item, url }: IRestartItemProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [showAlert, setShowAlert] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+
+  const handleRestart = async () => {
+    try {
+      const now = new Date();
+      const copy = JSON.parse(JSON.stringify(item));
+
+      if (copy.spec && copy.spec.template.metadata) {
+        if (copy.spec.template.metadata.annotations) {
+          copy.spec.template.metadata.annotations['kubenav.kubernetes.io/restartedAt'] = now.toJSON();
+        } else {
+          copy.spec.template.metadata.annotations = { 'kubenav.kubernetes.io/restartedAt': now.toJSON() };
+        }
+      }
+
+      const diff = jsonpatch.compare(item, copy);
+      await context.request('PATCH', url, JSON.stringify(diff));
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {activator === 'item-option' ? (
+        <IonItemOption color="danger" onClick={() => setShowAlert(true)}>
+          <IonIcon slot="start" icon={reload} />
+          Restart
+        </IonItemOption>
+      ) : null}
+
+      {activator === 'button' ? (
+        <IonButton onClick={() => setShowAlert(true)}>
+          <IonIcon slot="icon-only" icon={reload} />
+        </IonButton>
+      ) : null}
+
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
+          <IonIcon slot="end" color="primary" icon={reload} />
+          <IonLabel>Restart</IonLabel>
+        </IonItem>
+      ) : null}
+
+      {error !== '' ? (
+        <IonAlert
+          isOpen={error !== ''}
+          onDidDismiss={() => setError('')}
+          header={`Could not restart ${item.metadata ? item.metadata.name : ''}`}
+          message={error}
+          buttons={['OK']}
+        />
+      ) : null}
+
+      <IonAlert
+        isOpen={showAlert}
+        onDidDismiss={() => setShowAlert(false)}
+        header={item.metadata ? item.metadata.name : ''}
+        message={`Do you really want to restart ${
+          item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
+        }${item.metadata ? item.metadata.name : ''}?`}
+        buttons={[
+          { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
+          { text: 'Restart', handler: () => handleRestart() },
+        ]}
+      />
+    </React.Fragment>
+  );
+};
+
+export default RestartItem;

--- a/src/components/resources/misc/modify/RestartItem.tsx
+++ b/src/components/resources/misc/modify/RestartItem.tsx
@@ -1,7 +1,7 @@
-import * as jsonpatch from 'fast-json-patch';
 import { IonAlert, IonButton, IonIcon, IonItem, IonItemOption, IonLabel } from '@ionic/react';
-import { reload } from 'ionicons/icons';
 import { V1DaemonSet, V1Deployment, V1StatefulSet } from '@kubernetes/client-node';
+import * as jsonpatch from 'fast-json-patch';
+import { reload } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
 import { IContext, TActivator } from '../../../../declarations';
@@ -9,7 +9,6 @@ import { AppContext } from '../../../../utils/context';
 
 interface IRestartItemProps {
   activator: TActivator;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: V1DaemonSet | V1Deployment | V1StatefulSet;
   url: string;
 }

--- a/src/components/resources/misc/modify/ScaleItem.tsx
+++ b/src/components/resources/misc/modify/ScaleItem.tsx
@@ -1,0 +1,84 @@
+import { IonAlert, IonButton, IonIcon, IonItem, IonItemOption, IonLabel } from '@ionic/react';
+import { copy } from 'ionicons/icons';
+import React, { useContext, useState } from 'react';
+
+import { IContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+
+interface IScaleItemProps {
+  activator: TActivator;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+  url: string;
+}
+
+const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, url }: IScaleItemProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [showAlert, setShowAlert] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+
+  const handleScale = async (replicas: number) => {
+    try {
+      await context.request('PATCH', url, `[{"op": "replace", "path": "/spec/replicas", "value": ${replicas}}]`);
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {activator === 'item-option' ? (
+        <IonItemOption color="danger" onClick={() => setShowAlert(true)}>
+          <IonIcon slot="start" icon={copy} />
+          Scale
+        </IonItemOption>
+      ) : null}
+
+      {activator === 'button' ? (
+        <IonButton onClick={() => setShowAlert(true)}>
+          <IonIcon slot="icon-only" icon={copy} />
+        </IonButton>
+      ) : null}
+
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
+          <IonIcon slot="end" color="primary" icon={copy} />
+          <IonLabel>Scale</IonLabel>
+        </IonItem>
+      ) : null}
+
+      {error !== '' ? (
+        <IonAlert
+          isOpen={error !== ''}
+          onDidDismiss={() => setError('')}
+          header={`Could not scale ${item.metadata ? item.metadata.name : ''}`}
+          message={error}
+          buttons={['OK']}
+        />
+      ) : null}
+
+      <IonAlert
+        isOpen={showAlert}
+        onDidDismiss={() => setShowAlert(false)}
+        header={item.metadata ? item.metadata.name : ''}
+        message={`Enter a new number of replicas for ${
+          item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
+        }${item.metadata ? item.metadata.name : ''}?`}
+        inputs={[
+          {
+            name: 'replicas',
+            type: 'number',
+            value: item.spec && item.spec.replicas ? item.spec.replicas : 0,
+          },
+        ]}
+        buttons={[
+          { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
+          { text: 'Scale', handler: (data) => handleScale(data.replicas) },
+        ]}
+      />
+    </React.Fragment>
+  );
+};
+
+export default ScaleItem;

--- a/src/components/resources/misc/modify/ScaleItem.tsx
+++ b/src/components/resources/misc/modify/ScaleItem.tsx
@@ -1,4 +1,5 @@
 import { IonAlert, IonButton, IonIcon, IonItem, IonItemOption, IonLabel } from '@ionic/react';
+import { V1Deployment, V1StatefulSet, V1ReplicaSet, V1ReplicationController } from '@kubernetes/client-node';
 import { copy } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
@@ -7,8 +8,7 @@ import { AppContext } from '../../../../utils/context';
 
 interface IScaleItemProps {
   activator: TActivator;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  item: any;
+  item: V1Deployment | V1StatefulSet | V1ReplicaSet | V1ReplicationController;
   url: string;
 }
 

--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -166,18 +166,22 @@ const Container: React.FunctionComponent<IContainerProps> = ({
             </p>
           </IonLabel>
           {!isPlatform('hybrid') && logs && name && namespace ? (
-            <AddLogs namespace={namespace} pod={name} container={container.name} mobile={false} />
+            <AddLogs activator="button" namespace={namespace} pod={name} container={container.name} />
           ) : null}
 
           {!isPlatform('hybrid') && terminal && name && namespace ? (
-            <AddShell namespace={namespace} pod={name} container={container.name} mobile={false} />
+            <AddShell activator="button" namespace={namespace} pod={name} container={container.name} />
           ) : null}
         </IonItem>
 
         {isPlatform('hybrid') && logs && name && namespace ? (
           <IonItemOptions side="end">
-            {logs ? <AddLogs namespace={namespace} pod={name} container={container.name} mobile={true} /> : null}
-            {terminal ? <AddShell namespace={namespace} pod={name} container={container.name} mobile={true} /> : null}
+            {logs ? (
+              <AddLogs activator="item-option" namespace={namespace} pod={name} container={container.name} />
+            ) : null}
+            {terminal ? (
+              <AddShell activator="item-option" namespace={namespace} pod={name} container={container.name} />
+            ) : null}
           </IonItemOptions>
         ) : null}
       </IonItemSliding>

--- a/src/components/resources/workloads/daemonSets/DaemonSetItem.tsx
+++ b/src/components/resources/workloads/daemonSets/DaemonSetItem.tsx
@@ -23,9 +23,9 @@ const DaemonSetItem: React.FunctionComponent<IDaemonSetItemProps> = ({ item, sec
     }
 
     if (
-      item.status.desiredNumberScheduled === item.status.currentNumberScheduled ||
-      item.status.desiredNumberScheduled === item.status.numberReady ||
-      item.status.desiredNumberScheduled === item.status.updatedNumberScheduled ||
+      item.status.desiredNumberScheduled === item.status.currentNumberScheduled &&
+      item.status.desiredNumberScheduled === item.status.numberReady &&
+      item.status.desiredNumberScheduled === item.status.updatedNumberScheduled &&
       item.status.desiredNumberScheduled === item.status.numberAvailable
     ) {
       return 'success';

--- a/src/components/terminal/AddLogs.tsx
+++ b/src/components/terminal/AddLogs.tsx
@@ -3,7 +3,7 @@ import { list } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 import { Terminal } from 'xterm';
 
-import { IContext, ITerminalContext } from '../../declarations';
+import { IContext, ITerminalContext, TActivator } from '../../declarations';
 import { logsRequest } from '../../utils/api';
 import { SERVER, TERMINAL_DARK_THEME, TERMINAL_LIGHT_THEME } from '../../utils/constants';
 import { AppContext } from '../../utils/context';
@@ -12,13 +12,13 @@ import { TerminalContext } from '../../utils/terminal';
 const TAIL_LINES = 1000;
 
 interface IAddLogsProps {
+  activator: TActivator;
   namespace: string;
   pod: string;
   container: string;
-  mobile: boolean;
 }
 
-const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ namespace, pod, container, mobile }: IAddLogsProps) => {
+const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace, pod, container }: IAddLogsProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
@@ -167,7 +167,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ namespace, pod, conta
         </IonList>
       </IonPopover>
 
-      {mobile ? (
+      {activator === 'item-option' ? (
         <IonItemOption
           color="primary"
           onClick={(e) => {

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -4,20 +4,25 @@ import React, { useContext } from 'react';
 import SockJS from 'sockjs-client';
 import { Terminal } from 'xterm';
 
-import { IContext, ITerminalContext } from '../../declarations';
+import { IContext, ITerminalContext, TActivator } from '../../declarations';
 import { execRequest } from '../../utils/api';
 import { SERVER, TERMINAL_DARK_THEME, TERMINAL_LIGHT_THEME } from '../../utils/constants';
 import { AppContext } from '../../utils/context';
 import { TerminalContext } from '../../utils/terminal';
 
 interface IAddShellProps {
+  activator: TActivator;
   namespace: string;
   pod: string;
   container: string;
-  mobile: boolean;
 }
 
-const AddShell: React.FunctionComponent<IAddShellProps> = ({ namespace, pod, container, mobile }: IAddShellProps) => {
+const AddShell: React.FunctionComponent<IAddShellProps> = ({
+  activator,
+  namespace,
+  pod,
+  container,
+}: IAddShellProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
@@ -88,7 +93,7 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({ namespace, pod, con
     }
   };
 
-  if (mobile) {
+  if (activator === 'item-option') {
     return (
       <IonItemOption color="primary" onClick={() => add()}>
         <IonIcon slot="start" icon={terminal} />

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -259,7 +259,7 @@ export interface ITerminalResponse {
   id: string;
 }
 
-export type TActivator = 'button' | 'item-option';
+export type TActivator = 'button' | 'item' | 'item-option';
 
 export type TCondition =
   | V1DeploymentCondition


### PR DESCRIPTION
- Reuse `TActivator` for logs and shell.
- Move edit and delete option to a menu on the details page.
- Add scale option to the menu for Deployments, StatefulSets, ReplicationControllers and ReplicaSets. Closes #80. 
- Add restart option for Deployments, StatefulSets and Daemonsets. The command is similar to the `kubectl rollout restart` command.
- Fix DaemonSet status.