### PR TITLE
Show permissions for SA and Pods

### DIFF
--- a/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
@@ -1,0 +1,274 @@
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardSubtitle,
+  IonCardTitle,
+  IonCol,
+  IonIcon,
+  IonProgressBar,
+} from '@ionic/react';
+import { checkmark, close } from 'ionicons/icons';
+import {
+  V1ClusterRole,
+  V1ClusterRoleBindingList,
+  V1PolicyRule,
+  V1Role,
+  V1RoleBindingList,
+  V1Subject,
+} from '@kubernetes/client-node';
+import React, { useContext, useEffect } from 'react';
+
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import { resources } from '../../../../utils/resources';
+import useAsyncFn from '../../../../utils/useAsyncFn';
+
+interface IPermissionsProps {
+  namespace: string;
+  serviceAccountName: string;
+}
+
+const subjectsContainServiceAccount = (saNamespace: string, saName: string, subjects: V1Subject[]): boolean => {
+  for (const subject of subjects) {
+    if (subject.namespace && subject.namespace === saNamespace && subject.name === saName) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const renderRules = (rules: V1PolicyRule[] | undefined) => {
+  return (
+    <div className="table">
+      <table>
+        <thead>
+          <tr>
+            <th>Resource</th>
+            <th>Get</th>
+            <th>List</th>
+            <th>Create</th>
+            <th>Update</th>
+            <th>Patch</th>
+            <th>Delete</th>
+            <th>Watch</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rules
+            ? rules.map((rule, indexRule) => {
+                return rule.resources
+                  ? rule.resources.map((resource, indexResource) => {
+                      return (
+                        <tr key={`rule-${indexRule}-resource-${indexResource}`}>
+                          <td>
+                            Resource: {resource}
+                            {rule.apiGroups ? ` | API Groups: ${rule.apiGroups.join(',')}` : ''}
+                            {rule.resourceNames ? ` | Resource Name: ${rule.resourceNames.join(',')}` : ''}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('get') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('list') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('create') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('update') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('patch') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('delete') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('watch') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })
+                  : null;
+              })
+            : null}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const Permissions: React.FunctionComponent<IPermissionsProps> = ({
+  namespace,
+  serviceAccountName,
+}: IPermissionsProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [state, , fetchInit] = useAsyncFn(
+    async () => {
+      try {
+        const roles: V1ClusterRole[] = [];
+        const clusterRoles: V1Role[] = [];
+
+        const clusterRoleBindings: V1ClusterRoleBindingList = await context.request(
+          'GET',
+          resources['rbac'].pages['clusterrolebindings'].listURL(''),
+          '',
+        );
+
+        const roleBindings: V1RoleBindingList = await context.request(
+          'GET',
+          resources['rbac'].pages['rolebindings'].listURL(namespace),
+          '',
+        );
+
+        if (clusterRoleBindings && clusterRoleBindings.items) {
+          for (const item of clusterRoleBindings.items) {
+            if (
+              item.roleRef.kind.toLowerCase() === 'clusterrole' &&
+              item.subjects &&
+              subjectsContainServiceAccount(namespace, serviceAccountName, item.subjects)
+            ) {
+              const clusterRole: V1ClusterRole = await context.request(
+                'GET',
+                resources['rbac'].pages['clusterroles'].detailsURL(namespace, item.roleRef.name),
+                '',
+              );
+
+              clusterRoles.push(clusterRole);
+            } else if (
+              item.roleRef.kind.toLowerCase() === 'role' &&
+              item.subjects &&
+              subjectsContainServiceAccount(namespace, serviceAccountName, item.subjects)
+            ) {
+              const role: V1Role = await context.request(
+                'GET',
+                resources['rbac'].pages['roles'].detailsURL(namespace, item.roleRef.name),
+                '',
+              );
+
+              roles.push(role);
+            }
+          }
+        }
+
+        if (roleBindings && roleBindings.items) {
+          for (const item of roleBindings.items) {
+            if (
+              item.roleRef.kind.toLowerCase() === 'clusterrole' &&
+              item.subjects &&
+              subjectsContainServiceAccount(namespace, serviceAccountName, item.subjects)
+            ) {
+              const clusterRole: V1ClusterRole = await context.request(
+                'GET',
+                resources['rbac'].pages['clusterroles'].detailsURL(namespace, item.roleRef.name),
+                '',
+              );
+
+              clusterRoles.push(clusterRole);
+            } else if (
+              item.roleRef.kind.toLowerCase() === 'role' &&
+              item.subjects &&
+              subjectsContainServiceAccount(namespace, serviceAccountName, item.subjects)
+            ) {
+              const role: V1Role = await context.request(
+                'GET',
+                resources['rbac'].pages['roles'].detailsURL(namespace, item.roleRef.name),
+                '',
+              );
+
+              roles.push(role);
+            }
+          }
+        }
+
+        return {
+          clusterRoles: clusterRoles,
+          roles: roles,
+        };
+      } catch (err) {
+        throw err;
+      }
+    },
+    [namespace, serviceAccountName],
+    { loading: true, error: undefined, value: undefined },
+  );
+
+  useEffect(() => {
+    fetchInit();
+  }, [fetchInit]);
+
+  if (state.loading) {
+    return <IonProgressBar slot="fixed" type="indeterminate" color="primary" />;
+  } else if (!state.error && state.value) {
+    return (
+      <IonCol>
+        <IonCard>
+          <IonCardHeader>
+            <IonCardTitle>Permissions</IonCardTitle>
+          </IonCardHeader>
+          {state.value && state.value.clusterRoles
+            ? state.value.clusterRoles.map((clusterRole, index) => {
+                return (
+                  <React.Fragment key={index}>
+                    <IonCardHeader>
+                      <IonCardSubtitle>
+                        ClusterRole: {clusterRole.metadata ? clusterRole.metadata.name : ''}
+                      </IonCardSubtitle>
+                    </IonCardHeader>
+                    <IonCardContent>{renderRules(clusterRole.rules)}</IonCardContent>
+                  </React.Fragment>
+                );
+              })
+            : null}
+          {state.value && state.value.roles
+            ? state.value.roles.map((role, index) => {
+                return (
+                  <React.Fragment key={index}>
+                    <IonCardHeader>
+                      <IonCardSubtitle>Role: {role.metadata ? role.metadata.name : ''}</IonCardSubtitle>
+                    </IonCardHeader>
+                    <IonCardContent>{renderRules(role.rules)}</IonCardContent>
+                  </React.Fragment>
+                );
+              })
+            : null}
+        </IonCard>
+      </IonCol>
+    );
+  } else {
+    return <div>Test</div>;
+  }
+};
+
+export default Permissions;

--- a/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
@@ -7,6 +7,7 @@ import {
   IonCol,
   IonIcon,
   IonProgressBar,
+  IonRouterLink,
 } from '@ionic/react';
 import { checkmark, close } from 'ionicons/icons';
 import {
@@ -228,47 +229,68 @@ const Permissions: React.FunctionComponent<IPermissionsProps> = ({
     fetchInit();
   }, [fetchInit]);
 
-  if (state.loading) {
-    return <IonProgressBar slot="fixed" type="indeterminate" color="primary" />;
-  } else if (!state.error && state.value) {
-    return (
-      <IonCol>
-        <IonCard>
-          <IonCardHeader>
-            <IonCardTitle>Permissions</IonCardTitle>
-          </IonCardHeader>
-          {state.value && state.value.clusterRoles
-            ? state.value.clusterRoles.map((clusterRole, index) => {
-                return (
-                  <React.Fragment key={index}>
-                    <IonCardHeader>
-                      <IonCardSubtitle>
-                        ClusterRole: {clusterRole.metadata ? clusterRole.metadata.name : ''}
-                      </IonCardSubtitle>
-                    </IonCardHeader>
-                    <IonCardContent>{renderRules(clusterRole.rules)}</IonCardContent>
-                  </React.Fragment>
-                );
-              })
-            : null}
-          {state.value && state.value.roles
-            ? state.value.roles.map((role, index) => {
-                return (
-                  <React.Fragment key={index}>
-                    <IonCardHeader>
-                      <IonCardSubtitle>Role: {role.metadata ? role.metadata.name : ''}</IonCardSubtitle>
-                    </IonCardHeader>
-                    <IonCardContent>{renderRules(role.rules)}</IonCardContent>
-                  </React.Fragment>
-                );
-              })
-            : null}
-        </IonCard>
-      </IonCol>
-    );
-  } else {
-    return <div>Test</div>;
-  }
+  return (
+    <IonCol>
+      <IonCard>
+        <IonCardHeader>
+          <IonCardTitle>Permissions</IonCardTitle>
+        </IonCardHeader>
+        {state.loading ? (
+          <IonCardContent>
+            <IonProgressBar slot="fixed" type="indeterminate" color="primary" />
+          </IonCardContent>
+        ) : null}
+        {!state.error && state.value ? (
+          <React.Fragment>
+            {state.value && state.value.clusterRoles
+              ? state.value.clusterRoles.map((clusterRole, index) => {
+                  return (
+                    <React.Fragment key={index}>
+                      <IonCardHeader>
+                        <IonCardSubtitle>
+                          ClusterRole:{' '}
+                          <IonRouterLink
+                            routerLink={`/resources/rbac/clusterroles/undefined/${
+                              clusterRole.metadata ? clusterRole.metadata.name : ''
+                            }`}
+                            routerDirection="forward"
+                          >
+                            {clusterRole.metadata ? clusterRole.metadata.name : ''}
+                          </IonRouterLink>
+                        </IonCardSubtitle>
+                      </IonCardHeader>
+                      <IonCardContent>{renderRules(clusterRole.rules)}</IonCardContent>
+                    </React.Fragment>
+                  );
+                })
+              : null}
+            {state.value && state.value.roles
+              ? state.value.roles.map((role, index) => {
+                  return (
+                    <React.Fragment key={index}>
+                      <IonCardHeader>
+                        <IonCardSubtitle>
+                          Role:{' '}
+                          <IonRouterLink
+                            routerLink={`/resources/rbac/roles/${role.metadata ? role.metadata.namespace : ''}/${
+                              role.metadata ? role.metadata.name : ''
+                            }`}
+                            routerDirection="forward"
+                          >
+                            {role.metadata ? role.metadata.name : ''}
+                          </IonRouterLink>
+                        </IonCardSubtitle>
+                      </IonCardHeader>
+                      <IonCardContent>{renderRules(role.rules)}</IonCardContent>
+                    </React.Fragment>
+                  );
+                })
+              : null}
+          </React.Fragment>
+        ) : null}
+      </IonCard>
+    </IonCol>
+  );
 };
 
 export default Permissions;

--- a/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
@@ -7,6 +7,7 @@ import {
   IonCol,
   IonProgressBar,
   IonRouterLink,
+  IonRow,
 } from '@ionic/react';
 import { V1ClusterRole, V1ClusterRoleBindingList, V1Role, V1RoleBindingList, V1Subject } from '@kubernetes/client-node';
 import React, { useContext, useEffect } from 'react';
@@ -132,72 +133,79 @@ const Permissions: React.FunctionComponent<IPermissionsProps> = ({
     fetchInit();
   }, [fetchInit]);
 
-  return (
-    <IonCol>
-      <IonCard>
-        <IonCardHeader>
-          <IonCardTitle>Permissions</IonCardTitle>
-        </IonCardHeader>
-        {state.loading ? (
-          <IonCardContent>
-            <IonProgressBar slot="fixed" type="indeterminate" color="primary" />
-          </IonCardContent>
-        ) : null}
-        {!state.error && state.value ? (
-          <React.Fragment>
-            {state.value && state.value.clusterRoles
-              ? state.value.clusterRoles.map((clusterRole, index) => {
-                  return (
-                    <React.Fragment key={index}>
-                      <IonCardHeader>
-                        <IonCardSubtitle>
-                          ClusterRole:{' '}
-                          <IonRouterLink
-                            routerLink={`/resources/rbac/clusterroles/undefined/${
-                              clusterRole.metadata ? clusterRole.metadata.name : ''
-                            }`}
-                            routerDirection="forward"
-                          >
-                            {clusterRole.metadata ? clusterRole.metadata.name : ''}
-                          </IonRouterLink>
-                        </IonCardSubtitle>
-                      </IonCardHeader>
-                      <IonCardContent>
-                        <Rules rules={clusterRole.rules} />
-                      </IonCardContent>
-                    </React.Fragment>
-                  );
-                })
-              : null}
-            {state.value && state.value.roles
-              ? state.value.roles.map((role, index) => {
-                  return (
-                    <React.Fragment key={index}>
-                      <IonCardHeader>
-                        <IonCardSubtitle>
-                          Role:{' '}
-                          <IonRouterLink
-                            routerLink={`/resources/rbac/roles/${role.metadata ? role.metadata.namespace : ''}/${
-                              role.metadata ? role.metadata.name : ''
-                            }`}
-                            routerDirection="forward"
-                          >
-                            {role.metadata ? role.metadata.name : ''}
-                          </IonRouterLink>
-                        </IonCardSubtitle>
-                      </IonCardHeader>
-                      <IonCardContent>
-                        <Rules rules={role.rules} />
-                      </IonCardContent>
-                    </React.Fragment>
-                  );
-                })
-              : null}
-          </React.Fragment>
-        ) : null}
-      </IonCard>
-    </IonCol>
-  );
+  if (state.value && state.value.clusterRoles.length === 0 && state.value.roles.length === 0) {
+    return null;
+  } else {
+    return (
+      <IonRow>
+        <IonCol>
+          <IonCard>
+            <IonCardHeader>
+              <IonCardTitle>Permissions</IonCardTitle>
+            </IonCardHeader>
+            {state.loading ? (
+              <IonCardContent>
+                <IonProgressBar slot="fixed" type="indeterminate" color="primary" />
+              </IonCardContent>
+            ) : null}
+            {!state.error && state.value ? (
+              <React.Fragment>
+                {state.value && state.value.clusterRoles
+                  ? state.value.clusterRoles.map((clusterRole, index) => {
+                      return (
+                        <React.Fragment key={index}>
+                          <IonCardHeader>
+                            <IonCardSubtitle>
+                              ClusterRole:{' '}
+                              <IonRouterLink
+                                routerLink={`/resources/rbac/clusterroles/undefined/${
+                                  clusterRole.metadata ? clusterRole.metadata.name : ''
+                                }`}
+                                routerDirection="forward"
+                              >
+                                {clusterRole.metadata ? clusterRole.metadata.name : ''}
+                              </IonRouterLink>
+                            </IonCardSubtitle>
+                          </IonCardHeader>
+                          <IonCardContent>
+                            <Rules rules={clusterRole.rules} />
+                          </IonCardContent>
+                        </React.Fragment>
+                      );
+                    })
+                  : null}
+                {state.value && state.value.roles
+                  ? state.value.roles.map((role, index) => {
+                      return (
+                        <React.Fragment key={index}>
+                          <IonCardHeader>
+                            <IonCardSubtitle>
+                              Role:{' '}
+                              <IonRouterLink
+                                routerLink={`/resources/rbac/roles/${role.metadata ? role.metadata.namespace : ''}/${
+                                  role.metadata ? role.metadata.name : ''
+                                }`}
+                                routerDirection="forward"
+                              >
+                                {role.metadata && role.metadata.namespace ? `${role.metadata.namespace}/` : ''}
+                                {role.metadata ? role.metadata.name : ''}
+                              </IonRouterLink>
+                            </IonCardSubtitle>
+                          </IonCardHeader>
+                          <IonCardContent>
+                            <Rules rules={role.rules} />
+                          </IonCardContent>
+                        </React.Fragment>
+                      );
+                    })
+                  : null}
+              </React.Fragment>
+            ) : null}
+          </IonCard>
+        </IonCol>
+      </IonRow>
+    );
+  }
 };
 
 export default Permissions;

--- a/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/Permissions.tsx
@@ -5,25 +5,17 @@ import {
   IonCardSubtitle,
   IonCardTitle,
   IonCol,
-  IonIcon,
   IonProgressBar,
   IonRouterLink,
 } from '@ionic/react';
-import { checkmark, close } from 'ionicons/icons';
-import {
-  V1ClusterRole,
-  V1ClusterRoleBindingList,
-  V1PolicyRule,
-  V1Role,
-  V1RoleBindingList,
-  V1Subject,
-} from '@kubernetes/client-node';
+import { V1ClusterRole, V1ClusterRoleBindingList, V1Role, V1RoleBindingList, V1Subject } from '@kubernetes/client-node';
 import React, { useContext, useEffect } from 'react';
 
 import { IContext } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
 import { resources } from '../../../../utils/resources';
 import useAsyncFn from '../../../../utils/useAsyncFn';
+import Rules from '../../rbac/misc/Rules';
 
 interface IPermissionsProps {
   namespace: string;
@@ -38,95 +30,6 @@ const subjectsContainServiceAccount = (saNamespace: string, saName: string, subj
   }
 
   return false;
-};
-
-const renderRules = (rules: V1PolicyRule[] | undefined) => {
-  return (
-    <div className="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Resource</th>
-            <th>Get</th>
-            <th>List</th>
-            <th>Create</th>
-            <th>Update</th>
-            <th>Patch</th>
-            <th>Delete</th>
-            <th>Watch</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rules
-            ? rules.map((rule, indexRule) => {
-                return rule.resources
-                  ? rule.resources.map((resource, indexResource) => {
-                      return (
-                        <tr key={`rule-${indexRule}-resource-${indexResource}`}>
-                          <td>
-                            Resource: {resource}
-                            {rule.apiGroups ? ` | API Groups: ${rule.apiGroups.join(',')}` : ''}
-                            {rule.resourceNames ? ` | Resource Name: ${rule.resourceNames.join(',')}` : ''}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('get') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('list') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('create') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('update') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('patch') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('delete') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                          <td>
-                            {rule.verbs.includes('watch') ? (
-                              <IonIcon icon={checkmark} color="success" />
-                            ) : (
-                              <IonIcon icon={close} color="danger" />
-                            )}
-                          </td>
-                        </tr>
-                      );
-                    })
-                  : null;
-              })
-            : null}
-        </tbody>
-      </table>
-    </div>
-  );
 };
 
 const Permissions: React.FunctionComponent<IPermissionsProps> = ({
@@ -259,7 +162,9 @@ const Permissions: React.FunctionComponent<IPermissionsProps> = ({
                           </IonRouterLink>
                         </IonCardSubtitle>
                       </IonCardHeader>
-                      <IonCardContent>{renderRules(clusterRole.rules)}</IonCardContent>
+                      <IonCardContent>
+                        <Rules rules={clusterRole.rules} />
+                      </IonCardContent>
                     </React.Fragment>
                   );
                 })
@@ -281,7 +186,9 @@ const Permissions: React.FunctionComponent<IPermissionsProps> = ({
                           </IonRouterLink>
                         </IonCardSubtitle>
                       </IonCardHeader>
-                      <IonCardContent>{renderRules(role.rules)}</IonCardContent>
+                      <IonCardContent>
+                        <Rules rules={role.rules} />
+                      </IonCardContent>
                     </React.Fragment>
                   );
                 })

--- a/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
@@ -22,9 +22,7 @@ const ServiceAccountDetails: React.FunctionComponent<IServiceAccountDetailsProps
       {item.metadata ? <Metadata metadata={item.metadata} type={type} /> : null}
 
       {item.metadata && item.metadata.name && item.metadata.namespace ? (
-        <IonRow>
-          <Permissions namespace={item.metadata.namespace} serviceAccountName={item.metadata.name} />
-        </IonRow>
+        <Permissions namespace={item.metadata.namespace} serviceAccountName={item.metadata.name} />
       ) : null}
 
       {item.metadata && item.metadata.name && item.metadata.namespace ? (

--- a/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router';
 
 import List from '../../misc/List';
 import Metadata from '../../misc/template/Metadata';
+import Permissions from './Permissions';
 
 interface IServiceAccountDetailsProps extends RouteComponentProps {
   item: V1ServiceAccount;
@@ -19,6 +20,12 @@ const ServiceAccountDetails: React.FunctionComponent<IServiceAccountDetailsProps
   return (
     <IonGrid>
       {item.metadata ? <Metadata metadata={item.metadata} type={type} /> : null}
+
+      {item.metadata && item.metadata.name && item.metadata.namespace ? (
+        <IonRow>
+          <Permissions namespace={item.metadata.namespace} serviceAccountName={item.metadata.name} />
+        </IonRow>
+      ) : null}
 
       {item.metadata && item.metadata.name && item.metadata.namespace ? (
         <IonRow>

--- a/src/components/resources/rbac/clusterRoles/ClusterRoleDetails.tsx
+++ b/src/components/resources/rbac/clusterRoles/ClusterRoleDetails.tsx
@@ -1,12 +1,11 @@
 import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonGrid, IonRow } from '@ionic/react';
 import { V1ClusterRole } from '@kubernetes/client-node';
-import yaml from 'js-yaml';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
-import Editor from '../../../misc/Editor';
 import List from '../../misc/List';
 import Metadata from '../../misc/template/Metadata';
+import Rules from '../misc/Rules';
 
 interface IClusterRoleDetailsProps extends RouteComponentProps {
   item: V1ClusterRole;
@@ -30,7 +29,7 @@ const ClusterRoleDetails: React.FunctionComponent<IClusterRoleDetailsProps> = ({
                 <IonCardTitle>Rules</IonCardTitle>
               </IonCardHeader>
               <IonCardContent>
-                <Editor readOnly={true} value={yaml.safeDump(item.rules)} />
+                <Rules rules={item.rules} />
               </IonCardContent>
             </IonCard>
           </IonCol>

--- a/src/components/resources/rbac/misc/Rules.tsx
+++ b/src/components/resources/rbac/misc/Rules.tsx
@@ -13,6 +13,7 @@ const Rules: React.FunctionComponent<IRulesProps> = ({ rules }: IRulesProps) => 
       <table>
         <thead>
           <tr>
+            <th>API Groups</th>
             <th>Resource</th>
             <th>Get</th>
             <th>List</th>
@@ -30,10 +31,10 @@ const Rules: React.FunctionComponent<IRulesProps> = ({ rules }: IRulesProps) => 
                   ? rule.resources.map((resource, indexResource) => {
                       return (
                         <tr key={`rule-${indexRule}-resource-${indexResource}`}>
+                          <td>{rule.apiGroups ? rule.apiGroups.join(',') : ''}</td>
                           <td>
-                            Resource: {resource}
-                            {rule.apiGroups ? ` | API Groups: ${rule.apiGroups.join(',')}` : ''}
-                            {rule.resourceNames ? ` | Resource Name: ${rule.resourceNames.join(',')}` : ''}
+                            {resource}
+                            {rule.resourceNames ? ` (${rule.resourceNames.join(',')})` : ''}
                           </td>
                           <td>
                             {rule.verbs.includes('get') ? (

--- a/src/components/resources/rbac/misc/Rules.tsx
+++ b/src/components/resources/rbac/misc/Rules.tsx
@@ -1,0 +1,99 @@
+import { IonIcon } from '@ionic/react';
+import { checkmark, close } from 'ionicons/icons';
+import { V1PolicyRule } from '@kubernetes/client-node';
+import React from 'react';
+
+interface IRulesProps {
+  rules: V1PolicyRule[] | undefined;
+}
+
+const Rules: React.FunctionComponent<IRulesProps> = ({ rules }: IRulesProps) => {
+  return (
+    <div className="table">
+      <table>
+        <thead>
+          <tr>
+            <th>Resource</th>
+            <th>Get</th>
+            <th>List</th>
+            <th>Create</th>
+            <th>Update</th>
+            <th>Patch</th>
+            <th>Delete</th>
+            <th>Watch</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rules
+            ? rules.map((rule, indexRule) => {
+                return rule.resources
+                  ? rule.resources.map((resource, indexResource) => {
+                      return (
+                        <tr key={`rule-${indexRule}-resource-${indexResource}`}>
+                          <td>
+                            Resource: {resource}
+                            {rule.apiGroups ? ` | API Groups: ${rule.apiGroups.join(',')}` : ''}
+                            {rule.resourceNames ? ` | Resource Name: ${rule.resourceNames.join(',')}` : ''}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('get') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('list') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('create') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('update') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('patch') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('delete') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                          <td>
+                            {rule.verbs.includes('watch') ? (
+                              <IonIcon icon={checkmark} color="success" />
+                            ) : (
+                              <IonIcon icon={close} color="danger" />
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })
+                  : null;
+              })
+            : null}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Rules;

--- a/src/components/resources/rbac/roles/RoleDetails.tsx
+++ b/src/components/resources/rbac/roles/RoleDetails.tsx
@@ -1,12 +1,11 @@
 import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonGrid, IonRow } from '@ionic/react';
 import { V1Role } from '@kubernetes/client-node';
-import yaml from 'js-yaml';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
-import Editor from '../../../misc/Editor';
 import List from '../../misc/List';
 import Metadata from '../../misc/template/Metadata';
+import Rules from '../misc/Rules';
 
 interface IRoleDetailsProps extends RouteComponentProps {
   item: V1Role;
@@ -27,7 +26,7 @@ const RoleDetails: React.FunctionComponent<IRoleDetailsProps> = ({ item, type }:
                 <IonCardTitle>Rules</IonCardTitle>
               </IonCardHeader>
               <IonCardContent>
-                <Editor readOnly={true} value={yaml.safeDump(item.rules)} />
+                <Rules rules={item.rules} />
               </IonCardContent>
             </IonCard>
           </IonCol>

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -128,9 +128,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
       </IonRow>
 
       {item.metadata && item.metadata.namespace && item.spec && item.spec.serviceAccountName ? (
-        <IonRow>
-          <Permissions namespace={item.metadata.namespace} serviceAccountName={item.spec.serviceAccountName} />
-        </IonRow>
+        <Permissions namespace={item.metadata.namespace} serviceAccountName={item.spec.serviceAccountName} />
       ) : null}
 
       {item.metadata && item.metadata.name && item.metadata.namespace ? (

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { IContext, IPodMetrics } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
+import Permissions from '../../configAndStorage/serviceAccounts/Permissions';
 import List from '../../misc/List';
 import Affinities from '../../misc/podTemplate/affinities/Affinities';
 import Containers from '../../misc/podTemplate/containers/Containers';
@@ -55,7 +56,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
         <Configuration>
           <Row obj={item} objKey="spec.priority" title="Priority" />
           <Row obj={item} objKey="spec.nodeName" title="Node" />
-          <Row obj={item} objKey="spec.serviceAccount" title="Service Account" />
+          <Row obj={item} objKey="spec.serviceAccountName" title="Service Account" />
           <Row obj={item} objKey="spec.restartPolicy" title="Restart Policy" />
           <Row obj={item} objKey="spec.terminationGracePeriodSeconds" title="Termination Grace Period Seconds" />
         </Configuration>
@@ -125,6 +126,12 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
         ) : null}
         {item.spec && item.spec.affinity ? <Affinities affinities={item.spec.affinity} /> : null}
       </IonRow>
+
+      {item.metadata && item.metadata.namespace && item.spec && item.spec.serviceAccountName ? (
+        <IonRow>
+          <Permissions namespace={item.metadata.namespace} serviceAccountName={item.spec.serviceAccountName} />
+        </IonRow>
+      ) : null}
 
       {item.metadata && item.metadata.name && item.metadata.namespace ? (
         <IonRow>


### PR DESCRIPTION
- Show permissions for ServiceAccounts and Pods. For a ServiceAccount kubenav shows all associated ClusterRoles and Roles.
- Show rules table instead of yaml for ClusterRoles and Roles.

![Bildschirmfoto 2020-06-23 um 17 55 02](https://user-images.githubusercontent.com/18552168/85426408-b83f1180-b57a-11ea-8521-9ca7dc1a41fa.png)