### PR TITLE
Improve log and shell access

### DIFF
--- a/src/components/resources/DetailsPage.tsx
+++ b/src/components/resources/DetailsPage.tsx
@@ -43,7 +43,7 @@ const DetailsPage: React.FunctionComponent<IDetailsPageProps> = ({ match }: IDet
   // useAsyncFn is a custom React hook which wrapps our API call.
   const [state, fetch, fetchInit] = useAsyncFn(
     async () => await context.request('GET', page.detailsURL(match.params.namespace, match.params.name), ''),
-    [page],
+    [page, match.params.namespace, match.params.name],
     { loading: true, error: undefined, value: undefined },
   );
 

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -7,6 +7,7 @@ import EditItem from './modify/EditItem';
 import LogsItem from './modify/LogsItem';
 import RestartItem from './modify/RestartItem';
 import ScaleItem from './modify/ScaleItem';
+import ShellItem from './modify/ShellItem';
 
 interface IDetailsPopoverProps {
   type: string;
@@ -33,6 +34,7 @@ const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, i
             <RestartItem activator="item" item={item} url={url} />
           ) : null}
           {isPlatform('hybrid') && type === 'pods' ? <LogsItem activator="item" item={item} url={url} /> : null}
+          {isPlatform('hybrid') && type === 'pods' ? <ShellItem activator="item" item={item} url={url} /> : null}
           <EditItem activator="item" item={item} url={url} />
           <DeleteItem activator="item" item={item} url={url} />
         </IonList>

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -1,9 +1,10 @@
-import { IonButton, IonIcon, IonList, IonPopover } from '@ionic/react';
+import { IonButton, IonIcon, IonList, IonPopover, isPlatform } from '@ionic/react';
 import { ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
 import React, { useState } from 'react';
 
 import DeleteItem from './modify/DeleteItem';
 import EditItem from './modify/EditItem';
+import LogsItem from './modify/LogsItem';
 import RestartItem from './modify/RestartItem';
 import ScaleItem from './modify/ScaleItem';
 
@@ -31,6 +32,7 @@ const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, i
           {type === 'deployments' || type === 'statefulsets' || type === 'daemonsets' ? (
             <RestartItem activator="item" item={item} url={url} />
           ) : null}
+          {isPlatform('hybrid') && type === 'pods' ? <LogsItem activator="item" item={item} url={url} /> : null}
           <EditItem activator="item" item={item} url={url} />
           <DeleteItem activator="item" item={item} url={url} />
         </IonList>

--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -2,44 +2,26 @@ import { ActionSheetButton, IonActionSheet, IonIcon, IonItem, IonLabel } from '@
 import { V1Pod } from '@kubernetes/client-node';
 import { list } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
-import { Terminal } from 'xterm';
 
-import { LOG_TAIL_LINES, LOG_TERMINAL_OPTIONS } from '../../../../utils/constants';
+import { LOG_TAIL_LINES } from '../../../../utils/constants';
 import { IContext, ITerminalContext, TActivator } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
 import { TerminalContext } from '../../../../utils/terminal';
+import { addLogs } from '../../../terminal/helpers';
 
-interface IRestartItemProps {
+interface ILogsItemProps {
   activator: TActivator;
   item: V1Pod;
   url: string;
 }
 
-const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, item, url }: IRestartItemProps) => {
+const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, url }: ILogsItemProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
-
-  const getLogs = async (container: string) => {
-    const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
-
-    try {
-      const parameters = `container=${container}&tailLines=${LOG_TAIL_LINES}`;
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data: any = await context.request('GET', `${url}/log?${parameters}`, '');
-
-      term.write(`${typeof data === 'string' ? data : JSON.stringify(data)}\n\r`);
-    } catch (err) {
-      term.write(`${err.message}\n\r`);
-    }
-
-    terminalContext.add({
-      name: container,
-      shell: term,
-    });
-  };
+  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
+  const [showActionSheetOptions, setShowActionSheetOptions] = useState<boolean>(false);
+  const [container, setContainer] = useState<string>('');
 
   const buttons = () => {
     const buttons: ActionSheetButton[] = [];
@@ -49,7 +31,7 @@ const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, it
         buttons.push({
           text: container.name,
           handler: () => {
-            getLogs(container.name);
+            setContainer(container.name);
           },
         });
       }
