### PR TITLE
Fix GitHub Action for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
     name: Build
     runs-on: macos-latest
     steps:
+      - name: Trigger GitHub Action
+        run: echo "Trigger GitHub Action"
+
       - name: Get Version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     name: Build
     runs-on: macos-latest
     steps:
-      - name: Trigger GitHub Action
-        run: echo "Trigger GitHub Action"
-
       - name: Get Version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -60,12 +57,14 @@ jobs:
           make build-electron
 
       - name: Import Apple Code-signing Certificates and Keys
+        if: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event_name == 'schedule' }}
         uses: apple-actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATES_P12 }}
           p12-password: ${{ secrets.MACOS_CERTIFICATES_P12_PASSWORD }}
 
       - name: Code-sign macOS App
+        if: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event_name == 'schedule' }}
         run: |
           codesign --deep --force --options runtime --entitlements utils/resources/entitlements.plist --sign "Developer ID Application: Rico Berger" cmd/electron/output/darwin-amd64/kubenav.app
 


### PR DESCRIPTION
We have to omit the code-signing step, so the GitHub Action also works for PRs.