### PR TITLE
Fix panic for invalid Kubeconfig

### DIFF
--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -82,13 +82,13 @@ func (c *Client) Clusters() (map[string]Cluster, error) {
 	clusters = make(map[string]Cluster)
 
 	for context, details := range raw.Contexts {
-		cluster := raw.Clusters[details.Cluster]
-
-		clusters[context] = Cluster{
-			ID:        context,
-			Name:      context,
-			URL:       cluster.Server,
-			Namespace: details.Namespace,
+		if cluster, ok := raw.Clusters[details.Cluster]; ok && cluster.Server != "" {
+			clusters[context] = Cluster{
+				ID:        context,
+				Name:      context,
+				URL:       cluster.Server,
+				Namespace: details.Namespace,
+			}
 		}
 	}
 


### PR DESCRIPTION
When an invalid Kubeconfig file was provided to kubenav, it was possible that the loading of clusters panics. We are now checking the returned value when accessing the created map before processing with the creation of the clusters map.

Fixes #123.