@@ -60,7 +42,8 @@ const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, it
         buttons.push({
           text: container.name,
           handler: () => {
-            getLogs(container.name);
+            setContainer(container.name);
+            setShowActionSheetOptions(true);
           },
         });
       }
@@ -72,20 +55,58 @@ const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, it
   return (
     <React.Fragment>
       {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowActionSheet(true)}>
+        <IonItem button={true} detail={false} onClick={() => setShowActionSheetContainer(true)}>
           <IonIcon slot="end" color="primary" icon={list} />
           <IonLabel>Logs</IonLabel>
         </IonItem>
       ) : null}
 
       <IonActionSheet
-        isOpen={showActionSheet}
-        onDidDismiss={() => setShowActionSheet(false)}
+        isOpen={showActionSheetContainer}
+        onDidDismiss={() => setShowActionSheetContainer(false)}
         header="Select Container"
         buttons={buttons()}
+      />
+
+      <IonActionSheet
+        isOpen={showActionSheetOptions}
+        onDidDismiss={() => setShowActionSheetOptions(false)}
+        header="Select Container"
+        buttons={[
+          {
+            text: `Last ${LOG_TAIL_LINES} Log Lines`,
+            handler: () => {
+              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, false);
+            },
+          },
+          {
+            text: 'All Log Lines',
+            handler: () => {
+              addLogs(context, terminalContext, url, container, false, 0, false);
+            },
+          },
+          {
+            text: `Previous Last ${LOG_TAIL_LINES} Log Lines`,
+            handler: () => {
+              addLogs(context, terminalContext, url, container, true, LOG_TAIL_LINES, false);
+            },
+          },
+          {
+            text: 'All Previous Log Lines',
+            handler: () => {
+              addLogs(context, terminalContext, url, container, true, 0, false);
+            },
+          },
+          {
+            text: 'Stream Log Lines',
+            handler: () => {
+              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, true);
+            },
+          },
+        ]}
       />
     </React.Fragment>
   );
 };
 
-export default RestartItem;
+export default LogsItem;

