### PR TITLE
Support self signed certificates for OIDC

### DIFF
--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -109,7 +109,7 @@ const OIDC: React.FunctionComponent = () => {
         </p>
         <p className="paragraph-margin-bottom">
           When your OIDC provider uses self signed certificate you have to set the <b>Certificate Authority</b> field.
-          You can also skip the OIDC login, when providing a valid refresh token.
+          You can also skip the redirect to the OIDC login page, by providing a valid refresh token.
         </p>
 
         <IonList className="paragraph-margin-bottom" lines="full">

--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -16,6 +16,7 @@ import React, { useContext, useState } from 'react';
 import { IContext } from '../../../../declarations';
 import { getOIDCLink } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
+import { isBase64 } from '../../../../utils/helpers';
 import { saveOIDCLastProvider } from '../../../../utils/storage';
 
 const OIDC: React.FunctionComponent = () => {
@@ -25,6 +26,7 @@ const OIDC: React.FunctionComponent = () => {
   const [discoveryURL, setDiscoveryURL] = useState<string>('');
   const [clientID, setClientID] = useState<string>('');
   const [clientSecret, setClientSecret] = useState<string>('');
+  const [certificateAuthority, setCertificateAuthority] = useState<string>('');
   const [refreshToken, setRefreshToken] = useState<string>('');
   const [error, setError] = useState<string>('');
 
@@ -44,6 +46,10 @@ const OIDC: React.FunctionComponent = () => {
     setClientSecret(event.target.value);
   };
 
+  const handleCertificateAuthority = (event) => {
+    setCertificateAuthority(event.target.value);
+  };
+
   const handleRefreshToken = (event) => {
     setRefreshToken(event.target.value);
   };
@@ -52,12 +58,15 @@ const OIDC: React.FunctionComponent = () => {
     if (name === '' || discoveryURL === '' || clientID === '' || clientSecret === '') {
       setError('Discovery URL, Client ID and Client Secret are required.');
     } else {
+      const ca = isBase64(certificateAuthority) ? atob(certificateAuthority) : certificateAuthority;
+
       context.addOIDCProvider({
         name: name,
         clientID: clientID,
         clientSecret: clientSecret,
         idpIssuerURL: discoveryURL,
         refreshToken: refreshToken,
+        certificateAuthority: ca,
         idToken: '',
         accessToken: '',
         expiry: 0,
@@ -67,7 +76,7 @@ const OIDC: React.FunctionComponent = () => {
         window.location.replace('/settings/clusters/oidc');
       } else {
         try {
-          const url = await getOIDCLink(discoveryURL, clientID, clientSecret);
+          const url = await getOIDCLink(discoveryURL, clientID, clientSecret, ca);
           saveOIDCLastProvider(name);
           window.location.replace(url);
         } catch (err) {
@@ -98,6 +107,10 @@ const OIDC: React.FunctionComponent = () => {
           <code>idp-issuer-url</code>), a <b>Client ID</b> and a <b>Client Secret</b>. When you create the Client ID and
           Client Secret you have to allow <code>https://kubenav.io/oidc.html</code> as redirect URL.
         </p>
+        <p className="paragraph-margin-bottom">
+          When your OIDC provider uses self signed certificate you have to set the <b>Certificate Authority</b> field.
+          You can also skip the OIDC login, when providing a valid refresh token.
+        </p>
 
         <IonList className="paragraph-margin-bottom" lines="full">
           <IonItem>
@@ -115,6 +128,10 @@ const OIDC: React.FunctionComponent = () => {
           <IonItem>
             <IonLabel position="stacked">Client Secret</IonLabel>
             <IonInput type="text" required={true} value={clientSecret} onInput={handleClientSecret} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Certificate Authority (optional)</IonLabel>
+            <IonTextarea autoGrow={true} value={certificateAuthority} onInput={handleCertificateAuthority} />
           </IonItem>
           <IonItem>
             <IonLabel position="stacked">Refresh Token (optional)</IonLabel>

--- a/src/components/settings/clusters/oidc/OIDCRedirectPage.tsx
+++ b/src/components/settings/clusters/oidc/OIDCRedirectPage.tsx
@@ -53,6 +53,7 @@ const OIDCRedirectPage: React.FunctionComponent<IOIDCRedirectPageProps> = ({ his
               provider.idpIssuerURL,
               provider.clientID,
               provider.clientSecret,
+              provider.certificateAuthority,
               query.get('code') as string,
             );
 

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -212,6 +212,7 @@ export interface IOIDCProvider {
   idToken: string;
   idpIssuerURL: string;
   refreshToken: string;
+  certificateAuthority: string;
   accessToken: string;
   expiry: number;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -511,6 +511,7 @@ export const getOIDCAccessToken = async (provider: IOIDCProvider): Promise<IOIDC
         discoveryURL: provider.idpIssuerURL,
         clientID: provider.clientID,
         clientSecret: provider.clientSecret,
+        certificateAuthority: provider.certificateAuthority ? provider.certificateAuthority : '',
         redirectURL: OIDC_REDIRECT_URL_WEB,
         refreshToken: provider.refreshToken,
       }),
@@ -534,7 +535,12 @@ export const getOIDCAccessToken = async (provider: IOIDCProvider): Promise<IOIDC
 
 // getOIDCLink returns the login link for the OIDC provider. The user is redirect to the returned link. After the user
 // logged in the getOIDCRefreshToken function is used to exchange the returned code for a refresh token.
-export const getOIDCLink = async (discoveryURL: string, clientID: string, clientSecret: string): Promise<string> => {
+export const getOIDCLink = async (
+  discoveryURL: string,
+  clientID: string,
+  clientSecret: string,
+  certificateAuthority: string,
+): Promise<string> => {
   try {
     await checkServer();
 
@@ -544,6 +550,7 @@ export const getOIDCLink = async (discoveryURL: string, clientID: string, client
         discoveryURL: discoveryURL,
         clientID: clientID,
         clientSecret: clientSecret,
+        certificateAuthority: certificateAuthority,
         redirectURL: OIDC_REDIRECT_URL_WEB,
       }),
     });
@@ -570,6 +577,7 @@ export const getOIDCRefreshToken = async (
   discoveryURL: string,
   clientID: string,
   clientSecret: string,
+  certificateAuthority: string,
   code: string,
 ): Promise<IOIDCProviderToken> => {
   try {
@@ -581,6 +589,7 @@ export const getOIDCRefreshToken = async (
         discoveryURL: discoveryURL,
         clientID: clientID,
         clientSecret: clientSecret,
+        certificateAuthority: certificateAuthority,
         redirectURL: OIDC_REDIRECT_URL_WEB,
         code: code,
       }),


### PR DESCRIPTION
It is now possible to use OIDC providers with self signed certificates. A user have to provide the 'Certificate Authority' field in the OIDC section. This field corresponds to the `idp-certificate-authority` field in the `auth-provider` section of a Kubeconfig file.