### PR TITLE
Fix scrolling in terminal

### DIFF
--- a/src/components/terminal/Shell.tsx
+++ b/src/components/terminal/Shell.tsx
@@ -192,7 +192,7 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
       ) : null}
 
       <div
-        style={{ width: '100%', height: showSearch || showSelect ? 'calc(100% - 56px)' : '100%' }}
+        style={{ width: '100%', height: showSearch ? 'calc(100% - 56px)' : showSelect ? 'calc(100% - 58px)' : '100%' }}
         ref={termRef}
       ></div>
     </React.Fragment>

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -145,7 +145,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
         </IonToolbar>
       </IonHeader>
 
-      <IonContent>
+      <IonContent scrollX={false} scrollY={false}>
         {terminals.map((terminal, index) => {
           return activeTerminal === `term_${index}` ? (
             <Shell key={index} showSearch={showSearch} showSelect={showSelect} terminal={terminal} />


### PR DESCRIPTION
- Remove the bouncing when a user scrolls in the terminal on iOS.
- When the range selector is visible the height of the terminal was calculated wrong. It used the same value as for the search, but the range component is 2px higher.