### PR TITLE
Fix Kubeconfig handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On mobile you can add your Cluster via Kubeconfig file or via your prefered Clou
 - [Google OAuth 2.0 Configuration](https://kubenav.io/help/google-oauth2-configuration.html)
 - [Microsoft Azure: Creating App Credentials](https://kubenav.io/help/microsoft-azure-creating-app-credentials.html)
 
-On desktop kubenav will automatic load all configured clusters from your `~/.kube/config` file. If you want to use another Kubeconfig file you can start kubenav with the `-kubeconfig` Flag. You can also use the `-kubeconfig-include` and `-kubeconfig-exclude` flag to load Kubeconfig files from multiple locations. The `-sync` flag can be used to write context changes back to your Kubeconfig file, so the context is also changed on your terminal.
+On desktop kubenav will automatic load all configured clusters from the default Kubeconfig file or the `KUBECONFIG` environment variable. If you want to use another Kubeconfig file, you can start kubenav with the `-kubeconfig` Flag. You can also use the `-kubeconfig-include` and `-kubeconfig-exclude` flag to load Kubeconfig files from multiple locations by glob. The `-sync` flag can be used to write context changes back to your Kubeconfig file, so the context is also changed in your terminal.
 
 ## Beta and Nightly Builds
 

--- a/cmd/devserver/main.go
+++ b/cmd/devserver/main.go
@@ -15,21 +15,14 @@ import (
 var (
 	debugFlag             = flag.Bool("debug", false, "Enable debug mode.")
 	kubeconfigFlag        = flag.String("kubeconfig", "", "Optional Kubeconfig file.")
-	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig. When this option is used the '-kubeconfig' and '-sync' flag is ignored.")
+	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig.")
 	kubeconfigExcludeFlag = flag.String("kubeconfig-exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '-kubeconfig-include' flag.")
 	syncFlag              = flag.Bool("sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
 )
 
 func main() {
 	// Parse command-line flags.
-	// When the "-kubeconfig-includ" flag is used the sync flag is ignored. Therefor we set the sync value always to
-	// false. The same applies for the "-kubeconfig" flag, but this is handled by the Kubernetes client.
 	flag.Parse()
-
-	sync := *syncFlag
-	if *kubeconfigIncludeFlag != "" {
-		sync = false
-	}
 
 	// Setup the logger and print the version information.
 	log := logrus.StandardLogger()
@@ -51,7 +44,7 @@ func main() {
 
 	// Register the API for the Electron app and start the server.
 	router := http.NewServeMux()
-	electron.Register(router, sync, client)
+	electron.Register(router, *syncFlag, client)
 
 	if err := http.ListenAndServe(":14122", router); err != nil {
 		log.WithError(err).Fatalf("kubenav server died")

--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -28,7 +28,7 @@ var (
 var (
 	debugFlag             = flag.Bool("debug", false, "Enable debug mode.")
 	kubeconfigFlag        = flag.String("kubeconfig", "", "Optional Kubeconfig file.")
-	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig. When this option is used the '-kubeconfig' and '-sync' flag is ignored.")
+	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig.")
 	kubeconfigExcludeFlag = flag.String("kubeconfig-exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '-kubeconfig-include' flag.")
 	syncFlag              = flag.Bool("sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
 )
@@ -44,14 +44,7 @@ var messageChannel = make(chan Message)
 
 func main() {
 	// Parse command-line flags.
-	// When the "-kubeconfig-includ" flag is used the sync flag is ignored. Therefor we set the sync value always to
-	// false. The same applies for the "-kubeconfig" flag, but this is handled by the Kubernetes client.
 	flag.Parse()
-
-	sync := *syncFlag
-	if *kubeconfigIncludeFlag != "" {
-		sync = false
-	}
 
 	// Setup the logger and print the version information.
 	log := logrus.StandardLogger()
@@ -76,7 +69,7 @@ func main() {
 	// frontend from the embedded assets.
 	go func() {
 		router := http.NewServeMux()
-		electron.Register(router, sync, client)
+		electron.Register(router, *syncFlag, client)
 
 		// Add route for Server Sent Events. The events are handled via the message channel. Possible events are
 		// "navigation" and "cluster". These events are handled by the frontend to navigate to another page or to modify
@@ -138,7 +131,7 @@ func main() {
 	// selected context back to the Kubeconfig file, the result from the version check and the Kubernetes client and
 	// logger.
 	updateAvailable := checkVersion(version.Version, log)
-	menuOptions, err := getMenuOptions(sync, updateAvailable, client, log)
+	menuOptions, err := getMenuOptions(*syncFlag, updateAvailable, client, log)
 	if err != nil {
 		log.WithError(err).Fatalf("Could not create menu")
 	}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -64,7 +64,7 @@ const HomePage: React.FunctionComponent = () => {
               <p className="paragraph-margin-bottom">
                 Welcome to the kubenav app. After you added a cluster you can start the exploration of them within the
                 kubenav app. To add a new Kubernetes cluster to the app use the button <b>Add a Cluster</b> or the
-                <b>Clusters</b> item from the menu.
+                <b> Clusters</b> item from the menu.
               </p>
               <IonButton expand="block" routerLink="/settings/clusters" routerDirection="none">
                 Add a Cluster

--- a/src/components/misc/LoadingErrorCard.tsx
+++ b/src/components/misc/LoadingErrorCard.tsx
@@ -29,7 +29,7 @@ const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({
           <p className="paragraph-margin-bottom">
             Welcome to the kubenav app. After you added a cluster you can start the exploration of them within the
             kubenav app. To add a new Kubernetes cluster to the app use the button <b>Add a Cluster</b> or the
-            <b>Clusters</b> item from the menu.
+            <b> Clusters</b> item from the menu.
           </p>
           <IonButton expand="block" routerLink="/settings/clusters" routerDirection="none">
             Add a Cluster

--- a/src/components/settings/ClustersPage.tsx
+++ b/src/components/settings/ClustersPage.tsx
@@ -1,5 +1,7 @@
 import {
   IonButtons,
+  IonCard,
+  IonCardContent,
   IonContent,
   IonHeader,
   IonMenuButton,
@@ -30,11 +32,27 @@ const ClustersPage: React.FunctionComponent = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        {context.clusters
-          ? Object.keys(context.clusters).map((key) => {
-              return context.clusters ? <ClusterItem key={key} cluster={context.clusters[key]} /> : null;
-            })
-          : null}
+        {context.clusters ? (
+          Object.keys(context.clusters).map((key) => {
+            return context.clusters ? <ClusterItem key={key} cluster={context.clusters[key]} /> : null;
+          })
+        ) : !isPlatform('hybrid') ? (
+          <IonCard>
+            <IonCardContent>
+              <p className="paragraph-margin-bottom">
+                It looks like you have not configured a cluster yet. kubenav loads your clusters from{' '}
+                <code>~/.kube/.kubeconfig</code>, <code>~/.kube/.config</code> or the <code>KUBECONFIG</code>{' '}
+                environment variable. You can also pass a Kubeconfig to kubenav via the <code>-kubeconfig</code> flag.
+              </p>
+              <p>
+                With the <code>-include-kubeconfig</code> and <code>-exlude-kubeconfig</code> flags you can specify a
+                list of comma separated globs to load your Kubeconfig files from. The <code>-sync</code> flags wrotes
+                your cluster and namespace changes back to the loaded Kubeconfig, so that the context/namespace is also
+                changed in your terminal.
+              </p>
+            </IonCardContent>
+          </IonCard>
+        ) : null}
       </IonContent>
     </IonPage>
   );

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -172,7 +172,7 @@ export const getCluster = async (): Promise<string | undefined> => {
     const json = await response.json();
 
     if (response.status >= 200 && response.status < 300) {
-      return json.cluster;
+      return json.cluster || undefined;
     }
 
     return undefined;
@@ -191,7 +191,11 @@ export const getClusters = async (): Promise<IClusters | undefined> => {
     const json = await response.json();
 
     if (response.status >= 200 && response.status < 300) {
-      return json.clusters;
+      if (Object.keys(json.clusters).length === 0) {
+        return undefined;
+      } else {
+        return json.clusters;
+      }
     }
 
     return undefined;

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -85,13 +85,8 @@ export const AppContextProvider: React.FunctionComponent<IAppContextProvider> = 
 
       if (!isPlatform('hybrid')) {
         const receivedClusters = await getClusters();
+        const activeCluster = await getCluster();
         setClusters(receivedClusters);
-
-        let activeCluster = readCluster();
-        if (!activeCluster) {
-          activeCluster = await getCluster();
-        }
-
         setCluster(activeCluster);
       } else {
         setClusters(readClusters());


### PR DESCRIPTION
- Fix parsing of `KUBECONFIG` environment variable, when using multiple files. Closes #100.
- Allow sync flag for all options and use a similar logic like `kubectl` for modifying the loaded Kubeconfig. 
- Use context from loaded Kubeconfig after the start and not the last saved context.