### PR TITLE
Open links from Electron in external browser

### DIFF
--- a/src/components/settings/InfoPage.tsx
+++ b/src/components/settings/InfoPage.tsx
@@ -16,6 +16,7 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
+  isPlatform,
 } from '@ionic/react';
 import { useGetInfo } from '@ionic/react-hooks/device';
 import React, { memo, useEffect, useState } from 'react';
@@ -32,6 +33,15 @@ const InfoPage: React.FunctionComponent = () => {
       setVersion(info.appVersion);
     }
   }, [info]);
+
+  const openLink = (url: string) => {
+    if (isPlatform('electron')) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      window.require('electron').shell.openExternal(url);
+    } else {
+      window.open(url, '_system', 'location=yes');
+    }
+  };
 
   return (
     <IonPage>
@@ -79,19 +89,19 @@ const InfoPage: React.FunctionComponent = () => {
               <IonListHeader mode="md">
                 <IonLabel>Links</IonLabel>
               </IonListHeader>
-              <IonItem href="https://kubenav.io" target="_blank" rel="noopener noreferrer">
+              <IonItem onClick={() => openLink('https://kubenav.io')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="Website" src="/assets/icons/misc/browser.png" />
                 </IonAvatar>
                 <IonLabel>Website</IonLabel>
               </IonItem>
-              <IonItem href="https://github.com/kubenav/kubenav" target="_blank" rel="noopener noreferrer">
+              <IonItem onClick={() => openLink('https://github.com/kubenav/kubenav')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="GitHub" src="/assets/icons/misc/github.png" />
                 </IonAvatar>
                 <IonLabel>GitHub</IonLabel>
               </IonItem>
-              <IonItem href="https://twitter.com/kubenav" target="_blank" rel="noopener noreferrer">
+              <IonItem onClick={() => openLink('https://twitter.com/kubenav')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="Twitter" src="/assets/icons/misc/twitter.png" />
                 </IonAvatar>


### PR DESCRIPTION
Open links in the kubenav Electron app in an external browser instead of an new Electron window.

Fixes #141.