### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Docker
 
 on:
   push:
-  #  branches:
-  #    - master
+   branches:
+     - master
   release:
     types: [created]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Set Docker Tag
         if: ${{ github.event_name == 'push' }}
         run: echo ::set-env name=DOCKER_TAG::${GITHUB_SHA::8}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v1
         with:
-          username: ${{ DOCKER_USERNAME }}
-          password: ${{ DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           repository: kubenav/kubenav
           dockerfile: cmd/server/Dockerfile
           tags: ${{ env.DOCKER_TAG  }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+name: Docker
+
+on:
+  push:
+  #  branches:
+  #    - master
+  release:
+    types: [created]
+
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Docker Tag
+        if: ${{ github.event_name == 'push' }}
+        run: echo ::set-env name=DOCKER_TAG::${GITHUB_SHA::8}
+
+      - name: Set Docker Tag
+        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+        run: echo ::set-env name=DOCKER_TAG::${GITHUB_REF/refs\/tags\//}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ DOCKER_USERNAME }}
+          password: ${{ DOCKER_PASSWORD }}
+          repository: kubenav/kubenav
+          dockerfile: cmd/server/Dockerfile
+          tags: ${{ env.DOCKER_TAG  }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILDTIME   ?= $(shell date '+%Y-%m-%d@%H:%M:%S')
 BUILDUSER   ?= $(shell id -un)
 REPO        ?= github.com/kubenav/kubenav
 REVISION    ?= $(shell git rev-parse HEAD)
-VERSION     ?= $(shell git describe --tags)
+VERSION     ?= $(shell git describe --abbrev=0 --tags)
 
 .PHONY: bindings-android bindings-ios build-devserver build-electron release-beta release-major release-minor release-patch
 
@@ -15,13 +15,13 @@ bindings-ios:
 	mkdir -p ios/App/App/libs
 	gomobile bind -o ios/App/App/libs/Mobile.framework -target=ios github.com/kubenav/kubenav/pkg/mobile
 
-build-devserver:
+build-server:
 	go build -ldflags "-X ${REPO}/pkg/version.Version=${VERSION} \
 		-X ${REPO}/pkg/version.Revision=${REVISION} \
 		-X ${REPO}/pkg/version.Branch=${BRANCH} \
 		-X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
 		-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
-		-o ./bin/devserver ./cmd/devserver;
+		-o ./bin/server ./cmd/server;
 
 build-electron:
 	rm -rf cmd/electron/resources/app

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ On mobile you can add your Cluster via Kubeconfig file or via your prefered Clou
 
 On desktop kubenav will automatic load all configured clusters from the default Kubeconfig file or the `KUBECONFIG` environment variable. If you want to use another Kubeconfig file, you can start kubenav with the `-kubeconfig` Flag. You can also use the `-kubeconfig-include` and `-kubeconfig-exclude` flag to load Kubeconfig files from multiple locations by glob. The `-sync` flag can be used to write context changes back to your Kubeconfig file, so the context is also changed in your terminal.
 
+It is also possible to deploy kubenav to your Kubernetes cluster and use it via your browser. For the Kubernetes based deployment you can choose between the in cluster options or you can add your Kubeconfig file to the container. You can take a look at the [`utils/kubernetes`](./utils/kubernetes) folder, to deploy kubenav to your cluster, or you can run the following commands:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/serviceaccount.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/clusterrole.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/clusterrolebinding.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubenav/kubenav/master/utils/kubernetes/service.yaml
+```
+
+All available Docker images can be found at Docker Hub: [kubenav/kubenav](https://hub.docker.com/r/kubenav/kubenav)
+
 ## Beta and Nightly Builds
 
 For testing new features and faster feedback, we provide an **Beta** app via Apple Testflight and Google Play:

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ cd kubenav
 npm install
 ```
 
-To use kubenav in your browser you need to build and start the development server. The server listening on port `14122`:
+To use kubenav in your browser you need to build and start the server. The server listening on port `14122`:
 
 ```sh
-make build-devserver && ./bin/devserver
+make build-server && ./bin/server
 ```
 
 Now you can start the app and open [localhost:8100](http://localhost:8100) in your browser:

--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -16,7 +16,7 @@ import (
 	bootstrap "github.com/asticode/go-astilectron-bootstrap"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/sirupsen/logrus"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (
@@ -59,7 +59,7 @@ func main() {
 	log.Infof(version.BuildContext())
 
 	// Create the client for the interaction with the Kubernetes API.
-	client, err := kube.NewClient(*kubeconfigFlag, *kubeconfigIncludeFlag, *kubeconfigExcludeFlag)
+	client, err := kube.NewClient(false, *kubeconfigFlag, *kubeconfigIncludeFlag, *kubeconfigExcludeFlag)
 	if err != nil {
 		log.WithError(err).Fatalf("Could not create Kubernetes client")
 	}

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -3,7 +3,7 @@ COPY . /kubenav
 WORKDIR /kubenav
 RUN npm install -g ionic
 RUN npm install
-RUN export REACT_APP_SERVER=true
+ENV REACT_APP_SERVER true
 RUN ionic build
 
 FROM golang:1.14.4-alpine3.12 as server
@@ -18,4 +18,4 @@ COPY --from=build /kubenav/build /kubenav/build
 COPY --from=server /kubenav/bin/server /kubenav
 WORKDIR /kubenav
 USER nobody
-CMD ["./server"]
+ENTRYPOINT  [ "./server" ]

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -3,6 +3,7 @@ COPY . /kubenav
 WORKDIR /kubenav
 RUN npm install -g ionic
 RUN npm install
+RUN export REACT_APP_SERVER=true
 RUN ionic build
 
 FROM golang:1.14.4-alpine3.12 as server

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /kubenav
 RUN make build-server
 
 FROM alpine:3.12.0
-RUN apk update && apk add --no-cache ca-certificates
+RUN apk update && apk add --no-cache ca-certificates curl
 COPY --from=build /kubenav/build /kubenav/build
 COPY --from=server /kubenav/bin/server /kubenav
 WORKDIR /kubenav

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:13 as build
+COPY . /kubenav
+WORKDIR /kubenav
+RUN npm install -g ionic
+RUN npm install
+RUN ionic build
+
+FROM golang:1.14.4-alpine3.12 as server
+RUN apk update && apk add git make
+COPY . /kubenav
+WORKDIR /kubenav
+RUN make build-server
+
+FROM alpine:3.12.0
+RUN apk update && apk add --no-cache ca-certificates
+COPY --from=build /kubenav/build /kubenav/build
+COPY --from=server /kubenav/bin/server /kubenav
+WORKDIR /kubenav
+USER nobody
+CMD ["./server"]

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /kubenav
 RUN make build-server
 
 FROM alpine:3.12.0
-RUN apk update && apk add --no-cache ca-certificates curl
+RUN apk update && apk add --no-cache ca-certificates
 COPY --from=build /kubenav/build /kubenav/build
 COPY --from=server /kubenav/bin/server /kubenav
 WORKDIR /kubenav

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,11 +12,12 @@ import (
 	"github.com/kubenav/kubenav/pkg/version"
 
 	"github.com/sirupsen/logrus"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (
 	debugFlag             = flag.Bool("debug", false, "Enable debug mode.")
+	incluster             = flag.Bool("incluster", false, "Use the in cluster configuration. Only needed for a Kubernetes based Deployment using the Docker image.")
 	kubeconfigFlag        = flag.String("kubeconfig", "", "Optional Kubeconfig file.")
 	kubeconfigIncludeFlag = flag.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig.")
 	kubeconfigExcludeFlag = flag.String("kubeconfig-exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '-kubeconfig-include' flag.")
@@ -40,7 +41,7 @@ func main() {
 	log.Infof(version.BuildContext())
 
 	// Create the client for the interaction with the Kubernetes API.
-	client, err := kube.NewClient(*kubeconfigFlag, *kubeconfigIncludeFlag, *kubeconfigExcludeFlag)
+	client, err := kube.NewClient(*incluster, *kubeconfigFlag, *kubeconfigIncludeFlag, *kubeconfigExcludeFlag)
 	if err != nil {
 		log.WithError(err).Fatalf("Could not create Kubernetes client")
 	}

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/azure-sdk-for-go v42.0.0+incompatible h1:yz6sFf5bHZ+gEOQVuK5JhPqTTAmv+OvSLSaqgzqaCwY=
 github.com/Azure/azure-sdk-for-go v42.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -119,6 +120,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ type Response struct {
 // KubernetesRequest makes the request to the Kubernetes API server. A request contains a method, url, body and timeout.
 // The API server data is defined in the clientset.
 func KubernetesRequest(ctx context.Context, method, url, body string, clientset *kubernetes.Clientset) ([]byte, error) {
+	logrus.Infoln(method, url, body)
 	if method == "GET" {
 		return clientset.RESTClient().Get().RequestURI(url).DoRaw(ctx)
 	} else if method == "DELETE" {

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,7 +34,6 @@ type Response struct {
 // KubernetesRequest makes the request to the Kubernetes API server. A request contains a method, url, body and timeout.
 // The API server data is defined in the clientset.
 func KubernetesRequest(ctx context.Context, method, url, body string, clientset *kubernetes.Clientset) ([]byte, error) {
-	logrus.Infoln(method, url, body)
 	if method == "GET" {
 		return clientset.RESTClient().Get().RequestURI(url).DoRaw(ctx)
 	} else if method == "DELETE" {

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -16,6 +16,8 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	syncKubeconfig = sync
 	client = kubeClient
 
+	router.HandleFunc("/api/health", middleware.Cors(healthHandler))
+
 	router.HandleFunc("/api/cluster", middleware.Cors(clusterHandler))
 	router.HandleFunc("/api/clusters", middleware.Cors(clustersHandler))
 
@@ -27,4 +29,8 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	router.Handle("/api/kubernetes/sockjs/", api.CreateAttachHandler("/api/kubernetes/sockjs"))
 	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // loadInClusterConfig loads the Kubeconfig from the in cluster configuration.
@@ -23,7 +22,25 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 
 	logrus.Infof("%#v\n", config.String())
 
-	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
+	return clientcmd.NewClientConfigFromBytes([]byte(`apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ` + config.TLSClientConfig.CAFile + `
+    server: ` + config.Host + `
+  name: kubenav
+contexts:
+- context:
+    cluster: kubenav
+    user: kubenav
+  name: kubenav
+current-context: kubenav
+kind: Config
+users:
+- name: kubenav
+  user:
+    token: ` + config.BearerToken))
+
+	/*return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
 		CurrentContext: "incluster",
@@ -46,7 +63,7 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 				//TokenFile: config.BearerTokenFile,
 			},
 		},
-	}, &clientcmd.ConfigOverrides{}), nil
+	}, &clientcmd.ConfigOverrides{}), nil*/
 }
 
 // loadConfigFile implements the logic from kubectl to load Kubeconfig files. If the -kubeconfig flag is provided this

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -42,8 +42,8 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
 			"incluster": {
-				Token:     config.BearerToken,
-				TokenFile: config.BearerTokenFile,
+				Token: config.BearerToken,
+				//TokenFile: config.BearerTokenFile,
 			},
 		},
 	}, &clientcmd.ConfigOverrides{}), nil

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -20,8 +19,6 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	logrus.Infof("%#v", config)
 
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // loadInClusterConfig loads the Kubeconfig from the in cluster configuration.
@@ -20,27 +20,7 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 		return nil, err
 	}
 
-	logrus.Infof("%#v\n", config.String())
-
-	return clientcmd.NewClientConfigFromBytes([]byte(`apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority: ` + config.TLSClientConfig.CAFile + `
-    server: ` + config.Host + `
-  name: kubenav
-contexts:
-- context:
-    cluster: kubenav
-    user: kubenav
-  name: kubenav
-current-context: kubenav
-kind: Config
-users:
-- name: kubenav
-  user:
-    token: ` + config.BearerToken))
-
-	/*return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
+	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
 		CurrentContext: "incluster",
@@ -59,11 +39,11 @@ users:
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
 			"incluster": {
-				Token: config.BearerToken,
-				//TokenFile: config.BearerTokenFile,
+				Token:     config.BearerToken,
+				TokenFile: config.BearerTokenFile,
 			},
 		},
-	}, &clientcmd.ConfigOverrides{}), nil*/
+	}, &clientcmd.ConfigOverrides{}), nil
 }
 
 // loadConfigFile implements the logic from kubectl to load Kubeconfig files. If the -kubeconfig flag is provided this

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/user"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -19,6 +21,9 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	configBytes, _ := json.Marshal(config)
+	logrus.Infof("%#v\n", configBytes)
 
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/user"
@@ -22,8 +21,7 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 		return nil, err
 	}
 
-	configBytes, _ := json.Marshal(config)
-	logrus.Infof("%#v\n", configBytes)
+	logrus.Infof("%#v\n", config.String())
 
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -23,22 +23,22 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
-		CurrentContext: "incluster",
+		CurrentContext: "kubenav",
 		Contexts: map[string]*clientcmdapi.Context{
-			"incluster": {
-				Cluster:   "incluster",
-				AuthInfo:  "incluster",
+			"kubenav": {
+				Cluster:   "kubenav",
+				AuthInfo:  "kubenav",
 				Namespace: "default",
 			},
 		},
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"incluster": {
+			"kubenav": {
 				Server:               config.Host,
 				CertificateAuthority: config.TLSClientConfig.CAFile,
 			},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"incluster": {
+			"kubenav": {
 				Token:     config.BearerToken,
 				TokenFile: config.BearerTokenFile,
 			},

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -19,6 +20,8 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	logrus.Infof("%#v", config)
 
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -56,6 +57,8 @@ func NewClient(incluster bool, kubeconfig, kubeconfigInclude, kubeconfigExclude 
 		}
 	}
 
+	logrus.Infof("%#v", config)
+
 	return &Client{
 		config: config,
 	}, nil
@@ -77,6 +80,8 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	logrus.Infof("%#v", raw)
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -1,11 +1,9 @@
 package kube
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -79,9 +77,6 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	configBytes, _ := json.Marshal(raw)
-	logrus.Infof("%#v\n", string(configBytes))
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -77,6 +78,8 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	logrus.Infof("%#v\n", raw)
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,8 +56,6 @@ func NewClient(incluster bool, kubeconfig, kubeconfigInclude, kubeconfigExclude 
 		}
 	}
 
-	logrus.Infof("%#v", config)
-
 	return &Client{
 		config: config,
 	}, nil
@@ -80,8 +77,6 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	logrus.Infof("%#v", raw)
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -35,11 +35,16 @@ type Cluster struct {
 }
 
 // NewClient returns a new API client for a Kubernetes cluster.
-func NewClient(kubeconfig, kubeconfigInclude, kubeconfigExclude string) (*Client, error) {
+func NewClient(incluster bool, kubeconfig, kubeconfigInclude, kubeconfigExclude string) (*Client, error) {
 	var config clientcmd.ClientConfig
 	var err error
 
-	if kubeconfigInclude != "" {
+	if incluster {
+		config, err = loadInClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	} else if kubeconfigInclude != "" {
 		config, err = loadConfigFiles(kubeconfigInclude, kubeconfigExclude)
 		if err != nil {
 			return nil, err

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -79,7 +80,8 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 		return nil, err
 	}
 
-	logrus.Infof("%#v\n", raw)
+	configBytes, _ := json.Marshal(raw)
+	logrus.Infof("%#v\n", configBytes)
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -81,7 +81,7 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	}
 
 	configBytes, _ := json.Marshal(raw)
-	logrus.Infof("%#v\n", configBytes)
+	logrus.Infof("%#v\n", string(configBytes))
 
 	var clusters map[string]Cluster
 	clusters = make(map[string]Cluster)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,7 +3,7 @@ import { ITerminalOptions } from 'xterm';
 import { IAppSettings } from '../declarations';
 
 export const CUSTOM_URI_SCHEME = 'io.kubenav.kubenav';
-export const SERVER = 'http://localhost:14122';
+export const SERVER = process.env.REACT_APP_SERVER === 'true' ? '' : 'http://localhost:14122';
 export const VERSION = process.env.REACT_APP_VERSION;
 
 export const DEFAULT_SETTINGS: IAppSettings = {

--- a/utils/kubernetes/clusterrole.yaml
+++ b/utils/kubernetes/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubenav
+rules:
+- apiGroups:
+    - '*'
+  resources:
+    - '*'
+  verbs:
+    - '*'
+- nonResourceURLs:
+    - '*'
+  verbs:
+    - '*'

--- a/utils/kubernetes/clusterrolebinding.yaml
+++ b/utils/kubernetes/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubenav
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: kubenav
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/utils/kubernetes/clusterrolebinding.yaml
+++ b/utils/kubernetes/clusterrolebinding.yaml
@@ -3,12 +3,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubenav
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: kubenav
-  namespace: default
+  namespace: kubenav
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: kubenav
   apiGroup: rbac.authorization.k8s.io

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:f309a065
+          image: kubenav/kubenav:8e590bd8
           imagePullPolicy: IfNotPresent
           args:
              #

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,10 +19,13 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:78e6f803
+          image: kubenav/kubenav:328cc904
           imagePullPolicy: IfNotPresent
           args:
+             #
              - -incluster
+             #
+             #- -kubeconfig=/kubenav/kubeconfig/kubeconfig
           ports:
             - name: http
               containerPort: 14122
@@ -42,3 +45,11 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+          # volumeMounts:
+          #   - name: kubeconfig
+          #     mountPath: '/kubenav/kubeconfig'
+          #     readOnly: true
+      # volumes:
+      #   - name: kubeconfig
+      #     secret:
+      #       secretName: kubeconfig

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubenav
+  namespace: kubenav
+  labels:
+    app: kubenav
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubenav
+  template:
+    metadata:
+      labels:
+        app: kubenav
+    spec:
+      serviceAccountName: kubenav
+      containers:
+        - name: kubenav
+          image: kubenav/kubenav:998d975a
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 14122
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,8 +19,10 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:998d975a
+          image: kubenav/kubenav:31d61797
           imagePullPolicy: IfNotPresent
+          args:
+             - -incluster
           ports:
             - name: http
               containerPort: 14122

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,12 +19,15 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:8e590bd8
+          image: kubenav/kubenav:8e93455a
           imagePullPolicy: IfNotPresent
           args:
-             #
+             # Use the in cluster configuration for kubenav. This allows to manage only the cluster where kubenav is
+             # deployed.
              - -incluster
-             #
+             # Use a Kubeconfig to manage all clusters defined in the Kubeconfig file within the deployed kubenav. The
+             # command-line flag can also be replaced with a KUBECONFIG environment variable which contains the path to
+             # the Kubeconfig file.
              #- -kubeconfig=/kubenav/kubeconfig/kubeconfig
           ports:
             - name: http
@@ -45,10 +48,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+          # Mount the Kubeconfig file from your secret to the kubenav container.
           # volumeMounts:
           #   - name: kubeconfig
           #     mountPath: '/kubenav/kubeconfig'
           #     readOnly: true
+      # Define a new volume, to use the kubeconfig secret containing your Kubeconfig file. This is only required, if you
+      # do not want to use the in cluster option.
       # volumes:
       #   - name: kubeconfig
       #     secret:

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:31d61797
+          image: kubenav/kubenav:4695175f
           imagePullPolicy: IfNotPresent
           args:
              - -incluster

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:4695175f
+          image: kubenav/kubenav:7675a773
           imagePullPolicy: IfNotPresent
           args:
              - -incluster

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:7675a773
+          image: kubenav/kubenav:f7b6d114
           imagePullPolicy: IfNotPresent
           args:
              - -incluster

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:f7b6d114
+          image: kubenav/kubenav:78e6f803
           imagePullPolicy: IfNotPresent
           args:
              - -incluster

--- a/utils/kubernetes/deployment.yaml
+++ b/utils/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:328cc904
+          image: kubenav/kubenav:f309a065
           imagePullPolicy: IfNotPresent
           args:
              #

--- a/utils/kubernetes/namespace.yaml
+++ b/utils/kubernetes/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubenav

--- a/utils/kubernetes/secret.yaml
+++ b/utils/kubernetes/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig
+  namespace: kubenav
+data:
+  kubeconfig: <REPLACE WITH YOUR BASE64 ENCODED KUBECONFIG>
+type: Opaque

--- a/utils/kubernetes/service.yaml
+++ b/utils/kubernetes/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubenav
+  namespace: kubenav
+spec:
+  type: ClusterIP
+  ports:
+    - port: 14122
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: kubenav

--- a/utils/kubernetes/serviceaccount.yaml
+++ b/utils/kubernetes/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubenav
+  namespace: kubenav


### PR DESCRIPTION
- Rename the development server to server and reuse it for the Docker image.
- Add new GitHub Action workflow to build the Docker image for each master commit and release.
- Add a new command-line flag `incluster`, which can be used to manage a cluster where kubenav is deployed.
- Add example for a deployment to a Kubernetes cluster.

Close #107.