### PR TITLE
Fix path on macOS

### DIFF
--- a/cmd/electron/bundler.json
+++ b/cmd/electron/bundler.json
@@ -7,5 +7,17 @@
     {"arch": "amd64", "os": "darwin"},
     {"arch": "amd64", "os": "linux"},
     {"arch": "amd64", "os": "windows"}
-  ]
+  ],
+  "info_plist": {
+    "CFBundleIconFile": "kubenav.icns",
+    "CFBundleDisplayName": "kubenav",
+    "CFBundleExecutable": "kubenav",
+    "CFBundleName": "kubenav",
+    "CFBundleIdentifier": "io.kubenav.kubenav",
+    "LSUIElement": "NO",
+    "CFBundlePackageType": "APPL",
+    "LSEnvironment": {
+      "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    }
+  }
 }


### PR DESCRIPTION
Add `LSEnvironment` key to the `Info.plist` file, to include some default values to the `PATH` environment variable on macOS. This is required because the `PATH` doesn't include the required paths for the cloud providers.

Fix #132.