### PR TITLE
Improve error handling for requests

### DIFF
--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -31,6 +31,16 @@ type Response struct {
 	Data string `json:"data"`
 }
 
+// Error implements the structure of a response for a failed Kubernetes API request.
+type Error struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Status     string `json:"status"`
+	Message    string `json:"message"`
+	Reason     string `json:"reason"`
+	Code       int    `json:"code"`
+}
+
 // KubernetesRequest makes the request to the Kubernetes API server. A request contains a method, url, body and timeout.
 // The API server data is defined in the clientset.
 func KubernetesRequest(ctx context.Context, method, url, body string, clientset *kubernetes.Clientset) ([]byte, error) {

--- a/pkg/electron/cluster.go
+++ b/pkg/electron/cluster.go
@@ -1,6 +1,7 @@
 package electron
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/kubenav/kubenav/pkg/api/middleware"
@@ -15,7 +16,7 @@ func clusterHandler(w http.ResponseWriter, r *http.Request) {
 
 	cluster, err := client.Cluster()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not load current cluster")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not load current cluster: %s", err.Error()))
 		return
 	}
 
@@ -37,7 +38,7 @@ func clustersHandler(w http.ResponseWriter, r *http.Request) {
 
 	clusters, err := client.Clusters()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not load clusters")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not load clusters %s", err.Error()))
 		return
 	}
 

--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -39,7 +39,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := api.KubernetesRequest(r.Context(), request.Method, request.URL, request.Body, clientset)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+		var apiError api.Error
+		if err := json.Unmarshal(result, &apiError); err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+			return
+		}
+
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", apiError.Message))
 		return
 	}
 

--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -27,19 +27,19 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	_, clientset, err := client.ConfigClientset(request.Cluster, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	result, err := api.KubernetesRequest(r.Context(), request.Method, request.URL, request.Body, clientset)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
 		return
 	}
 
@@ -65,19 +65,19 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	config, clientset, err := client.ConfigClientset(request.Cluster, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 
@@ -108,19 +108,19 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	_, clientset, err := client.ConfigClientset(request.Cluster, 6*time.Hour)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 
@@ -147,13 +147,13 @@ func sshHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 

--- a/pkg/electron/sync.go
+++ b/pkg/electron/sync.go
@@ -2,6 +2,7 @@ package electron
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/kubenav/kubenav/pkg/api/middleware"
@@ -31,13 +32,13 @@ func syncContextHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&sync)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode sync body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode sync body: %s", err.Error()))
 		return
 	}
 
 	err = client.ChangeContext(sync.Context)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not change context")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not change context: %s", err.Error()))
 		return
 	}
 
@@ -63,13 +64,13 @@ func syncNamespaceHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&sync)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode sync body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode sync body: %s", err.Error()))
 		return
 	}
 
 	err = client.ChangeNamespace(sync.Context, sync.Namespace)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not change namespace")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not change context: %s", err.Error()))
 		return
 	}
 

--- a/pkg/mobile/aws.go
+++ b/pkg/mobile/aws.go
@@ -42,7 +42,7 @@ func awsGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&awsRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
@@ -54,7 +54,7 @@ func awsGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 
 	sess, err := session.NewSession(&aws.Config{Region: aws.String(awsRequest.Region), Credentials: cred})
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create new AWS session")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create new AWS session: %s", err.Error()))
 		return
 	}
 
@@ -63,7 +63,7 @@ func awsGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 	for {
 		c, err := eksClient.ListClusters(&eks.ListClustersInput{NextToken: nextToken})
 		if err != nil {
-			middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not list EKS clusters")
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not list EKS clusters: %s", err.Error()))
 			return
 		}
 
@@ -79,7 +79,7 @@ func awsGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 	for _, name := range names {
 		cluster, err := eksClient.DescribeCluster(&eks.DescribeClusterInput{Name: name})
 		if err != nil {
-			middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not cluster details")
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not cluster details: %s", err.Error()))
 			return
 		}
 
@@ -107,7 +107,7 @@ func awsGetTokenHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&awsRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
@@ -115,7 +115,7 @@ func awsGetTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	sess, err := session.NewSession(&aws.Config{Region: aws.String(awsRequest.Region), Credentials: cred})
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create new AWS session")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create new AWS session: %s", err.Error()))
 		return
 	}
 
@@ -125,7 +125,7 @@ func awsGetTokenHandler(w http.ResponseWriter, r *http.Request) {
 	request.HTTPRequest.Header.Add("x-k8s-aws-id", awsRequest.ClusterID)
 	presignedURLString, err := request.Presign(60)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create presigned URL")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create presigned URL: %s", err.Error()))
 		return
 	}
 

--- a/pkg/mobile/azure.go
+++ b/pkg/mobile/azure.go
@@ -44,7 +44,7 @@ func azureGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&azureRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
@@ -53,7 +53,7 @@ func azureGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 
 	authorizer, err := getAzureAuthorizer(azureRequest.ClientID, azureRequest.ClientSecret, azureRequest.TenantID)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not not create authorizer")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not not create authorizer: %s", err.Error()))
 		return
 	}
 	client.Authorizer = authorizer
