### PR TITLE
Fix pod status

### DIFF
--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -50,6 +50,8 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
     }
   }, [item, type, context]);
 
+  const status = getStatus(item);
+
   return (
     <IonGrid>
       <IonRow>
@@ -74,14 +76,9 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
             </IonCol>
             <IonCol>{getRestarts(item)}</IonCol>
           </IonRow>
-          <IonRow>
-            <IonCol size="auto">
-              <b>Status:</b>
-            </IonCol>
-            <IonCol>{getStatus(item)}</IonCol>
-          </IonRow>
+          <Row obj={status} objKey="phase" title="Phase" />
+          {status.reason ? <Row obj={status} objKey="reason" title="Reason" /> : null}
           <Row obj={item} objKey="status.qosClass" title="QoS" />
-          <Row obj={item} objKey="status.phase" title="Phase" />
           <Row obj={item} objKey="status.podIP" title="Pod IP" />
           <Row obj={item} objKey="status.hostIP" title="Host IP" />
         </Status>

--- a/src/components/resources/workloads/pods/PodItem.tsx
+++ b/src/components/resources/workloads/pods/PodItem.tsx
@@ -45,12 +45,12 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
   const podStatus = getStatus(item);
 
   const status = (): string => {
-    if (podStatus === 'Pending') {
-      return 'warning';
+    if (podStatus.phase === 'Running' || podStatus.phase === 'Succeeded') {
+      return 'success';
     }
 
-    if (podStatus === 'Running' || podStatus === 'Completed') {
-      return 'success';
+    if (podStatus.phase === 'Unknown') {
+      return 'warning';
     }
 
     return 'danger';
@@ -72,7 +72,8 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
         <p>
-          Ready: {getReady(item)} | Restarts: {getRestarts(item)} | Status: {podStatus}
+          Ready: {getReady(item)} | Restarts: {getRestarts(item)} | Phase: {podStatus.phase}
+          {podStatus.reason ? ` | Reason: ${podStatus.reason}` : ''}
           {item.spec && item.spec.initContainers && item.spec.containers
             ? ` | ${getResources(item.spec.initContainers.concat(item.spec.containers), metrics)}`
             : item.spec && item.spec.containers


### PR DESCRIPTION
The pod status wasn't shown correctly, therefor the `Status` field is replaced by `Phase` and if available `Reason`.

If the phase of the pod is `Running` or `Succeeded` the status is *success*. If the phase is `Unknown` the status is *warning* and for `Pending` and `Failed` the status is *danger*.

Fixes #128.