### PR TITLE
Support terminal selection on mobile and add new shortcut to copy text

### DIFF
--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -47,6 +47,14 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
           term.open(termRef.current);
           fitAddon.fit();
 
+          term.attachCustomKeyEventHandler((event) => {
+            if (event.ctrlKey && event.shiftKey && event.keyCode === 3) {
+              selectCopy();
+            }
+
+            return false;
+          });
+
           if (terminal.webSocket) {
             term.focus();
           }

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -41,6 +41,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
 }: ITerminalsProps) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [showSearch, setShowSearch] = useState<boolean>(false);
+  const [showSelect, setShowSelect] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
 
   useEffect(() => {
@@ -84,10 +85,22 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                   detail={false}
                   onClick={() => {
                     setShowSearch(!showSearch);
+                    setShowSelect(false);
                     setShowPopover(false);
                   }}
                 >
                   <IonLabel>Search</IonLabel>
+                </IonItem>
+                <IonItem
+                  button={true}
+                  detail={false}
+                  onClick={() => {
+                    setShowSearch(false);
+                    setShowSelect(!showSelect);
+                    setShowPopover(false);
+                  }}
+                >
+                  <IonLabel>Select</IonLabel>
                 </IonItem>
               </IonItemGroup>
               <IonItemGroup>
@@ -135,7 +148,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
       <IonContent>
         {terminals.map((terminal, index) => {
           return activeTerminal === `term_${index}` ? (
-            <Shell key={index} showSearch={showSearch} terminal={terminal} />
+            <Shell key={index} showSearch={showSearch} showSelect={showSelect} terminal={terminal} />
           ) : null;
         })}
       </IonContent>


### PR DESCRIPTION
**Select and copy text on mobile**

Because of the limitation of xterm.js on mobile it wasn't possible to select and copy text from the terminal. Therefore a new entry was added to the terminal menu, which enables the selection and copying text.

The text can be selected via a range slider and copied via button. Maybe the range selection must be changed later, because it can be difficult to select the correct lines, when the number of displayed lines is very large.

**Add new shortcut to copy text**

Add a custom shortcut to copy the current selection in a terminal. The custom shortcut is <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>, which seems to be a common shortcut on linux to copy text.

Closes #120.