--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -19,11 +19,7 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
-  const [showActionSheetOptions, setShowActionSheetOptions] = useState<boolean>(false);
-  const [container, setContainer] = useState<string>('');
-
-  const buttons = () => {
+  const generateButtons = (): ActionSheetButton[] => {
     const buttons: ActionSheetButton[] = [];
 
     if (item.spec && item.spec.initContainers) {
@@ -52,10 +48,22 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
     return buttons;
   };
 
+  const buttons = generateButtons();
+
+  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
+  const [showActionSheetOptions, setShowActionSheetOptions] = useState<boolean>(false);
+  const [container, setContainer] = useState<string>(
+    buttons.length === 1 ? (buttons[0].text ? buttons[0].text : '') : '',
+  );
+
   return (
     <React.Fragment>
       {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowActionSheetContainer(true)}>
+        <IonItem
+          button={true}
+          detail={false}
+          onClick={() => (buttons.length === 1 ? setShowActionSheetOptions(true) : setShowActionSheetContainer(true))}
+        >
           <IonIcon slot="end" color="primary" icon={list} />
           <IonLabel>Logs</IonLabel>
         </IonItem>
@@ -65,13 +73,13 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
         isOpen={showActionSheetContainer}
         onDidDismiss={() => setShowActionSheetContainer(false)}
         header="Select Container"
-        buttons={buttons()}
+        buttons={buttons}
       />
 
       <IonActionSheet
         isOpen={showActionSheetOptions}
         onDidDismiss={() => setShowActionSheetOptions(false)}
-        header="Select Container"
+        header="Select Option"
         buttons={[
           {
             text: `Last ${LOG_TAIL_LINES} Log Lines`,

--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -1,0 +1,91 @@
+import { ActionSheetButton, IonActionSheet, IonIcon, IonItem, IonLabel } from '@ionic/react';
+import { V1Pod } from '@kubernetes/client-node';
+import { list } from 'ionicons/icons';
+import React, { useContext, useState } from 'react';
+import { Terminal } from 'xterm';
+
+import { LOG_TAIL_LINES, LOG_TERMINAL_OPTIONS } from '../../../../utils/constants';
+import { IContext, ITerminalContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import { TerminalContext } from '../../../../utils/terminal';
+
+interface IRestartItemProps {
+  activator: TActivator;
+  item: V1Pod;
+  url: string;
+}
+
+const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, item, url }: IRestartItemProps) => {
+  const context = useContext<IContext>(AppContext);
+  const terminalContext = useContext<ITerminalContext>(TerminalContext);
+
+  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
+
+  const getLogs = async (container: string) => {
+    const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
+
+    try {
+      const parameters = `container=${container}&tailLines=${LOG_TAIL_LINES}`;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data: any = await context.request('GET', `${url}/log?${parameters}`, '');
+
+      term.write(`${typeof data === 'string' ? data : JSON.stringify(data)}\n\r`);
+    } catch (err) {
+      term.write(`${err.message}\n\r`);
+    }
+
+    terminalContext.add({
+      name: container,
+      shell: term,
+    });
+  };
+
+  const buttons = () => {
+    const buttons: ActionSheetButton[] = [];
+
+    if (item.spec && item.spec.initContainers) {
+      for (const container of item.spec.initContainers) {
+        buttons.push({
+          text: container.name,
+          handler: () => {
+            getLogs(container.name);
+          },
+        });
+      }
+    }
+
+    if (item.spec && item.spec.containers) {
+      for (const container of item.spec.containers) {
+        buttons.push({
+          text: container.name,
+          handler: () => {
+            getLogs(container.name);
+          },
+        });
+      }
+    }
+
+    return buttons;
+  };
+
+  return (
+    <React.Fragment>
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowActionSheet(true)}>
+          <IonIcon slot="end" color="primary" icon={list} />
+          <IonLabel>Logs</IonLabel>
+        </IonItem>
+      ) : null}
+
+      <IonActionSheet
+        isOpen={showActionSheet}
+        onDidDismiss={() => setShowActionSheet(false)}
+        header="Select Container"
+        buttons={buttons()}
+      />
+    </React.Fragment>
+  );
+};
+
+export default RestartItem;

--- a/src/components/resources/misc/modify/ShellItem.tsx
+++ b/src/components/resources/misc/modify/ShellItem.tsx
@@ -20,7 +20,7 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
 
   const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
 
-  const buttons = () => {
+  const generateButtons = (): ActionSheetButton[] => {
     const buttons: ActionSheetButton[] = [];
 
     if (item.spec && item.spec.initContainers) {
@@ -48,10 +48,20 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
     return buttons;
   };
 
+  const buttons = generateButtons();
+
   return (
     <React.Fragment>
       {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowActionSheet(true)}>
+        <IonItem
+          button={true}
+          detail={false}
+          onClick={() =>
+            buttons.length === 1
+              ? addShell(context, terminalContext, url, buttons[0].text ? buttons[0].text : '')
+              : setShowActionSheet(true)
+          }
+        >
           <IonIcon slot="end" color="primary" icon={terminal} />
           <IonLabel>Shell</IonLabel>
         </IonItem>
@@ -61,7 +71,7 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         isOpen={showActionSheet}
         onDidDismiss={() => setShowActionSheet(false)}
         header="Select Container"
-        buttons={buttons()}
+        buttons={buttons}
       />
     </React.Fragment>
   );

--- a/src/components/resources/misc/modify/ShellItem.tsx
+++ b/src/components/resources/misc/modify/ShellItem.tsx
@@ -1,0 +1,70 @@
+import { ActionSheetButton, IonActionSheet, IonIcon, IonItem, IonLabel } from '@ionic/react';
+import { V1Pod } from '@kubernetes/client-node';
+import { terminal } from 'ionicons/icons';
+import React, { useContext, useState } from 'react';
+
+import { IContext, ITerminalContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import { TerminalContext } from '../../../../utils/terminal';
+import { addShell } from '../../../terminal/helpers';
+
+interface IShellItemProps {
+  activator: TActivator;
+  item: V1Pod;
+  url: string;
+}
+
+const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, url }: IShellItemProps) => {
+  const context = useContext<IContext>(AppContext);
+  const terminalContext = useContext<ITerminalContext>(TerminalContext);
+
+  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
+
+  const buttons = () => {
+    const buttons: ActionSheetButton[] = [];
+
+    if (item.spec && item.spec.initContainers) {
+      for (const container of item.spec.initContainers) {
+        buttons.push({
+          text: container.name,
+          handler: () => {
+            addShell(context, terminalContext, url, container.name);
+          },
+        });
+      }
+    }
+
+    if (item.spec && item.spec.containers) {
+      for (const container of item.spec.containers) {
+        buttons.push({
+          text: container.name,
+          handler: () => {
+            addShell(context, terminalContext, url, container.name);
+          },
+        });
+      }
+    }
+
+    return buttons;
+  };
+
+  return (
+    <React.Fragment>
+      {activator === 'item' ? (
+        <IonItem button={true} detail={false} onClick={() => setShowActionSheet(true)}>
+          <IonIcon slot="end" color="primary" icon={terminal} />
+          <IonLabel>Shell</IonLabel>
+        </IonItem>
+      ) : null}
+
+      <IonActionSheet
+        isOpen={showActionSheet}
+        onDidDismiss={() => setShowActionSheet(false)}
+        header="Select Container"
+        buttons={buttons()}
+      />
+    </React.Fragment>
+  );
+};
+
+export default ShellItem;

--- a/src/components/terminal/AddLogs.tsx
+++ b/src/components/terminal/AddLogs.tsx
@@ -1,13 +1,12 @@
 import { IonButton, IonIcon, IonItem, IonItemOption, IonLabel, IonList, IonPopover } from '@ionic/react';
 import { list } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
-import { Terminal } from 'xterm';
 
 import { IContext, ITerminalContext, TActivator } from '../../declarations';
-import { logsRequest } from '../../utils/api';
-import { LOG_TAIL_LINES, LOG_TERMINAL_OPTIONS, SERVER } from '../../utils/constants';
+import { LOG_TAIL_LINES } from '../../utils/constants';
 import { AppContext } from '../../utils/context';
 import { TerminalContext } from '../../utils/terminal';
+import { addLogs } from './helpers';
 
 interface IAddLogsProps {
   activator: TActivator;
@@ -23,77 +22,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
 
-  const add = async (previous: boolean, tailLines: number, follow: boolean) => {
-    const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
-
-    if (context.clusters && context.cluster) {
-      if (follow) {
-        try {
-          const parameters = `container=${container}&tailLines=10&follow=true`;
-
-          const { id } = await logsRequest(
-            `/api/v1/namespaces/${namespace}/pods/${pod}/log?${parameters}`,
-            context.clusters[context.cluster],
-          );
-
-          const eventSource = new EventSource(`${SERVER}/api/kubernetes/logs/${id}`);
-
-          eventSource.onmessage = (event: MessageEvent) => {
-            term.write(`${event.data}\n\r`);
-          };
-
-          eventSource.onerror = () => {
-            term.write('\n\rAN ERROR OCCURRED, WHILE STREAMING LOG LINES.\n\r');
-            eventSource.close();
-          };
-
-          terminalContext.add({
-            name: container,
-            shell: term,
-            eventSource: eventSource,
-          });
-        } catch (err) {
-          term.write(`${err.message}\n\r`);
-
-          terminalContext.add({
-            name: container,
-            shell: term,
-          });
-        }
-      } else {
-        try {
-          let parameters = `container=${container}`;
-
-          if (previous) {
-            parameters = `${parameters}&previous=true`;
-          }
-
-          if (tailLines !== 0) {
-            parameters = `${parameters}&tailLines=${tailLines}`;
-          }
-
-          // It is possible that the returned log only contains one line with valid json. This gets parsed by the requests
-          // function and so an object instead of a string is returned. In this case we have to revert the parsing.
-          // Befor writing the logs to the terminal we have to replace all '\n' with '\n\r' to print the new lines.
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const data: any = await context.request(
-            'GET',
-            `/api/v1/namespaces/${namespace}/pods/${pod}/log?${parameters}`,
-            '',
-          );
-
-          term.write(`${typeof data === 'string' ? data : JSON.stringify(data)}\n\r`);
-        } catch (err) {
-          term.write(`${err.message}\n\r`);
-        }
-
-        terminalContext.add({
-          name: container,
-          shell: term,
-        });
-      }
-    }
-  };
+  const url = `/api/v1/namespaces/${namespace}/pods/${pod}`;
 
   return (
     <React.Fragment>
@@ -105,7 +34,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(false, LOG_TAIL_LINES, false);
+              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, false);
             }}
           >
             <IonLabel>{`Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
@@ -116,7 +45,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(false, 0, false);
+              addLogs(context, terminalContext, url, container, false, 0, false);
             }}
           >
             <IonLabel>All Log Lines</IonLabel>
@@ -127,7 +56,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(true, LOG_TAIL_LINES, false);
+              addLogs(context, terminalContext, url, container, true, LOG_TAIL_LINES, false);
             }}
           >
             <IonLabel>{`Previous Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
@@ -138,7 +67,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(true, 0, false);
+              addLogs(context, terminalContext, url, container, true, 0, false);
             }}
           >
             <IonLabel>All Previous Log Lines</IonLabel>
@@ -149,10 +78,10 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(false, LOG_TAIL_LINES, true);
+              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, true);
             }}
           >
