### PR TITLE
Refresh lists when details page is refreshed

### DIFF
--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
@@ -144,6 +144,7 @@ const CustomResourcesDetailsPage: React.FunctionComponent<ICustomResourcesDetail
                   section="cluster"
                   type="events"
                   namespace={state.value.metadata.namespace}
+                  parent={state.value}
                   selector={`fieldSelector=involvedObject.name=${state.value.metadata.name}`}
                 />
               </IonRow>

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -219,6 +219,7 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
             section="workloads"
             type="pods"
             namespace=""
+            parent={item}
             selector={`fieldSelector=spec.nodeName=${item.metadata.name}`}
           />
         </IonRow>
@@ -231,6 +232,7 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
             section="cluster"
             type="events"
             namespace=""
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/configAndStorage/configMaps/ConfigMapDetails.tsx
+++ b/src/components/resources/configAndStorage/configMaps/ConfigMapDetails.tsx
@@ -28,6 +28,7 @@ const ConfigMapDetailsDetails: React.FunctionComponent<IConfigMapDetailsDetailsP
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimDetails.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimDetails.tsx
@@ -72,6 +72,7 @@ const PersistentVolumeClaimDetails: React.FunctionComponent<IPersistentVolumeCla
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeDetails.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeDetails.tsx
@@ -61,6 +61,7 @@ const PersistentVolumeDetails: React.FunctionComponent<IPersistentVolumeDetailsP
             section="cluster"
             type="events"
             namespace=""
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/configAndStorage/podDisruptionBudgets/PodDisruptionBudgetDetails.tsx
+++ b/src/components/resources/configAndStorage/podDisruptionBudgets/PodDisruptionBudgetDetails.tsx
@@ -78,6 +78,7 @@ const PodDisruptionBudgetDetails: React.FunctionComponent<IPodDisruptionBudgetDe
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -90,6 +91,7 @@ const PodDisruptionBudgetDetails: React.FunctionComponent<IPodDisruptionBudgetDe
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
+++ b/src/components/resources/configAndStorage/serviceAccounts/ServiceAccountDetails.tsx
@@ -32,6 +32,7 @@ const ServiceAccountDetails: React.FunctionComponent<IServiceAccountDetailsProps
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/discoveryAndLoadbalancing/horizontalpodautoscalers/HorizontalPodAutoscalerDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/horizontalpodautoscalers/HorizontalPodAutoscalerDetails.tsx
@@ -226,6 +226,7 @@ const HorizontalPodAutoscalerDetails: React.FunctionComponent<IHorizontalPodAuto
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/discoveryAndLoadbalancing/ingresses/IngressDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/ingresses/IngressDetails.tsx
@@ -113,6 +113,7 @@ const IngressDetails: React.FunctionComponent<IIngressDetailsProps> = ({ item, t
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
@@ -115,6 +115,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${matchLabels(item.spec.selector)}`}
           />
         </IonRow>
@@ -127,6 +128,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/misc/List.tsx
+++ b/src/components/resources/misc/List.tsx
@@ -12,6 +12,8 @@ interface IListProps {
   section: string;
   type: string;
   namespace: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parent: any;
   selector?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filter?: (item: any) => boolean;
@@ -22,6 +24,7 @@ const List: React.FunctionComponent<IListProps> = ({
   section,
   type,
   namespace,
+  parent,
   selector,
   filter,
 }: IListProps) => {
@@ -30,7 +33,7 @@ const List: React.FunctionComponent<IListProps> = ({
   const page = resources[section].pages[type];
   const Component = page.listItemComponent;
 
-  const [state, , fetchInit] = useAsyncFn(
+  const [state, fetch, fetchInit] = useAsyncFn(
     async () =>
       await kubernetesRequest(
         'GET',
@@ -46,6 +49,10 @@ const List: React.FunctionComponent<IListProps> = ({
   useEffect(() => {
     fetchInit();
   }, [fetchInit]);
+
+  useEffect(() => {
+    fetch();
+  }, [parent, fetch]);
 
   if (state.value && state.value.items && state.value.items.filter(filter ? filter : () => true).length > 0) {
     return (

--- a/src/components/resources/rbac/clusterRoleBindings/ClusterRoleBindingDetails.tsx
+++ b/src/components/resources/rbac/clusterRoleBindings/ClusterRoleBindingDetails.tsx
@@ -75,6 +75,7 @@ const ClusterRoleBindingDetails: React.FunctionComponent<IClusterRoleBindingDeta
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/rbac/clusterRoles/ClusterRoleDetails.tsx
+++ b/src/components/resources/rbac/clusterRoles/ClusterRoleDetails.tsx
@@ -43,6 +43,7 @@ const ClusterRoleDetails: React.FunctionComponent<IClusterRoleDetailsProps> = ({
             section="cluster"
             type="events"
             namespace=""
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/rbac/roleBindings/RoleBindingDetails.tsx
+++ b/src/components/resources/rbac/roleBindings/RoleBindingDetails.tsx
@@ -75,6 +75,7 @@ const RoleBindingDetails: React.FunctionComponent<IRoleBindingDetailsProps> = ({
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/rbac/roles/RoleDetails.tsx
+++ b/src/components/resources/rbac/roles/RoleDetails.tsx
@@ -40,6 +40,7 @@ const RoleDetails: React.FunctionComponent<IRoleDetailsProps> = ({ item, type }:
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/cronJobs/CronJobDetails.tsx
+++ b/src/components/resources/workloads/cronJobs/CronJobDetails.tsx
@@ -44,6 +44,7 @@ const CronJobDetails: React.FunctionComponent<ICronJobDetailsProps> = ({ item, t
             section="workloads"
             type="jobs"
             namespace={item.metadata.namespace}
+            parent={item}
             filter={(job: V1Job) =>
               job.metadata && job.metadata.ownerReferences && job.metadata.ownerReferences.length === 1
                 ? job.metadata.ownerReferences[0].name ===
@@ -61,6 +62,7 @@ const CronJobDetails: React.FunctionComponent<ICronJobDetailsProps> = ({ item, t
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/daemonSets/DaemonSetDetails.tsx
+++ b/src/components/resources/workloads/daemonSets/DaemonSetDetails.tsx
@@ -87,6 +87,7 @@ const DaemonSetDetails: React.FunctionComponent<IDaemonSetDetailsProps> = ({ ite
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -99,6 +100,7 @@ const DaemonSetDetails: React.FunctionComponent<IDaemonSetDetailsProps> = ({ ite
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/deployments/DeploymentDetails.tsx
+++ b/src/components/resources/workloads/deployments/DeploymentDetails.tsx
@@ -82,6 +82,7 @@ const DeploymentDetails: React.FunctionComponent<IDeploymentDetailsProps> = ({
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -94,6 +95,7 @@ const DeploymentDetails: React.FunctionComponent<IDeploymentDetailsProps> = ({
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/jobs/JobDetails.tsx
+++ b/src/components/resources/workloads/jobs/JobDetails.tsx
@@ -64,6 +64,7 @@ const JobDetails: React.FunctionComponent<IJobDetailsProps> = ({ item, type }: I
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -76,6 +77,7 @@ const JobDetails: React.FunctionComponent<IJobDetailsProps> = ({ item, type }: I
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -138,6 +138,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/replicaSets/ReplicaSetDetails.tsx
+++ b/src/components/resources/workloads/replicaSets/ReplicaSetDetails.tsx
@@ -70,6 +70,7 @@ const ReplicaSetDetails: React.FunctionComponent<IReplicaSetDetailsProps> = ({
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -82,6 +83,7 @@ const ReplicaSetDetails: React.FunctionComponent<IReplicaSetDetailsProps> = ({
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/replicationControllers/ReplicationControllerDetails.tsx
+++ b/src/components/resources/workloads/replicationControllers/ReplicationControllerDetails.tsx
@@ -70,6 +70,7 @@ const ReplicationControllerDetails: React.FunctionComponent<IReplicationControll
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -82,6 +83,7 @@ const ReplicationControllerDetails: React.FunctionComponent<IReplicationControll
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>

--- a/src/components/resources/workloads/statefulSets/StatefulSetDetails.tsx
+++ b/src/components/resources/workloads/statefulSets/StatefulSetDetails.tsx
@@ -83,6 +83,7 @@ const StatefulSetDetails: React.FunctionComponent<IStatefulSetDetailsProps> = ({
             section="workloads"
             type="pods"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`labelSelector=${labelSelector(item.spec.selector)}`}
           />
         </IonRow>
@@ -95,6 +96,7 @@ const StatefulSetDetails: React.FunctionComponent<IStatefulSetDetailsProps> = ({
             section="cluster"
             type="events"
             namespace={item.metadata.namespace}
+            parent={item}
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>


### PR DESCRIPTION
Currently the lists in a details page aren't refreshed by a click on the refresh button. For example when a user view a deployment and the number of replicas is scaled up the new pod isn't shown in the list of pods after a refresh of the details page.

This is now fixed, by passing the parent element to the list view. If the parent element changes (e.g. the deployment) then the list is also refreshed.

Fixes #148.