@@ -62,7 +62,7 @@ func azureGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 
 	for list, err := client.ListComplete(ctx); list.NotDone(); err = list.Next() {
 		if err != nil {
-			middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not list clusters")
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not list clusters: %s", err.Error()))
 			return
 		}
 
@@ -72,13 +72,13 @@ func azureGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 		if azureRequest.Admin {
 			res, err = client.ListClusterAdminCredentials(ctx, azureRequest.ResourceGroupName, name)
 			if err != nil {
-				middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not list cluster credentials")
+				middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not list cluster credentials: %s", err.Error()))
 				return
 			}
 		} else {
 			res, err = client.ListClusterUserCredentials(ctx, azureRequest.ResourceGroupName, name)
 			if err != nil {
-				middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not list cluster credentials")
+				middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not list cluster credentials: %s", err.Error()))
 				return
 			}
 		}
@@ -87,7 +87,7 @@ func azureGetClustersHandler(w http.ResponseWriter, r *http.Request) {
 			var kubeconfigJSON interface{}
 			err := yaml.Unmarshal(*kubeconfig.Value, &kubeconfigJSON)
 			if err != nil {
-				middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not umarshal Kubeconfig")
+				middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not umarshal Kubeconfig: %s", err.Error()))
 				return
 			}
 

--- a/pkg/mobile/kubernetes.go
+++ b/pkg/mobile/kubernetes.go
@@ -28,19 +28,19 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	_, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create Kubernetes API client")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	result, err := api.KubernetesRequest(r.Context(), request.Method, request.URL, request.Body, clientset)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
 		return
 	}
 
@@ -66,19 +66,19 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	config, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create Kubernetes API client")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 
@@ -109,19 +109,19 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	_, clientset, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, 6*time.Hour)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not create clientset")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 
@@ -148,13 +148,13 @@ func sshHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	sessionID, err := api.GenTerminalSessionID()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not generate terminal session id")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not generate terminal session id: %s", err.Error()))
 		return
 	}
 

--- a/pkg/mobile/kubernetes.go
+++ b/pkg/mobile/kubernetes.go
@@ -40,7 +40,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := api.KubernetesRequest(r.Context(), request.Method, request.URL, request.Body, clientset)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+		var apiError api.Error
+		if err := json.Unmarshal(result, &apiError); err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", err.Error()))
+			return
+		}
+
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Kubernetes API request failed: %s", apiError.Message))
 		return
 	}
 

--- a/pkg/mobile/oidc.go
+++ b/pkg/mobile/oidc.go
@@ -48,19 +48,19 @@ func oidcGetLinkHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&oidcRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	ctx, err := oidcContext(r.Context(), oidcRequest.CertificateAuthority)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create context: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create context: %s", err.Error()))
 		return
 	}
 
 	provider, err := oidc.NewProvider(ctx, oidcRequest.DiscoveryURL)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
 		return
 	}
 
@@ -93,19 +93,19 @@ func oidcGetRefreshTokenHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&oidcRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	ctx, err := oidcContext(r.Context(), oidcRequest.CertificateAuthority)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create context: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create context: %s", err.Error()))
 		return
 	}
 
 	provider, err := oidc.NewProvider(ctx, oidcRequest.DiscoveryURL)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
 		return
 	}
 
@@ -119,13 +119,13 @@ func oidcGetRefreshTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	oauth2Token, err := oauth2Config.Exchange(ctx, oidcRequest.Code)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not get oauth token: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not get oauth token: %s", err.Error()))
 		return
 	}
 
 	idToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		middleware.Errorf(w, r, nil, http.StatusInternalServerError, "Could not get id token")
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Could not get id token")
 		return
 	}
 
@@ -154,19 +154,19 @@ func oidcGetAccessTokenHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	err := json.NewDecoder(r.Body).Decode(&oidcRequest)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, "Could not decode request body")
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
 		return
 	}
 
 	ctx, err := oidcContext(r.Context(), oidcRequest.CertificateAuthority)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create context: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create context: %s", err.Error()))
 		return
 	}
 
 	provider, err := oidc.NewProvider(ctx, oidcRequest.DiscoveryURL)
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create OIDC provider: %s", err.Error()))
 		return
 	}
 
@@ -181,7 +181,7 @@ func oidcGetAccessTokenHandler(w http.ResponseWriter, r *http.Request) {
 	ts := oauth2Config.TokenSource(ctx, &oauth2.Token{RefreshToken: oidcRequest.RefreshToken})
 	token, err := ts.Token()
 	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusInternalServerError, fmt.Sprintf("Could not get token: %s", err.Error()))
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not get token: %s", err.Error()))
 		return
 	}
 


### PR DESCRIPTION
Return status 400 (bad request) instead of 500 (internal server error) for requests were an error happend. This was changed because a request can also fail if the user hasn't enough permissions to view or edit a resource. When kubenav is running in a cluster behind an Ingress the high rate 500 can trigger an alert, so instead we are returning 400.

Now we are also returning the detailed error message for a failed request, to give the user better feedback on what was going wrong.