-            <IonLabel>{`Stream Log Lines`}</IonLabel>
+            <IonLabel>Stream Log Lines</IonLabel>
           </IonItem>
         </IonList>
       </IonPopover>

--- a/src/components/terminal/AddLogs.tsx
+++ b/src/components/terminal/AddLogs.tsx
@@ -5,11 +5,9 @@ import { Terminal } from 'xterm';
 
 import { IContext, ITerminalContext, TActivator } from '../../declarations';
 import { logsRequest } from '../../utils/api';
-import { SERVER, TERMINAL_DARK_THEME, TERMINAL_LIGHT_THEME } from '../../utils/constants';
+import { LOG_TAIL_LINES, LOG_TERMINAL_OPTIONS, SERVER } from '../../utils/constants';
 import { AppContext } from '../../utils/context';
 import { TerminalContext } from '../../utils/terminal';
-
-const TAIL_LINES = 1000;
 
 interface IAddLogsProps {
   activator: TActivator;
@@ -26,15 +24,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
   const [popoverEvent, setPopoverEvent] = useState();
 
   const add = async (previous: boolean, tailLines: number, follow: boolean) => {
-    const term = new Terminal({
-      fontSize: 12,
-      bellStyle: 'sound',
-      cursorBlink: true,
-      disableStdin: true,
-      convertEol: true,
-      scrollback: 10000,
-      theme: context.settings.darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
-    });
+    const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
 
     if (context.clusters && context.cluster) {
       if (follow) {
@@ -115,10 +105,10 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(false, TAIL_LINES, false);
+              add(false, LOG_TAIL_LINES, false);
             }}
           >
-            <IonLabel>{`Last ${TAIL_LINES} Log Lines`}</IonLabel>
+            <IonLabel>{`Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
           </IonItem>
           <IonItem
             button={true}
@@ -137,10 +127,10 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(true, TAIL_LINES, false);
+              add(true, LOG_TAIL_LINES, false);
             }}
           >
-            <IonLabel>{`Previous Last ${TAIL_LINES} Log Lines`}</IonLabel>
+            <IonLabel>{`Previous Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
           </IonItem>
           <IonItem
             button={true}
@@ -159,7 +149,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              add(false, TAIL_LINES, true);
+              add(false, LOG_TAIL_LINES, true);
             }}
           >
             <IonLabel>{`Stream Log Lines`}</IonLabel>
@@ -180,7 +170,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
           <IonIcon slot="start" icon={list} />
           Logs
         </IonItemOption>
-      ) : (
+      ) : null}
+
+      {activator === 'button' ? (
         <IonButton
           fill="outline"
           slot="end"
@@ -195,7 +187,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
           <IonIcon slot="start" icon={list} />
           Logs
         </IonButton>
-      )}
+      ) : null}
     </React.Fragment>
   );
 };

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -40,7 +40,7 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
         slot="end"
         onClick={(e) => {
           e.stopPropagation();
-          add();
+          addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container);
         }}
       >
         <IonIcon slot="start" icon={terminal} />

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -1,14 +1,11 @@
 import { IonButton, IonIcon, IonItemOption } from '@ionic/react';
 import { terminal } from 'ionicons/icons';
 import React, { useContext } from 'react';
