### PR TITLE
Fix namespace switching bug for Electron

### DIFF
--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -13,7 +13,7 @@ import {
   IonToolbar,
   isPlatform,
 } from '@ionic/react';
-import React, { memo, useContext } from 'react';
+import React, { memo, useContext, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { IAppSections, IContext } from '../../declarations';
@@ -38,8 +38,11 @@ interface IMenuProps extends RouteComponentProps {
 
 const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location }: IMenuProps) => {
   const context = useContext<IContext>(AppContext);
+  const [eventSourceInitialized, setEventSourceInitialized] = useState<boolean>(false);
 
-  if (isPlatform('electron')) {
+  if (isPlatform('electron') && !eventSourceInitialized) {
+    setEventSourceInitialized(true);
+
     const eventSource = new EventSource(`${SERVER}/api/electron`);
 
     eventSource.addEventListener('navigation', async (event) => {


### PR DESCRIPTION
It could happen that the Electron app stopped working, when a user switched fast between different namespaces. This bug was caused by the event listener in the Menu component, which handles the navigation from the Electron menu.

When the namespace was switched a new listener was initialized, which results in to many pending requests.

Fixes #143.