### PR TITLE
Restart server for API requests on mobile

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.kubenav.kubenav"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "1.4.4"
+        versionCode 11
+        versionName "1.4.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/android/app/src/main/java/io/kubenav/kubenav/KubenavPlugin.java
+++ b/android/app/src/main/java/io/kubenav/kubenav/KubenavPlugin.java
@@ -1,0 +1,20 @@
+package io.kubenav.kubenav;
+
+import android.os.AsyncTask;
+
+import com.getcapacitor.NativePlugin;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+
+@NativePlugin()
+public class KubenavPlugin extends Plugin {
+
+  @PluginMethod()
+  public void startServer(PluginCall call) {
+    AsyncTask<Void, Void, String> runningServer = new BackgroundServer();
+    runningServer.execute();
+
+    call.success();
+  }
+}

--- a/android/app/src/main/java/io/kubenav/kubenav/MainActivity.java
+++ b/android/app/src/main/java/io/kubenav/kubenav/MainActivity.java
@@ -22,6 +22,7 @@ public class MainActivity extends BridgeActivity {
     this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
       // Additional plugins you've installed go here
       // Ex: add(TotallyAwesomePlugin.class);
+      add(KubenavPlugin.class);
     }});
   }
 }

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.kubenav.kubenav;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -410,7 +410,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = io.kubenav.kubenav;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		5513B08D248CE8620088D8DD /* KubenavPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513B08C248CE8620088D8DD /* KubenavPlugin.swift */; };
+		5513B090248CE8F10088D8DD /* KubenavPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 5513B08F248CE8F10088D8DD /* KubenavPlugin.m */; };
 		552BFCFE2467FA960015C039 /* Mobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552BFCFD2467FA960015C039 /* Mobile.framework */; };
 		55F0C93924633600003250B5 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F0C93824633600003250B5 /* DispatchQueue.swift */; };
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
@@ -29,6 +31,9 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = SOURCE_ROOT; };
+		5513B08C248CE8620088D8DD /* KubenavPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubenavPlugin.swift; sourceTree = "<group>"; };
+		5513B08E248CE8F10088D8DD /* App-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "App-Bridging-Header.h"; sourceTree = "<group>"; };
+		5513B08F248CE8F10088D8DD /* KubenavPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KubenavPlugin.m; sourceTree = "<group>"; };
 		552BFCFD2467FA960015C039 /* Mobile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mobile.framework; sourceTree = "<group>"; };
 		55F0C93824633600003250B5 /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +93,9 @@
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 				55F0C93824633600003250B5 /* DispatchQueue.swift */,
+				5513B08C248CE8620088D8DD /* KubenavPlugin.swift */,
+				5513B08F248CE8F10088D8DD /* KubenavPlugin.m */,
+				5513B08E248CE8F10088D8DD /* App-Bridging-Header.h */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -222,6 +230,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5513B08D248CE8620088D8DD /* KubenavPlugin.swift in Sources */,
+				5513B090248CE8F10088D8DD /* KubenavPlugin.m in Sources */,
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
 				55F0C93924633600003250B5 /* DispatchQueue.swift in Sources */,
 			);
@@ -361,6 +371,7 @@
 			baseConfigurationReference = FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -376,6 +387,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.kubenav.kubenav;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG USE_PUSH";
+				SWIFT_OBJC_BRIDGING_HEADER = "App/App-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -386,6 +399,7 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -400,6 +414,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.kubenav.kubenav;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "App/App-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ios/App/App/App-Bridging-Header.h
+++ b/ios/App/App/App-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/App/App/KubenavPlugin.m
+++ b/ios/App/App/KubenavPlugin.m
@@ -1,0 +1,13 @@
+//
+//  KubenavPlugin.m
+//  App
+//
+//  Created by Rico Berger on 07.06.20.
+//
+
+#import <Foundation/Foundation.h>
+#import <Capacitor/Capacitor.h>
+
+CAP_PLUGIN(KubenavPlugin, "KubenavPlugin",
+           CAP_PLUGIN_METHOD(startServer, CAPPluginReturnPromise);
+)

--- a/ios/App/App/KubenavPlugin.swift
+++ b/ios/App/App/KubenavPlugin.swift
@@ -1,0 +1,21 @@
+//
+//  KubenavPlugin.swift
+//  App
+//
+//  Created by Rico Berger on 07.06.20.
+//
+
+import Foundation
+import Capacitor
+import Mobile
+
+@objc(KubenavPlugin)
+public class KubenavPlugin: CAPPlugin {
+    @objc func startServer(_ call: CAPPluginCall) {
+        DispatchQueue.background {
+            MobileStartServer()
+        }
+
+        call.success()
+    }
+}

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -11,6 +11,8 @@ import (
 func StartServer() {
 	router := http.NewServeMux()
 
+	router.HandleFunc("/api/health", middleware.Cors(healthHandler))
+
 	router.HandleFunc("/api/aws/clusters", middleware.Cors(awsGetClustersHandler))
 	router.HandleFunc("/api/aws/token", middleware.Cors(awsGetTokenHandler))
 
@@ -29,4 +31,8 @@ func StartServer() {
 	if err := http.ListenAndServe(":14122", router); err != nil {
 		return
 	}
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
After a period of inactivity the background task for the server is stopped on mobile.

To check the health status of the server a new API endpoint `/api/health` was added. This endpoint is requested before each request to the server. If the status code is not `OK`, the server is started again before the original request is made.

Fixes #85. 