-import SockJS from 'sockjs-client';
-import { Terminal } from 'xterm';
 
 import { IContext, ITerminalContext, TActivator } from '../../declarations';
-import { execRequest } from '../../utils/api';
-import { SERVER, TERMINAL_DARK_THEME, TERMINAL_LIGHT_THEME } from '../../utils/constants';
 import { AppContext } from '../../utils/context';
 import { TerminalContext } from '../../utils/terminal';
+import { addShell } from './helpers';
 
 interface IAddShellProps {
   activator: TActivator;
@@ -26,76 +23,12 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const add = async () => {
-    const term = new Terminal({
-      fontSize: 12,
-      bellStyle: 'sound',
-      cursorBlink: true,
-      scrollback: 10000,
-      theme: context.settings.darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
-    });
-
-    try {
-      if (context.clusters && context.cluster) {
-        const { id } = await execRequest(
-          `/api/v1/namespaces/${namespace}/pods/${pod}/exec?command=sh&container=${container}&stdin=true&stdout=true&stderr=true&tty=true`,
-          context.clusters[context.cluster],
-        );
-
-        const webSocket = new SockJS(`${SERVER}/api/kubernetes/sockjs?${id}`);
-
-        term?.onData((str) => {
-          webSocket.send(
-            JSON.stringify({
-              Op: 'stdin',
-              Data: str,
-              Cols: term.cols,
-              Rows: term.rows,
-            }),
-          );
-        });
-
-        term?.onResize(() => {
-          webSocket.send(
-            JSON.stringify({
-              Op: 'resize',
-              Cols: term.cols,
-              Rows: term.rows,
-            }),
-          );
-        });
-
-        webSocket.onopen = () => {
-          const startData = { Op: 'bind', SessionID: id };
-          webSocket.send(JSON.stringify(startData));
-        };
-
-        webSocket.onmessage = (event) => {
-          const msg = JSON.parse(event.data);
-          if (msg.Op === 'stdout') {
-            term?.write(msg.Data);
-          }
-        };
-
-        terminalContext.add({
-          name: container,
-          shell: term,
-          webSocket: webSocket,
-        });
-      }
-    } catch (err) {
-      term.write(`${err.message}\n\r`);
-
-      terminalContext.add({
-        name: container,
-        shell: term,
-      });
-    }
-  };
-
   if (activator === 'item-option') {
     return (
-      <IonItemOption color="primary" onClick={() => add()}>
+      <IonItemOption
+        color="primary"
+        onClick={() => addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container)}
+      >
         <IonIcon slot="start" icon={terminal} />
         Term
       </IonItemOption>

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -1,0 +1,72 @@
+import SockJS from 'sockjs-client';
+import { Terminal } from 'xterm';
+
+import { IContext, ITerminalContext } from '../../declarations';
+import { execRequest } from '../../utils/api';
+import { SERVER, SHELL_TERMINAL_OPTIONS } from '../../utils/constants';
+
+export const addShell = async (
+  context: IContext,
+  terminalContext: ITerminalContext,
+  url: string,
+  container: string,
+): Promise<void> => {
+  const term = new Terminal(SHELL_TERMINAL_OPTIONS(context.settings.darkMode));
+
+  try {
+    if (context.clusters && context.cluster) {
+      const { id } = await execRequest(
+        `${url}/exec?command=sh&container=${container}&stdin=true&stdout=true&stderr=true&tty=true`,
+        context.clusters[context.cluster],
+      );
+
+      const webSocket = new SockJS(`${SERVER}/api/kubernetes/sockjs?${id}`);
+
+      term?.onData((str) => {
+        webSocket.send(
+          JSON.stringify({
+            Op: 'stdin',
+            Data: str,
+            Cols: term.cols,
+            Rows: term.rows,
+          }),
+        );
+      });
+
+      term?.onResize(() => {
+        webSocket.send(
+          JSON.stringify({
+            Op: 'resize',
+            Cols: term.cols,
+            Rows: term.rows,
+          }),
+        );
+      });
+
+      webSocket.onopen = () => {
+        const startData = { Op: 'bind', SessionID: id };
+        webSocket.send(JSON.stringify(startData));
+      };
+
+      webSocket.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.Op === 'stdout') {
+          term?.write(msg.Data);
+        }
+      };
+
+      terminalContext.add({
+        name: container,
+        shell: term,
+        webSocket: webSocket,
+      });
+    }
+  } catch (err) {
+    term.write(`${err.message}\n\r`);
+
+    terminalContext.add({
+      name: container,
+      shell: term,
+    });
+  }
+};

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -2,8 +2,8 @@ import SockJS from 'sockjs-client';
 import { Terminal } from 'xterm';
 
 import { IContext, ITerminalContext } from '../../declarations';
