### PR TITLE
Improve context switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { IonApp, IonRouterOutlet, IonSplitPane } from '@ionic/react';
+import { IonApp, IonRouterOutlet, IonSplitPane, isPlatform } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import React from 'react';
 import { Route } from 'react-router-dom';
@@ -43,7 +43,7 @@ const App: React.FunctionComponent = () => (
     <AppContextProvider>
       <TerminalContextProvider>
         <IonReactRouter>
-          <IonSplitPane contentId="main">
+          <IonSplitPane contentId="main" className={isPlatform('hybrid') ? '' : 'menu-width'}>
             <Menu sections={resources} />
             <IonRouterOutlet id="main">
               <Route path="/" component={HomePage} exact={true} />

--- a/src/components/menu/Clusters.tsx
+++ b/src/components/menu/Clusters.tsx
@@ -1,11 +1,11 @@
-import { IonItem, IonLabel, IonListHeader, IonSelect, IonSelectOption, IonMenuToggle } from '@ionic/react';
+import { IonItem, IonLabel, IonListHeader, IonSelect, IonSelectOption, IonMenuToggle, isPlatform } from '@ionic/react';
 import React, { memo, useContext } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { IContext } from '../../declarations';
 import { AppContext } from '../../utils/context';
 
-const Context: React.FunctionComponent<RouteComponentProps> = ({ history, location }: RouteComponentProps) => {
+const Clusters: React.FunctionComponent<RouteComponentProps> = ({ history, location }: RouteComponentProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
 
@@ -40,24 +40,30 @@ const Context: React.FunctionComponent<RouteComponentProps> = ({ history, locati
     return (
       <React.Fragment>
         <IonListHeader mode="md">
-          <IonLabel>Context</IonLabel>
+          <IonLabel>Clusters</IonLabel>
         </IonListHeader>
         <IonMenuToggle autoHide={false}>
           <IonItem>
             <IonSelect
               disabled={location.pathname.startsWith('/settings/clusters')}
-              value={cluster.name}
+              value={cluster.id}
               onIonChange={(e) => changeCluster(e.detail.value)}
-              interface="action-sheet"
-              interfaceOptions={{
-                header: 'Select Context',
-              }}
-              style={{ maxWidth: '100%', width: '100%' }}
+              interface={isPlatform('hybrid') ? 'action-sheet' : 'popover'}
+              interfaceOptions={
+                isPlatform('hybrid')
+                  ? {
+                      header: 'Select Cluster',
+                    }
+                  : {
+                      cssClass: 'menu-cluster-select',
+                    }
+              }
+              className="menu-cluster-select"
             >
               {context.clusters
                 ? Object.keys(context.clusters).map((key) => {
                     return context.clusters ? (
-                      <IonSelectOption key={key} value={context.clusters[key].name}>
+                      <IonSelectOption key={key} value={context.clusters[key].id}>
                         {context.clusters[key].name}
                       </IonSelectOption>
                     ) : null;
@@ -74,7 +80,7 @@ const Context: React.FunctionComponent<RouteComponentProps> = ({ history, locati
 };
 
 export default withRouter(
-  memo(Context, (prevProps, nextProps): boolean => {
+  memo(Clusters, (prevProps, nextProps): boolean => {
     if (prevProps.location.pathname !== nextProps.location.pathname) {
       return false;
     }

--- a/src/components/menu/Context.tsx
+++ b/src/components/menu/Context.tsx
@@ -1,0 +1,57 @@
+import { IonItem, IonLabel, IonListHeader, IonSelect, IonSelectOption, IonMenuToggle } from '@ionic/react';
+import React, { memo, useContext } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+import { IContext } from '../../declarations';
+import { AppContext } from '../../utils/context';
+
+const Context: React.FunctionComponent<RouteComponentProps> = ({ history }: RouteComponentProps) => {
+  const context = useContext<IContext>(AppContext);
+  const cluster = context.currentCluster();
+
+  const changeCluster = (ctx: string) => {
+    context.changeCluster(ctx);
+    history.push('/');
+  };
+
+  if (cluster) {
+    return (
+      <React.Fragment>
+        <IonListHeader mode="md">
+          <IonLabel>Context</IonLabel>
+        </IonListHeader>
+        <IonMenuToggle autoHide={false}>
+          <IonItem>
+            <IonSelect
+              value={cluster.name}
+              onIonChange={(e) => changeCluster(e.detail.value)}
+              interface="action-sheet"
+              interfaceOptions={{
+                header: 'Select Context',
+              }}
+              style={{ maxWidth: '100%', width: '100%' }}
+            >
+              {context.clusters
+                ? Object.keys(context.clusters).map((key) => {
+                    return context.clusters ? (
+                      <IonSelectOption key={key} value={context.clusters[key].name}>
+                        {context.clusters[key].name}
+                      </IonSelectOption>
+                    ) : null;
+                  })
+                : null}
+            </IonSelect>
+          </IonItem>
+        </IonMenuToggle>
+      </React.Fragment>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default withRouter(
+  memo(Context, (): boolean => {
+    return true;
+  }),
+);

--- a/src/components/menu/Context.tsx
+++ b/src/components/menu/Context.tsx
@@ -5,13 +5,35 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { IContext } from '../../declarations';
 import { AppContext } from '../../utils/context';
 
-const Context: React.FunctionComponent<RouteComponentProps> = ({ history }: RouteComponentProps) => {
+const Context: React.FunctionComponent<RouteComponentProps> = ({ history, location }: RouteComponentProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
 
-  const changeCluster = (ctx: string) => {
-    context.changeCluster(ctx);
-    history.push('/');
+  // The change cluster function is used to change the current cluster. The function doesn't work for the
+  // /settings/clusters page, because the function is also triggered when the cluster is changed on this page. Therefore
+  // the user is redirect from the /settings/clusters to another page and the context.changeCluster function is called
+  // twice.
+  // This is also the reason why the select box is disabled for the /settings/clusters page.
+  const changeCluster = async (id: string) => {
+    const path = location.pathname;
+
+    // If the user is viewing a details page, when changing the cluster, he is redirected to the corresponding list
+    // view. For every other case the user isn't redirected.
+    if (!path.startsWith('/settings/clusters')) {
+      await context.changeCluster(id);
+
+      if (path.startsWith('/resources')) {
+        const parts = path.split('/');
+        if (parts.length > 4) {
+          history.push(parts.slice(0, 4).join('/'));
+        }
+      } else if (path.startsWith('/customresources')) {
+        const parts = path.split('/');
+        if (parts.length > 5) {
+          history.push(parts.slice(0, 5).join('/'));
+        }
+      }
+    }
   };
 
   if (cluster) {
@@ -23,6 +45,7 @@ const Context: React.FunctionComponent<RouteComponentProps> = ({ history }: Rout
         <IonMenuToggle autoHide={false}>
           <IonItem>
             <IonSelect
+              disabled={location.pathname.startsWith('/settings/clusters')}
               value={cluster.name}
               onIonChange={(e) => changeCluster(e.detail.value)}
               interface="action-sheet"
@@ -51,7 +74,11 @@ const Context: React.FunctionComponent<RouteComponentProps> = ({ history }: Rout
 };
 
 export default withRouter(
-  memo(Context, (): boolean => {
+  memo(Context, (prevProps, nextProps): boolean => {
+    if (prevProps.location.pathname !== nextProps.location.pathname) {
+      return false;
+    }
+
     return true;
   }),
 );

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -19,7 +19,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { IAppSections } from '../../declarations';
 import { CUSTOM_URI_SCHEME, GOOGLE_REDIRECT_URI, OIDC_REDIRECT_URL, SERVER } from '../../utils/constants';
 import { saveCluster } from '../../utils/storage';
-import Context from './Context';
+import Clusters from './Clusters';
 import Sections from './Sections';
 
 const { App } = Plugins;
@@ -61,7 +61,7 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections }: IMenuProps) => 
       </IonHeader>
       <IonContent>
         <IonList>
-          <Context />
+          <Clusters />
 
           <Sections sections={sections} isMenu={true} />
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -19,6 +19,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { IAppSections } from '../../declarations';
 import { CUSTOM_URI_SCHEME, GOOGLE_REDIRECT_URI, OIDC_REDIRECT_URL, SERVER } from '../../utils/constants';
 import { saveCluster } from '../../utils/storage';
+import Context from './Context';
 import Sections from './Sections';
 
 const { App } = Plugins;
@@ -60,6 +61,8 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections }: IMenuProps) => 
       </IonHeader>
       <IonContent>
         <IonList>
+          <Context />
+
           <Sections sections={sections} isMenu={true} />
 
           <IonListHeader mode="md">

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -60,7 +60,7 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
   // useAsyncFn is a custom React hook which wrapps our API call.
   const [state, fetch, fetchInit] = useAsyncFn(
     async () => await context.request('GET', page.listURL(cluster ? cluster.namespace : ''), ''),
-    [page, cluster?.namespace],
+    [page, cluster?.id, cluster?.namespace],
     { loading: true, error: undefined, value: undefined },
   );
 

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -64,7 +64,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
         getURL(cluster ? cluster.namespace : '', match.params.group, match.params.version, match.params.name),
         '',
       ),
-    [cluster?.namespace],
+    [cluster?.id, cluster?.namespace],
     { loading: true, error: undefined, value: undefined },
   );
 

--- a/src/components/settings/clusters/ClusterItem.tsx
+++ b/src/components/settings/clusters/ClusterItem.tsx
@@ -33,9 +33,13 @@ const ClusterItem: React.FunctionComponent<IClusterItemProps> = ({ cluster }: IC
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const changeCluster = async (id: string) => {
+    await context.changeCluster(id);
+  };
+
   return (
     <IonItemSliding>
-      <IonItem button={true} onClick={() => context.changeCluster(cluster.id)}>
+      <IonItem button={true} onClick={() => changeCluster(cluster.id)}>
         <IonIcon
           slot="end"
           color={status ? 'success' : 'danger'}

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -116,3 +116,24 @@ ion-avatar {
 .ion-card-content-divider {
   border-bottom: 1px solid var(--ion-color-light);
 }
+
+/* Menu customization
+   On desktop the menu should always have a width of 400px, Therefor we are setting the minimum and maximum width of the
+   IonSplitPane. 400px corresponds to one quater of the default Electron window size.
+   To fit the menu we set the width of the cluster select box to 100% and the width of the popover to 400px - 32px
+   (the padding left + right). */
+.menu-width {
+  --side-max-width: 400px;
+  --side-min-width: 400px;
+  --side-width: 400px;
+}
+
+.menu-cluster-select {
+  max-width: 100%;
+  width: 100%;
+}
+
+.menu-cluster-select .popover-content {
+  width: 368px;
+}
+


### PR DESCRIPTION
Improve the switch between contexts/clusters by adding a new select box to the top of the menu. The select box always shows the current context and by selecting an action sheet is opened to change the context.

After selecting a context the user is redirected to the home page.

The user haven't to go to the clusters page now, to switch the context/cluster.

![Bildschirmfoto 2020-06-10 um 21 16 34](https://user-images.githubusercontent.com/18552168/84309939-23431e00-ab61-11ea-9dfc-ad4b6cf35911.png)

Closes #98 