### PR TITLE
Add support for SSH connections to nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/sirupsen/logrus v1.6.0
-	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
+	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/mobile v0.0.0-20200329125638-4c31acba0007 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect

--- a/pkg/api/ssh.go
+++ b/pkg/api/ssh.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"net/http"
+
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/igm/sockjs-go.v2/sockjs"
+)
+
+// SSHRequest defines the structure to init a new SSH session.
+type SSHRequest struct {
+	Key     string `json:"key"`
+	Address string `json:"address"`
+	User    string `json:"user"`
+}
+
+// CreateSSHHandler is called from main for /api/kubernetes/exec/sockjs
+func CreateSSHHandler(path string) http.Handler {
+	return sockjs.NewHandler(path, sockjs.DefaultOptions, handleTerminalSession)
+}
+
+// startSSHProcess is called by sshHandler
+// Executed cmd in the container specified in request and connects it up with the ptyHandler (a session)
+func startSSHProcess(key, addr, user string, ptyHandler PtyHandler) error {
+	signer, err := ssh.ParsePrivateKey([]byte(key))
+	if err != nil {
+		return err
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	client, err := ssh.Dial("tcp", addr, sshConfig)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	if err := session.RequestPty("xterm", 40, 80, ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}); err != nil {
+		return err
+	}
+
+	session.Stdin = ptyHandler
+	session.Stdout = ptyHandler
+	session.Stderr = ptyHandler
+
+	sizeChan := ptyHandler.GetSizeChan()
+
+	go func() {
+		for {
+			select {
+			case size := <-sizeChan:
+				session.WindowChange(int(size.Height), int(size.Width))
+			}
+		}
+	}()
+
+	err = session.Shell()
+	if err != nil {
+		return err
+	}
+
+	if err := session.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WaitForSSH is called from execHandler as a goroutine
+// Waits for the SockJS connection to be opened by the client the session to be bound in handleSSHSession
+func WaitForSSH(key, addr, user string, sessionID string) {
+	select {
+	case <-TerminalSessions.Get(sessionID).Bound:
+		close(TerminalSessions.Get(sessionID).Bound)
+
+		err := startSSHProcess(key, addr, user, TerminalSessions.Get(sessionID))
+		if err != nil {
+			TerminalSessions.Close(sessionID, 2, err.Error())
+			return
+		}
+
+		TerminalSessions.Close(sessionID, 1, "Process exited")
+	}
+}

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -146,7 +146,7 @@ func (sm *SessionMap) Close(sessionID string, status uint32, reason string) {
 
 var TerminalSessions = SessionMap{Sessions: make(map[string]TerminalSession)}
 
-// handleTerminalSession is Called by net/http for any new /api/sockjs connections
+// handleTerminalSession is Called by net/http for any new /api/kubernetes/exec/sockjs connections
 func handleTerminalSession(session sockjs.Session) {
 	var (
 		buf             string
@@ -176,7 +176,7 @@ func handleTerminalSession(session sockjs.Session) {
 	terminalSession.Bound <- nil
 }
 
-// CreateAttachHandler is called from main for /api/sockjs
+// CreateAttachHandler is called from main for /api/kubernetes/exec/sockjs
 func CreateAttachHandler(path string) http.Handler {
 	return sockjs.NewHandler(path, sockjs.DefaultOptions, handleTerminalSession)
 }
@@ -229,7 +229,7 @@ func isValidShell(validShells []string, shell string) bool {
 	return false
 }
 
-// WaitForTerminal is called from apihandler.handleAttach as a goroutine
+// WaitForTerminal is called from execHandler as a goroutine
 // Waits for the SockJS connection to be opened by the client the session to be bound in handleTerminalSession
 func WaitForTerminal(config *rest.Config, clientset *kubernetes.Clientset, request *Request, shell string, sessionID string) {
 	select {

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -29,6 +29,8 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	router.Handle("/api/kubernetes/exec/sockjs/", api.CreateAttachHandler("/api/kubernetes/exec/sockjs"))
 	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
+	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
+	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -26,7 +26,7 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 
 	router.HandleFunc("/api/kubernetes/request", middleware.Cors(requestHandler))
 	router.HandleFunc("/api/kubernetes/exec", middleware.Cors(execHandler))
-	router.Handle("/api/kubernetes/sockjs/", api.CreateAttachHandler("/api/kubernetes/sockjs"))
+	router.Handle("/api/kubernetes/exec/sockjs/", api.CreateAttachHandler("/api/kubernetes/exec/sockjs"))
 	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 }

--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -132,3 +132,39 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
 	return
 }
+
+// sshHandler handles SSH connections to a node
+func sshHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.SSHRequest
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		return
+	}
+
+	sessionID, err := api.GenTerminalSessionID()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		return
+	}
+
+	api.TerminalSessions.Set(sessionID, api.TerminalSession{
+		ID:       sessionID,
+		Bound:    make(chan error),
+		SizeChan: make(chan remotecommand.TerminalSize),
+	})
+
+	go api.WaitForSSH(request.Key, request.Address, request.User, sessionID)
+
+	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
+	return
+}

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -23,6 +23,8 @@ func StartServer() {
 	router.Handle("/api/kubernetes/exec/sockjs/", api.CreateAttachHandler("/api/kubernetes/exec/sockjs"))
 	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
+	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
+	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 
 	router.HandleFunc("/api/oidc/link", middleware.Cors(oidcGetLinkHandler))
 	router.HandleFunc("/api/oidc/refreshtoken", middleware.Cors(oidcGetRefreshTokenHandler))

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -20,7 +20,7 @@ func StartServer() {
 
 	router.HandleFunc("/api/kubernetes/request", middleware.Cors(requestHandler))
 	router.HandleFunc("/api/kubernetes/exec", middleware.Cors(execHandler))
-	router.Handle("/api/kubernetes/sockjs/", api.CreateAttachHandler("/api/kubernetes/sockjs"))
+	router.Handle("/api/kubernetes/exec/sockjs/", api.CreateAttachHandler("/api/kubernetes/exec/sockjs"))
 	router.HandleFunc("/api/kubernetes/logs", middleware.Cors(logsHandler))
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -1,13 +1,17 @@
 import {
+  IonCard,
   IonCardContent,
   IonCardHeader,
   IonCardTitle,
   IonCol,
   IonGrid,
   IonItem,
+  IonItemOptions,
+  IonItemSliding,
   IonLabel,
   IonList,
   IonRow,
+  isPlatform,
 } from '@ionic/react';
 import { V1Node, V1NodeAddress } from '@kubernetes/client-node';
 import React, { useContext, useEffect, useState } from 'react';
@@ -17,6 +21,7 @@ import { IContext, INodeMetrics } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
 import { formatBytes, formatResourceValue } from '../../../../utils/helpers';
 import IonCardEqualHeight from '../../../misc/IonCardEqualHeight';
+import AddSSH from '../../../terminal/AddSSH';
 import List from '../../misc/List';
 import Conditions from '../../misc/template/Conditions';
 import Configuration from '../../misc/template/Configuration';
@@ -109,6 +114,50 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
       </IonRow>
 
       {item.metadata ? <Metadata metadata={item.metadata} type={type} /> : null}
+
+      {item.status && item.status.addresses ? (
+        <IonRow>
+          <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="12" sizeXl="12">
+            <IonCard>
+              <IonCardHeader>
+                <IonCardTitle>Addresses</IonCardTitle>
+              </IonCardHeader>
+              <IonCardContent>
+                <IonList>
+                  {item.status.addresses.map((address, index) => (
+                    <IonItemSliding key={index}>
+                      <IonItem>
+                        <IonLabel>
+                          <h2>
+                            {address.type}: {address.address}
+                          </h2>
+                        </IonLabel>
+                        {!isPlatform('hybrid') ? (
+                          <AddSSH
+                            activator="button"
+                            node={item.metadata && item.metadata.name ? item.metadata.name : ''}
+                            ip={address.address}
+                          />
+                        ) : null}
+                      </IonItem>
+
+                      {isPlatform('hybrid') ? (
+                        <IonItemOptions side="end">
+                          <AddSSH
+                            activator="item-option"
+                            node={item.metadata && item.metadata.name ? item.metadata.name : ''}
+                            ip={address.address}
+                          />
+                        </IonItemOptions>
+                      ) : null}
+                    </IonItemSliding>
+                  ))}
+                </IonList>
+              </IonCardContent>
+            </IonCard>
+          </IonCol>
+        </IonRow>
+      ) : null}
 
       <IonRow>
         {item.status && item.status.capacity && item.status.allocatable ? (

--- a/src/components/resources/misc/DetailsPopover.tsx
+++ b/src/components/resources/misc/DetailsPopover.tsx
@@ -8,6 +8,7 @@ import LogsItem from './modify/LogsItem';
 import RestartItem from './modify/RestartItem';
 import ScaleItem from './modify/ScaleItem';
 import ShellItem from './modify/ShellItem';
+import SSHItem from './modify/SSHItem';
 
 interface IDetailsPopoverProps {
   type: string;
@@ -35,6 +36,7 @@ const DetailsPopover: React.FunctionComponent<IDetailsPopoverProps> = ({ type, i
           ) : null}
           {isPlatform('hybrid') && type === 'pods' ? <LogsItem activator="item" item={item} url={url} /> : null}
           {isPlatform('hybrid') && type === 'pods' ? <ShellItem activator="item" item={item} url={url} /> : null}
+          {isPlatform('hybrid') && type === 'nodes' ? <SSHItem activator="item" item={item} /> : null}
           <EditItem activator="item" item={item} url={url} />
           <DeleteItem activator="item" item={item} url={url} />
         </IonList>

--- a/src/components/resources/misc/modify/SSHItem.tsx
+++ b/src/components/resources/misc/modify/SSHItem.tsx
@@ -1,0 +1,78 @@
+import { ActionSheetButton, IonActionSheet, IonIcon, IonItem, IonLabel } from '@ionic/react';
+import { V1Node } from '@kubernetes/client-node';
+import { terminal } from 'ionicons/icons';
+import React, { useContext, useState } from 'react';
+
+import { IContext, ITerminalContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import { TerminalContext } from '../../../../utils/terminal';
+import { addSSH } from '../../../terminal/helpers';
+
+interface ISSHItemProps {
+  activator: TActivator;
+  item: V1Node;
+}
+
+const SSHItem: React.FunctionComponent<ISSHItemProps> = ({ activator, item }: ISSHItemProps) => {
+  const context = useContext<IContext>(AppContext);
+  const terminalContext = useContext<ITerminalContext>(TerminalContext);
+
+  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
+
+  const generateButtons = (): ActionSheetButton[] => {
+    const buttons: ActionSheetButton[] = [];
+
+    if (item.status && item.status.addresses) {
+      for (const address of item.status.addresses) {
+        buttons.push({
+          text: address.address,
+          handler: () => {
+            addSSH(
+              context,
+              terminalContext,
+              item.metadata && item.metadata.name ? item.metadata.name : '',
+              address.address,
+            );
+          },
+        });
+      }
+    }
+
+    return buttons;
+  };
+
+  const buttons = generateButtons();
+
+  return (
+    <React.Fragment>
+      {activator === 'item' ? (
+        <IonItem
+          button={true}
+          detail={false}
+          onClick={() =>
+            buttons.length === 1
+              ? addSSH(
+                  context,
+                  terminalContext,
+                  item.metadata && item.metadata.name ? item.metadata.name : '',
+                  buttons[0].text ? buttons[0].text : '',
+                )
+              : setShowActionSheet(true)
+          }
+        >
+          <IonIcon slot="end" color="primary" icon={terminal} />
+          <IonLabel>SSH</IonLabel>
+        </IonItem>
+      ) : null}
+
+      <IonActionSheet
+        isOpen={showActionSheet}
+        onDidDismiss={() => setShowActionSheet(false)}
+        header="Select IP Address"
+        buttons={buttons}
+      />
+    </React.Fragment>
+  );
+};
+
+export default SSHItem;

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -10,6 +10,7 @@ import {
   IonList,
   IonMenuButton,
   IonPage,
+  IonTextarea,
   IonTitle,
   IonToggle,
   IonToolbar,
@@ -28,6 +29,9 @@ const GeneralPage: React.FunctionComponent = () => {
     context.editSettings({
       darkMode: context.settings.darkMode,
       timeout: parseInt(event.target.value),
+      sshKey: context.settings.sshKey,
+      sshPort: context.settings.sshPort,
+      sshUser: context.settings.sshUser,
     });
   };
 
@@ -35,6 +39,39 @@ const GeneralPage: React.FunctionComponent = () => {
     context.editSettings({
       darkMode: event.detail.checked,
       timeout: context.settings.timeout,
+      sshKey: context.settings.sshKey,
+      sshPort: context.settings.sshPort,
+      sshUser: context.settings.sshUser,
+    });
+  };
+
+  const changeSSHKey = (event) => {
+    context.editSettings({
+      darkMode: context.settings.darkMode,
+      timeout: context.settings.timeout,
+      sshKey: event.target.value,
+      sshPort: context.settings.sshPort,
+      sshUser: context.settings.sshUser,
+    });
+  };
+
+  const changeSSHPort = (event) => {
+    context.editSettings({
+      darkMode: context.settings.darkMode,
+      timeout: context.settings.timeout,
+      sshKey: context.settings.sshKey,
+      sshPort: event.target.value,
+      sshUser: context.settings.sshUser,
+    });
+  };
+
+  const changeSSHUser = (event) => {
+    context.editSettings({
+      darkMode: context.settings.darkMode,
+      timeout: context.settings.timeout,
+      sshKey: context.settings.sshKey,
+      sshPort: context.settings.sshPort,
+      sshUser: event.target.value,
     });
   };
 
@@ -61,6 +98,24 @@ const GeneralPage: React.FunctionComponent = () => {
             <IonItem>
               <IonLabel position="stacked">Timeout (in seconds)</IonLabel>
               <IonInput type="number" required={true} value={context.settings.timeout} onInput={changeTimeout} />
+            </IonItem>
+          </IonItemGroup>
+
+          <IonItemGroup>
+            <IonItemDivider>
+              <IonLabel>SSH</IonLabel>
+            </IonItemDivider>
+            <IonItem>
+              <IonLabel position="stacked">Port</IonLabel>
+              <IonInput type="text" required={true} value={context.settings.sshPort} onInput={changeSSHPort} />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Private Key</IonLabel>
+              <IonTextarea autoGrow={true} value={context.settings.sshKey} onInput={changeSSHKey} />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">User</IonLabel>
+              <IonInput type="text" required={true} value={context.settings.sshUser} onInput={changeSSHUser} />
             </IonItem>
           </IonItemGroup>
 

--- a/src/components/terminal/AddSSH.tsx
+++ b/src/components/terminal/AddSSH.tsx
@@ -1,0 +1,44 @@
+import { IonButton, IonIcon, IonItemOption } from '@ionic/react';
+import { terminal } from 'ionicons/icons';
+import React, { useContext } from 'react';
+
+import { IContext, ITerminalContext, TActivator } from '../../declarations';
+import { AppContext } from '../../utils/context';
+import { TerminalContext } from '../../utils/terminal';
+import { addSSH } from './helpers';
+
+interface IAddShellProps {
+  activator: TActivator;
+  node: string;
+  ip: string;
+}
+
+const AddShell: React.FunctionComponent<IAddShellProps> = ({ activator, node, ip }: IAddShellProps) => {
+  const context = useContext<IContext>(AppContext);
+  const terminalContext = useContext<ITerminalContext>(TerminalContext);
+
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="primary" onClick={() => addSSH(context, terminalContext, node, ip)}>
+        <IonIcon slot="start" icon={terminal} />
+        SSH
+      </IonItemOption>
+    );
+  } else {
+    return (
+      <IonButton
+        fill="outline"
+        slot="end"
+        onClick={(e) => {
+          e.stopPropagation();
+          addSSH(context, terminalContext, node, ip);
+        }}
+      >
+        <IonIcon slot="start" icon={terminal} />
+        SSH
+      </IonButton>
+    );
+  }
+};
+
+export default AddShell;

--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -45,7 +45,7 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
           term.loadAddon(fitAddon);
           term.loadAddon(searchAddon);
           term.open(termRef.current);
-          fitAddon.fit();
+          updateTerminalSize();
 
           term.attachCustomKeyEventHandler((event) => {
             if (event.ctrlKey && event.shiftKey && event.keyCode === 3) {
@@ -85,17 +85,26 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
     }
 
     updateTerminalSize();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showSearch]);
-
-  const updateTerminalSize = () => {
-    fitAddon.fit();
 
     if (showSearch) {
       term?.resize(term.cols, term.rows - 4);
     } else {
       term?.resize(term.cols, term.rows + 4);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSearch]);
+
+  useEffect(() => {
+    if (showSelect) {
+      term?.resize(term.cols, term.rows - 4);
+    } else {
+      term?.resize(term.cols, term.rows + 4);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSelect]);
+
+  const updateTerminalSize = () => {
+    fitAddon.fit();
   };
 
   const search = (event) => {

--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -50,9 +50,10 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
           term.attachCustomKeyEventHandler((event) => {
             if (event.ctrlKey && event.shiftKey && event.keyCode === 3) {
               selectCopy();
+              return false;
             }
 
-            return false;
+            return true;
           });
 
           if (terminal.webSocket) {

--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -86,19 +86,23 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
 
     updateTerminalSize();
 
-    if (showSearch) {
-      term?.resize(term.cols, term.rows - 4);
-    } else {
-      term?.resize(term.cols, term.rows + 4);
+    if (term) {
+      if (showSearch) {
+        term.resize(term.cols, term.rows - 4);
+      } else {
+        term.resize(term.cols, term.rows + 4);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showSearch]);
 
   useEffect(() => {
-    if (showSelect) {
-      term?.resize(term.cols, term.rows - 4);
-    } else {
-      term?.resize(term.cols, term.rows + 4);
+    if (term) {
+      if (showSelect) {
+        term.resize(term.cols, term.rows - 4);
+      } else {
+        term.resize(term.cols, term.rows + 4);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showSelect]);

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -20,7 +20,7 @@ export const addShell = async (
         context.clusters[context.cluster],
       );
 
-      const webSocket = new SockJS(`${SERVER}/api/kubernetes/sockjs?${id}`);
+      const webSocket = new SockJS(`${SERVER}/api/kubernetes/exec/sockjs?${id}`);
 
       term?.onData((str) => {
         webSocket.send(

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -41,6 +41,9 @@ export interface IAppSections {
 export interface IAppSettings {
   darkMode: boolean;
   timeout: number;
+  sshKey: string;
+  sshPort: string;
+  sshUser: string;
 }
 
 export interface IAWSCluster {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -487,6 +487,37 @@ export const logsRequest = async (url: string, cluster: ICluster): Promise<ITerm
   }
 };
 
+// sshRequest initialize the request to get a SSH connection to a node. The generated session id is returned and can be
+// used to get the SSH connection to the node.
+export const sshRequest = async (key: string, address: string, user: string): Promise<ITerminalResponse> => {
+  try {
+    await checkServer();
+
+    const response = await fetch(`${SERVER}/api/kubernetes/ssh`, {
+      method: 'post',
+      body: JSON.stringify({
+        key: key,
+        address: address,
+        user: user,
+      }),
+    });
+
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.message);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
 // getOIDCAccessToken returns a new id and access token for the provided OIDC provider. To get a new id and access token
 // a valid refresh token is required.
 export const getOIDCAccessToken = async (provider: IOIDCProvider): Promise<IOIDCProviderToken> => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,9 @@ export const VERSION = process.env.REACT_APP_VERSION;
 export const DEFAULT_SETTINGS: IAppSettings = {
   darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
   timeout: 60,
+  sshKey: '',
+  sshPort: '22',
+  sshUser: '',
 };
 
 export const GOOGLE_OAUTH2_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -87,6 +87,9 @@ export const readSettings = (): IAppSettings => {
     return {
       darkMode: settings.hasOwnProperty('darkMode') ? settings.darkMode : DEFAULT_SETTINGS.darkMode,
       timeout: settings.timeout ? settings.timeout : DEFAULT_SETTINGS.timeout,
+      sshKey: settings.sshKey ? settings.sshKey : DEFAULT_SETTINGS.sshKey,
+      sshPort: settings.sshPort ? settings.sshPort : DEFAULT_SETTINGS.sshPort,
+      sshUser: settings.sshUser ? settings.sshUser : DEFAULT_SETTINGS.sshUser,
     };
   }
 


### PR DESCRIPTION
- It is now possible to create a SSH connection to a node. Therefor the user has to provide the SSH username, SSH port and his SSH private key. It is only possible to set these credentials globally, so that each node must use the same credentials.
- Fix a bug in the custom key event handling, whereby the shell for Pods stopped working. No key events were passed to the websocket connection.