### PR TITLE
Add re-authentication support for OIDC and Google

### DIFF
--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -30,7 +30,9 @@ import {
   IContext,
   TAuthProvider,
 } from '../../../declarations';
+import { getOIDCLink } from '../../../utils/api';
 import { AppContext } from '../../../utils/context';
+import { saveTemporaryCredentials } from '../../../utils/storage';
 
 interface IEditClusterProps {
   cluster: ICluster;
@@ -145,6 +147,30 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IE
           }
         : undefined,
     );
+  };
+
+  const reAuthenticateOIDC = async () => {
+    if (authProviderOIDC) {
+      saveTemporaryCredentials({
+        clientID: authProviderOIDC.clientID,
+        clientSecret: authProviderOIDC.clientSecret,
+        idpIssuerURL: authProviderOIDC.idpIssuerURL,
+        refreshToken: authProviderOIDC.refreshToken,
+        certificateAuthority: authProviderOIDC.certificateAuthority,
+        idToken: '',
+        accessToken: '',
+        expiry: 0,
+        clusterID: cluster.id,
+      });
+
+      const url = await getOIDCLink(
+        authProviderOIDC.idpIssuerURL,
+        authProviderOIDC.clientID,
+        authProviderOIDC.clientSecret,
+        authProviderOIDC.certificateAuthority,
+      );
+      window.location.replace(url);
+    }
   };
 
   const editCluster = () => {
@@ -418,6 +444,10 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IE
                   <IonLabel position="stacked">Refresh Token (optional)</IonLabel>
                   <IonTextarea autoGrow={true} value={authProviderOIDC.refreshToken} onInput={handleAuthProviderOIDC} />
                 </IonItem>
+
+                <IonButton expand="block" onClick={() => reAuthenticateOIDC()}>
+                  Re-Authenticate
+                </IonButton>
               </IonItemGroup>
             ) : null}
           </IonList>

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -31,6 +31,12 @@ import {
   TAuthProvider,
 } from '../../../declarations';
 import { getOIDCLink } from '../../../utils/api';
+import {
+  GOOGLE_OAUTH2_ENDPOINT,
+  GOOGLE_REDIRECT_URI,
+  GOOGLE_RESPONSE_TYPE,
+  GOOGLE_SCOPE,
+} from '../../../utils/constants';
 import { AppContext } from '../../../utils/context';
 import { saveTemporaryCredentials } from '../../../utils/storage';
 
@@ -170,6 +176,24 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IE
         authProviderOIDC.certificateAuthority,
       );
       window.location.replace(url);
+    }
+  };
+
+  const reAuthenticateGoogle = async () => {
+    if (authProviderGoogle) {
+      saveTemporaryCredentials({
+        accessToken: '',
+        clientID: authProviderGoogle.clientID,
+        expiresIn: '',
+        idToken: '',
+        refreshToken: '',
+        tokenType: '',
+        clusterID: cluster.id,
+      });
+
+      window.location.replace(
+        `${GOOGLE_OAUTH2_ENDPOINT}?client_id=${authProviderGoogle.clientID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=${GOOGLE_RESPONSE_TYPE}&scope=${GOOGLE_SCOPE}`,
+      );
     }
   };
 
@@ -394,6 +418,9 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IE
                     onInput={handleAuthProviderGoogle}
                   />
                 </IonItem>
+                <IonButton expand="block" onClick={() => reAuthenticateGoogle()}>
+                  Re-Authenticate
+                </IonButton>
               </IonItemGroup>
             ) : null}
             {authProvider === 'oidc' && authProviderOIDC ? (

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -112,6 +112,7 @@ export interface IClusterAuthProviderGoogle {
   idToken: string;
   refreshToken: string;
   tokenType: string;
+  clusterID?: string;
 }
 
 export interface IClusterAuthProviderOIDC {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -123,6 +123,7 @@ export interface IClusterAuthProviderOIDC {
   certificateAuthority: string;
   accessToken: string;
   expiry: number;
+  clusterID?: string;
 }
 
 export interface IClusters {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -211,6 +211,9 @@ export const getGoogleAccessToken = async (
   if (response.status >= 200 && response.status < 300) {
     credentials.accessToken = json.access_token;
     credentials.expiresIn = json.expires_in;
+    credentials.idToken = json.id_token;
+    credentials.refreshToken = json.refresh_token;
+    credentials.tokenType = json.token_type;
 
     return credentials;
   }

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -254,6 +254,7 @@ export const AppContextProvider: React.FunctionComponent<IAppContextProvider> = 
         if (credentials) {
           credentials = await getGoogleAccessToken(credentials);
           clusters[clusterID].token = credentials.accessToken;
+          clusters[clusterID].authProviderGoogle = credentials;
         } else {
           throw new Error('AWS credentials are missing');
         }


### PR DESCRIPTION
- Add re-authentication support for Google. When the refresh token for Google is expired, it is now possible to retrieve a new token from the edit cluster page
- Add re-authentication support for OIDC. When the refresh token for OIDC is expired, it is now possible to retrieve a new token from the edit cluster page:
![oidc-re-authenticate-flow](https://user-images.githubusercontent.com/18552168/90337316-fccab480-dfe1-11ea-9289-64354521d4f5.png)

Fixes #136.