-import { execRequest } from '../../utils/api';
-import { SERVER, SHELL_TERMINAL_OPTIONS } from '../../utils/constants';
+import { execRequest, logsRequest } from '../../utils/api';
+import { LOG_TERMINAL_OPTIONS, SERVER, SHELL_TERMINAL_OPTIONS } from '../../utils/constants';
 
 export const addShell = async (
   context: IContext,
@@ -68,5 +68,78 @@ export const addShell = async (
       name: container,
       shell: term,
     });
+  }
+};
+
+export const addLogs = async (
+  context: IContext,
+  terminalContext: ITerminalContext,
+  url: string,
+  container: string,
+  previous: boolean,
+  tailLines: number,
+  follow: boolean,
+): Promise<void> => {
+  const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
+
+  if (context.clusters && context.cluster) {
+    if (follow) {
+      try {
+        const parameters = `container=${container}&tailLines=10&follow=true`;
+
+        const { id } = await logsRequest(`${url}/log?${parameters}`, context.clusters[context.cluster]);
+
+        const eventSource = new EventSource(`${SERVER}/api/kubernetes/logs/${id}`);
+
+        eventSource.onmessage = (event: MessageEvent) => {
+          term.write(`${event.data}\n\r`);
+        };
+
+        eventSource.onerror = () => {
+          term.write('\n\rAN ERROR OCCURRED, WHILE STREAMING LOG LINES.\n\r');
+          eventSource.close();
+        };
+
+        terminalContext.add({
+          name: container,
+          shell: term,
+          eventSource: eventSource,
+        });
+      } catch (err) {
+        term.write(`${err.message}\n\r`);
+
+        terminalContext.add({
+          name: container,
+          shell: term,
+        });
+      }
+    } else {
+      try {
+        let parameters = `container=${container}`;
+
+        if (previous) {
+          parameters = `${parameters}&previous=true`;
+        }
+
+        if (tailLines !== 0) {
+          parameters = `${parameters}&tailLines=${tailLines}`;
+        }
+
+        // It is possible that the returned log only contains one line with valid json. This gets parsed by the requests
+        // function and so an object instead of a string is returned. In this case we have to revert the parsing.
+        // Befor writing the logs to the terminal we have to replace all '\n' with '\n\r' to print the new lines.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data: any = await context.request('GET', `${url}/log?${parameters}`, '');
+
+        term.write(`${typeof data === 'string' ? data : JSON.stringify(data)}\n\r`);
+      } catch (err) {
+        term.write(`${err.message}\n\r`);
+      }
+
+      terminalContext.add({
+        name: container,
+        shell: term,
+      });
+    }
   }
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,6 +42,16 @@ export const LOG_TERMINAL_OPTIONS = (darkMode: boolean): ITerminalOptions => {
   };
 };
 
