### PR TITLE
Add support for Pod Security Policies

### DIFF
--- a/src/components/resources/cluster/podsecuritypolicies/PodSecurityPolicyDetails.tsx
+++ b/src/components/resources/cluster/podsecuritypolicies/PodSecurityPolicyDetails.tsx
@@ -1,0 +1,42 @@
+import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonGrid, IonRow } from '@ionic/react';
+import { V1beta1PodSecurityPolicy } from '@kubernetes/client-node';
+import yaml from 'js-yaml';
+import React from 'react';
+import { RouteComponentProps } from 'react-router';
+
+import Editor from '../../../misc/Editor';
+import Metadata from '../../misc/template/Metadata';
+
+interface IPodSecurityPolicyDetailsProps extends RouteComponentProps {
+  item: V1beta1PodSecurityPolicy;
+  section: string;
+  type: string;
+}
+
+const PodSecurityPolicyDetails: React.FunctionComponent<IPodSecurityPolicyDetailsProps> = ({
+  item,
+  type,
+}: IPodSecurityPolicyDetailsProps) => {
+  return (
+    <IonGrid>
+      {item.metadata ? <Metadata metadata={item.metadata} type={type} /> : null}
+
+      {item.spec ? (
+        <IonRow>
+          <IonCol>
+            <IonCard>
+              <IonCardHeader>
+                <IonCardTitle>Policy</IonCardTitle>
+              </IonCardHeader>
+              <IonCardContent>
+                <Editor readOnly={true} value={yaml.safeDump(item.spec)} />
+              </IonCardContent>
+            </IonCard>
+          </IonCol>
+        </IonRow>
+      ) : null}
+    </IonGrid>
+  );
+};
+
+export default PodSecurityPolicyDetails;

--- a/src/components/resources/cluster/podsecuritypolicies/PodSecurityPolicyItem.tsx
+++ b/src/components/resources/cluster/podsecuritypolicies/PodSecurityPolicyItem.tsx
@@ -1,0 +1,45 @@
+import { IonItem, IonLabel } from '@ionic/react';
+import { V1beta1PodSecurityPolicy } from '@kubernetes/client-node';
+import React from 'react';
+import { RouteComponentProps } from 'react-router';
+import { timeDifference } from '../../../../utils/helpers';
+
+interface IPodSecurityPolicyItemProps extends RouteComponentProps {
+  item: V1beta1PodSecurityPolicy;
+  section: string;
+  type: string;
+}
+
+const PodSecurityPolicyItem: React.FunctionComponent<IPodSecurityPolicyItemProps> = ({
+  item,
+  section,
+  type,
+}: IPodSecurityPolicyItemProps) => {
+  // - Age: The time when the namespace was created.
+  return (
+    <IonItem
+      routerLink={`/resources/${section}/${type}/${item.metadata ? item.metadata.namespace : ''}/${
+        item.metadata ? item.metadata.name : ''
+      }`}
+      routerDirection="forward"
+    >
+      <IonLabel>
+        <h2>{item.metadata ? item.metadata.name : ''}</h2>
+        <p>
+          Privileged: {item.spec && item.spec.privileged ? 'true' : 'false'}
+          {item.spec && item.spec.allowedCapabilities
+            ? ` | Capabilities: ${item.spec.allowedCapabilities.join(', ')}`
+            : ''}
+          {item.metadata && item.metadata.creationTimestamp
+            ? ` | Age: ${timeDifference(
+                new Date().getTime(),
+                new Date(item.metadata.creationTimestamp.toString()).getTime(),
+              )}`
+            : ''}
+        </p>
+      </IonLabel>
+    </IonItem>
+  );
+};
+
+export default PodSecurityPolicyItem;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -135,7 +135,8 @@ export const isNamespaced = (type: string): boolean => {
     type === 'clusterrolebindings' ||
     type === 'customresourcedefinitions' ||
     type === 'namespaces' ||
-    type === 'nodes'
+    type === 'nodes' ||
+    type === 'podsecuritypolicies'
   );
 };
 

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -30,6 +30,7 @@ import ComponentStatusDetails from '../components/resources/cluster/componentsta
 import EventDetails from '../components/resources/cluster/events/EventDetails';
 import NamespaceDetails from '../components/resources/cluster/namespaces/NamespaceDetails';
 import NodeDetails from '../components/resources/cluster/nodes/NodeDetails';
+import PodSecurityPolicyDetails from '../components/resources/cluster/podsecuritypolicies/PodSecurityPolicyDetails';
 
 import CronJobItem from '../components/resources/workloads/cronJobs/CronJobItem';
 import DaemonSetItem from '../components/resources/workloads/daemonSets/DaemonSetItem';
@@ -64,6 +65,7 @@ import CustomResourceDefinitionItem from '../components/resources/cluster/custom
 import EventItem from '../components/resources/cluster/events/EventItem';
 import NamespaceItem from '../components/resources/cluster/namespaces/NamespaceItem';
 import NodeItem from '../components/resources/cluster/nodes/NodeItem';
+import PodSecurityPolicyItem from '../components/resources/cluster/podsecuritypolicies/PodSecurityPolicyItem';
 
 import { IAppSections } from '../declarations';
 
@@ -493,6 +495,20 @@ export const resources: IAppSections = {
           return `/api/v1/nodes/${name}`;
         },
         detailsComponent: NodeDetails,
+      },
+      podsecuritypolicies: {
+        singleText: 'Pod Security Policy',
+        pluralText: 'Pod Security Policies',
+        icon: '/assets/icons/kubernetes/psp.png',
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        listURL: (namespace: string): string => {
+          return `/apis/policy/v1beta1/podsecuritypolicies`;
+        },
+        listItemComponent: PodSecurityPolicyItem,
+        detailsURL: (namespace: string, name: string): string => {
+          return `/apis/policy/v1beta1/podsecuritypolicies/${name}`;
+        },
+        detailsComponent: PodSecurityPolicyDetails,
       },
     },
   },


### PR DESCRIPTION
Show all available Pod Security Policies in the cluster section. The list item shows if the the privileged property is true/false and the allowed capabilities. The details page shows the policy as yaml file.