### PR TITLE
Add debugging configuration for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 .env.development.local
 .env.test.local
 .env.production.local
-.vscode
 
 npm-debug.log*
 yarn-debug.log*
@@ -41,3 +40,7 @@ yarn-error.log*
 
 # development server
 /bin
+
+# VS Code
+.vscode/*
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/server",
+      "env": {},
+      "args": ["-ionic=../../build"]
+    },
+    {
+      "name": "Electron",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": 0
+    },
+    {
+      "name": "Ionic",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:8100",
+      "webRoot": "${workspaceFolder}/src"
+    }
+  ]
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/kubenav/kubenav/pkg/electron"
@@ -20,6 +21,7 @@ var (
 	fs                    = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	debugFlag             = fs.Bool("debug", false, "Enable debug mode.")
 	inclusterFlag         = fs.Bool("incluster", false, "Use the in cluster configuration. Only needed for a Kubernetes based Deployment using the Docker image.")
+	ionicFlag             = fs.String("ionic", "build", "Path to the Ionic app.")
 	kubeconfigFlag        = fs.String("kubeconfig", "", "Optional Kubeconfig file.")
 	kubeconfigIncludeFlag = fs.String("kubeconfig-include", "", "Comma separated list of globs to include in the Kubeconfig.")
 	kubeconfigExcludeFlag = fs.String("kubeconfig-exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '-kubeconfig-include' flag.")
@@ -52,12 +54,12 @@ func main() {
 	router := http.NewServeMux()
 	electron.Register(router, *syncFlag, client)
 
-	index, err := ioutil.ReadFile("build/index.html")
+	index, err := ioutil.ReadFile(path.Join(*ionicFlag, "index.html"))
 	if err != nil {
 		log.WithError(err).Fatalf("Could not load index.html file")
 	}
 
-	staticHandler := http.StripPrefix("/", http.FileServer(http.Dir("build")))
+	staticHandler := http.StripPrefix("/", http.FileServer(http.Dir(*ionicFlag)))
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, ".") {
 			staticHandler.ServeHTTP(w, r)


### PR DESCRIPTION
Add debugging configuration for VS Code. The following options are supported:

- `Server`: Debug the kubenav server at `cmd/server`
- `Electron`: Debug the Electron app. To use this option you have to start the Electron app and replace the `"processId": 0` in the `.vscode/launch.json` with the current PID of kubenav.
  - Start the Electron app: `./cmd/electron/output/darwin-amd64/kubenav.app/Contents/MacOS/kubenav -debug`
  - Get the PID: `ps -ef | grep "kubenav -debug"`
- `Ionic`: Debug the Ionic app which was started with `ionic serve`