+export const SHELL_TERMINAL_OPTIONS = (darkMode: boolean): ITerminalOptions => {
+  return {
+    fontSize: 12,
+    bellStyle: 'sound',
+    cursorBlink: true,
+    scrollback: 10000,
+    theme: darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
+  };
+};
+
 export const TERMINAL_DARK_THEME = {
   foreground: '#d8dee9',
   background: '#2e3440',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import { ITerminalOptions } from 'xterm';
+
 import { IAppSettings } from '../declarations';
 
 export const CUSTOM_URI_SCHEME = 'io.kubenav.kubenav';
@@ -26,6 +28,19 @@ export const STORAGE_GOOGLE_TOKENS = 'google';
 export const STORAGE_OIDC_PROVIDERS = 'oidc';
 export const STORAGE_OIDC_PROVIDERS_LAST = 'oidc_last';
 export const STORAGE_SETTINGS = 'settings';
+
+export const LOG_TAIL_LINES = 1000;
+export const LOG_TERMINAL_OPTIONS = (darkMode: boolean): ITerminalOptions => {
+  return {
+    fontSize: 12,
+    bellStyle: 'sound',
+    cursorBlink: true,
+    disableStdin: true,
+    convertEol: true,
+    scrollback: 10000,
+    theme: darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
+  };
+};
 
 export const TERMINAL_DARK_THEME = {
   foreground: '#d8dee9',


### PR DESCRIPTION
Currently the log and shell option is hidden behind a swipe gesture on mobile. Now the logs and the shell is also available through the details menu of a Pod.