### PR TITLE
Add Support for Port-Forwarding

### DIFF
--- a/pkg/api/portforwarding.go
+++ b/pkg/api/portforwarding.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// PortForwardRequest is the structure of a request to initalize the port forwarding.
+type PortForwardRequest struct {
+	Request
+	PodPort   int64 `json:"podPort"`
+	LocalPort int64 `json:"localPort"`
+}
+
+// PortForwardResponse is the structure of an initialized port forwarding request. It contains the session id which can
+// be used to close the opened port and the port number.
+type PortForwardResponse struct {
+	ID        string `json:"id"`
+	PodPort   int64  `json:"podPort"`
+	LocalPort int64  `json:"localPort"`
+}
+
+// PortForwardSessions holds all open port forwarding sessions.
+var PortForwardSessions = make(map[string]*PortForward)
+
+// PortForward ...
+type PortForward struct {
+	ID        string
+	PodPort   int64
+	LocalPort int64
+
+	forwarder *portforward.PortForwarder
+	readyChan chan struct{}
+	stopChan  chan struct{}
+	out       *bytes.Buffer
+	errOut    *bytes.Buffer
+}
+
+// NewPortForwarding returns a new PortForward struct with all details needed to start the port forwarding. It also adds
+// it to the map of port forwarding sessions.
+// When the local port is 0 a random port is picked.
+func NewPortForwarding(config *rest.Config, podURL string, podPort, localPort int64) (*PortForward, error) {
+	if localPort == 0 {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		localPort, err = strconv.ParseInt(strings.TrimLeft(listener.Addr().String(), "127.0.0.1:"), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(podURL)
+	if err != nil {
+		return nil, err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, serverURL)
+
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, podPort)}, stopChan, readyChan, out, errOut)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID, err := GenTerminalSessionID()
+	if err != nil {
+		return nil, err
+	}
+
+	pf := &PortForward{
+		ID:        sessionID,
+		PodPort:   podPort,
+		LocalPort: localPort,
+
+		forwarder: forwarder,
+		readyChan: readyChan,
+		stopChan:  stopChan,
+		errOut:    errOut,
+		out:       out,
+	}
+
+	PortForwardSessions[sessionID] = pf
+
+	return pf, nil
+}
+
+// Start starts the port forwarding.
+func (pf *PortForward) Start() {
+	go func() {
+		for range pf.readyChan {
+			if len(pf.errOut.String()) != 0 {
+				fmt.Println(pf.errOut.String())
+				pf.Stop()
+				return
+			} else if len(pf.out.String()) != 0 {
+				fmt.Println(pf.out.String())
+			}
+		}
+	}()
+
+	if err := pf.forwarder.ForwardPorts(); err != nil {
+		delete(PortForwardSessions, pf.ID)
+		return
+	}
+}
+
+// Stop stops the port forwarding.
+func (pf *PortForward) Stop() {
+	pf.stopChan <- struct{}{}
+	delete(PortForwardSessions, pf.ID)
+}

--- a/pkg/api/portforwarding.go
+++ b/pkg/api/portforwarding.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubenav/kubenav/pkg/api/middleware"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -32,7 +34,7 @@ type PortForwardResponse struct {
 // PortForwardSessions holds all open port forwarding sessions.
 var PortForwardSessions = make(map[string]*PortForward)
 
-// PortForward ...
+// PortForward is the structure with all needed data for a port forwarding.
 type PortForward struct {
 	ID        string
 	PodPort   int64
@@ -43,6 +45,12 @@ type PortForward struct {
 	stopChan  chan struct{}
 	out       *bytes.Buffer
 	errOut    *bytes.Buffer
+}
+
+// ActivePortForwardingSessions returns all active port forwarding sessions.
+func ActivePortForwardingSessions(w http.ResponseWriter, r *http.Request) {
+	middleware.Write(w, r, PortForwardSessions)
+	return
 }
 
 // NewPortForwarding returns a new PortForward struct with all details needed to start the port forwarding. It also adds

--- a/pkg/api/portforwarding.go
+++ b/pkg/api/portforwarding.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubenav/kubenav/pkg/api/middleware"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -45,12 +43,6 @@ type PortForward struct {
 	stopChan  chan struct{}
 	out       *bytes.Buffer
 	errOut    *bytes.Buffer
-}
-
-// ActivePortForwardingSessions returns all active port forwarding sessions.
-func ActivePortForwardingSessions(w http.ResponseWriter, r *http.Request) {
-	middleware.Write(w, r, PortForwardSessions)
-	return
 }
 
 // NewPortForwarding returns a new PortForward struct with all details needed to start the port forwarding. It also adds

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -31,6 +31,8 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
+	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
+	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -32,8 +32,6 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
-	router.HandleFunc("/api/kubernetes/portforwarding/sessions", middleware.Cors(api.ActivePortForwardingSessions))
-	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/electron/electron.go
+++ b/pkg/electron/electron.go
@@ -32,6 +32,7 @@ func Register(router *http.ServeMux, sync bool, kubeClient *kube.Client) {
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
+	router.HandleFunc("/api/kubernetes/portforwarding/sessions", middleware.Cors(api.ActivePortForwardingSessions))
 	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 }
 

--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -174,3 +174,64 @@ func sshHandler(w http.ResponseWriter, r *http.Request) {
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})
 	return
 }
+
+// portForwardingHandler handles the requests to initialize the port forwarding to a pod.
+func portForwardingHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.PortForwardRequest
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+		return
+	}
+
+	config, _, err := client.ConfigClientset(request.Cluster, time.Duration(request.Timeout)*time.Second, request.Proxy)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
+		return
+	}
+
+	pf, err := api.NewPortForwarding(config, request.URL, request.PodPort, request.LocalPort)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not initialize port forwarding: %s", err.Error()))
+		return
+	}
+	go pf.Start()
+
+	middleware.Write(w, r, api.PortForwardResponse{ID: pf.ID, PodPort: pf.PodPort, LocalPort: pf.LocalPort})
+	return
+}
+
+// portForwardingStopHandler handles the requests to initialize the port forwarding to a pod.
+func portForwardingStopHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var request api.PortForwardResponse
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+		return
+	}
+
+	if _, ok := api.PortForwardSessions[request.ID]; ok {
+		api.PortForwardSessions[request.ID].Stop()
+	}
+
+	middleware.Write(w, r, nil)
+	return
+}

--- a/pkg/mobile/kubernetes.go
+++ b/pkg/mobile/kubernetes.go
@@ -176,61 +176,63 @@ func sshHandler(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-// portForwardingHandler handles the requests to initialize the port forwarding to a pod.
+// portForwardingHandler handles all requests related to port forwarding.
+//   - GET: Return all active port forwarding sessions
+//   - POST: Initialize a new port forwarding session
+//   - DELETE: Delete a port forwarding session
 func portForwardingHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	if r.Method == http.MethodGet {
+		middleware.Write(w, r, api.PortForwardSessions)
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		var request api.PortForwardRequest
+		if r.Body == nil {
+			middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+			return
+		}
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+			return
+		}
+
+		config, _, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second, request.Proxy)
+		if err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
+			return
+		}
+
+		pf, err := api.NewPortForwarding(config, request.URL, request.PodPort, request.LocalPort)
+		if err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not initialize port forwarding: %s", err.Error()))
+			return
+		}
+		go pf.Start()
+
+		middleware.Write(w, r, api.PortForwardResponse{ID: pf.ID, PodPort: pf.PodPort, LocalPort: pf.LocalPort})
+		return
+	}
+
+	if r.Method == http.MethodDelete {
+		var request api.PortForwardResponse
+		if r.Body == nil {
+			middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+			return
+		}
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+			return
+		}
+
+		if _, ok := api.PortForwardSessions[request.ID]; ok {
+			api.PortForwardSessions[request.ID].Stop()
+		}
+
 		middleware.Write(w, r, nil)
 		return
-	}
-
-	var request api.PortForwardRequest
-	if r.Body == nil {
-		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
-		return
-	}
-	err := json.NewDecoder(r.Body).Decode(&request)
-	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
-		return
-	}
-
-	config, _, err := kube.ConfigClientset(request.URL, request.CertificateAuthorityData, request.ClientCertificateData, request.ClientKeyData, request.Token, request.Username, request.Password, request.InsecureSkipTLSVerify, time.Duration(request.Timeout)*time.Second, request.Proxy)
-	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create Kubernetes API client: %s", err.Error()))
-		return
-	}
-
-	pf, err := api.NewPortForwarding(config, request.URL, request.PodPort, request.LocalPort)
-	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not initialize port forwarding: %s", err.Error()))
-		return
-	}
-	go pf.Start()
-
-	middleware.Write(w, r, api.PortForwardResponse{ID: pf.ID, PodPort: pf.PodPort, LocalPort: pf.LocalPort})
-	return
-}
-
-// portForwardingStopHandler handles the requests to initialize the port forwarding to a pod.
-func portForwardingStopHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		middleware.Write(w, r, nil)
-		return
-	}
-
-	var request api.PortForwardResponse
-	if r.Body == nil {
-		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
-		return
-	}
-	err := json.NewDecoder(r.Body).Decode(&request)
-	if err != nil {
-		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
-		return
-	}
-
-	if _, ok := api.PortForwardSessions[request.ID]; ok {
-		api.PortForwardSessions[request.ID].Stop()
 	}
 
 	middleware.Write(w, r, nil)

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -26,8 +26,6 @@ func StartServer() {
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
-	router.HandleFunc("/api/kubernetes/portforwarding/sessions", middleware.Cors(api.ActivePortForwardingSessions))
-	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 
 	router.HandleFunc("/api/oidc/link", middleware.Cors(oidcGetLinkHandler))
 	router.HandleFunc("/api/oidc/refreshtoken", middleware.Cors(oidcGetRefreshTokenHandler))

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -26,6 +26,7 @@ func StartServer() {
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
 	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
+	router.HandleFunc("/api/kubernetes/portforwarding/sessions", middleware.Cors(api.ActivePortForwardingSessions))
 	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 
 	router.HandleFunc("/api/oidc/link", middleware.Cors(oidcGetLinkHandler))

--- a/pkg/mobile/mobile.go
+++ b/pkg/mobile/mobile.go
@@ -25,6 +25,8 @@ func StartServer() {
 	router.HandleFunc("/api/kubernetes/logs/", middleware.Cors(api.StreamLogsHandler))
 	router.HandleFunc("/api/kubernetes/ssh", middleware.Cors(sshHandler))
 	router.Handle("/api/kubernetes/ssh/sockjs/", api.CreateSSHHandler("/api/kubernetes/ssh/sockjs"))
+	router.HandleFunc("/api/kubernetes/portforwarding", middleware.Cors(portForwardingHandler))
+	router.HandleFunc("/api/kubernetes/portforwarding/stop", middleware.Cors(portForwardingStopHandler))
 
 	router.HandleFunc("/api/oidc/link", middleware.Cors(oidcGetLinkHandler))
 	router.HandleFunc("/api/oidc/refreshtoken", middleware.Cors(oidcGetRefreshTokenHandler))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import ClustersPage from './components/settings/ClustersPage';
 import GeneralPage from './components/settings/GeneralPage';
 import InfoPage from './components/settings/InfoPage';
 import { AppContextProvider } from './utils/context';
+import { PortForwardingContextProvider } from './utils/portforwarding';
 import { resources } from './utils/resources';
 import { TerminalContextProvider } from './utils/terminal';
 
@@ -42,32 +43,34 @@ const App: React.FunctionComponent = () => (
   <IonApp>
     <AppContextProvider>
       <TerminalContextProvider>
-        <IonReactRouter>
-          <IonSplitPane contentId="main" className={isPlatform('hybrid') ? '' : 'menu-width'}>
-            <Menu sections={resources} />
-            <IonRouterOutlet id="main">
-              <Route path="/" component={HomePage} exact={true} />
-              <Route path="/resources/:section/:type" component={ListPage} exact={true} />
-              <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />
-              <Route path="/customresources/:group/:version/:name" component={CustomResourcesListPage} exact={true} />
-              <Route
-                path="/customresources/:group/:version/:name/:crnamespace/:crname"
-                component={CustomResourcesDetailsPage}
-                exact={true}
-              />
-              <Route path="/settings/clusters" component={ClustersPage} exact={true} />
-              <Route path="/settings/clusters/aws" component={ClustersAWSPage} exact={true} />
-              <Route path="/settings/clusters/azure" component={ClustersAzurePage} exact={true} />
-              <Route path="/settings/clusters/google" component={ClustersGooglePage} exact={true} />
-              <Route path="/settings/clusters/kubeconfig" component={ClustersKubeconfigPage} exact={true} />
-              <Route path="/settings/clusters/manual" component={ClustersManualPage} exact={true} />
-              <Route path="/settings/clusters/oidc" component={ClustersOIDCPage} exact={true} />
-              <Route path="/settings/clusters/oidc/redirect" component={ClustersOIDCRedirectPage} exact={true} />
-              <Route path="/settings/general" component={GeneralPage} exact={true} />
-              <Route path="/settings/info" component={InfoPage} exact={true} />
-            </IonRouterOutlet>
-          </IonSplitPane>
-        </IonReactRouter>
+        <PortForwardingContextProvider>
+          <IonReactRouter>
+            <IonSplitPane contentId="main" className={isPlatform('hybrid') ? '' : 'menu-width'}>
+              <Menu sections={resources} />
+              <IonRouterOutlet id="main">
+                <Route path="/" component={HomePage} exact={true} />
+                <Route path="/resources/:section/:type" component={ListPage} exact={true} />
+                <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />
+                <Route path="/customresources/:group/:version/:name" component={CustomResourcesListPage} exact={true} />
+                <Route
+                  path="/customresources/:group/:version/:name/:crnamespace/:crname"
+                  component={CustomResourcesDetailsPage}
+                  exact={true}
+                />
+                <Route path="/settings/clusters" component={ClustersPage} exact={true} />
+                <Route path="/settings/clusters/aws" component={ClustersAWSPage} exact={true} />
+                <Route path="/settings/clusters/azure" component={ClustersAzurePage} exact={true} />
+                <Route path="/settings/clusters/google" component={ClustersGooglePage} exact={true} />
+                <Route path="/settings/clusters/kubeconfig" component={ClustersKubeconfigPage} exact={true} />
+                <Route path="/settings/clusters/manual" component={ClustersManualPage} exact={true} />
+                <Route path="/settings/clusters/oidc" component={ClustersOIDCPage} exact={true} />
+                <Route path="/settings/clusters/oidc/redirect" component={ClustersOIDCRedirectPage} exact={true} />
+                <Route path="/settings/general" component={GeneralPage} exact={true} />
+                <Route path="/settings/info" component={InfoPage} exact={true} />
+              </IonRouterOutlet>
+            </IonSplitPane>
+          </IonReactRouter>
+        </PortForwardingContextProvider>
       </TerminalContextProvider>
     </AppContextProvider>
   </IonApp>

--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
@@ -48,6 +48,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
                 return (
                   <Port
                     key={index}
+                    enabled={port.protocol === undefined || port.protocol === 'TCP'}
                     name=""
                     namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
                     selector={

--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { matchLabels } from '../../../../utils/helpers';
 import List from '../../misc/List';
+import Port from '../../misc/Port';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
 import Row from '../../misc/template/Row';
@@ -43,9 +44,21 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
             objKey="spec.ports"
             title="Ports"
             value={(ports) =>
-              ports.map((port: V1ServicePort, index) => {
+              ports.map((port: V1ServicePort, index: number) => {
                 return (
-                  <IonChip key={index} className="unset-chip-height">
+                  <Port
+                    key={index}
+                    name=""
+                    namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
+                    selector={
+                      item.spec && item.spec.selector
+                        ? Object.keys(item.spec.selector)
+                            .map((key) => `${key}=${item.spec && item.spec.selector ? item.spec.selector[key] : ''}`)
+                            .join(',')
+                        : ''
+                    }
+                    port={port.port}
+                  >
                     <IonLabel>
                       {port.name ? `${port.name} ` : ''}
                       {port.port}
@@ -53,7 +66,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
                       {port.protocol ? `/${port.protocol}` : ''}
                       {port.targetPort ? ` > ${port.targetPort}` : ''}
                     </IonLabel>
-                  </IonChip>
+                  </Port>
                 );
               })
             }

--- a/src/components/resources/misc/Port.tsx
+++ b/src/components/resources/misc/Port.tsx
@@ -1,0 +1,84 @@
+import { IonAlert, IonChip } from '@ionic/react';
+import { V1PodList } from '@kubernetes/client-node';
+import React, { useContext, useState, ReactElement } from 'react';
+
+import { IContext, IPortForwardingContext } from '../../../declarations';
+import { kubernetesRequest } from '../../../utils/api';
+import { AppContext } from '../../../utils/context';
+import { PortForwardingContext } from '../../../utils/portforwarding';
+
+interface IPortProps {
+  name: string;
+  namespace: string;
+  selector: string;
+  port: number;
+  children: ReactElement;
+}
+
+const Port: React.FunctionComponent<IPortProps> = ({ name, namespace, selector, port, children }: IPortProps) => {
+  const context = useContext<IContext>(AppContext);
+  const portForwardingContext = useContext<IPortForwardingContext>(PortForwardingContext);
+  const [showPortLocalInput, setShowPortLocalInput] = useState<boolean>(false);
+
+  const portForward = async (localPort: number) => {
+    try {
+      if (name === '') {
+        const podList: V1PodList = await kubernetesRequest(
+          'GET',
+          `/api/v1/namespaces/${namespace}/pods?labelSelector=${selector}`,
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        if (podList.items.length > 0 && podList.items[0].metadata) {
+          await portForwardingContext.add({
+            id: '',
+            podName: podList.items[0].metadata.name ? podList.items[0].metadata.name : '',
+            podNamespace: namespace,
+            podPort: port,
+            localPort: localPort,
+          });
+        }
+      } else {
+        await portForwardingContext.add({
+          id: '',
+          podName: name,
+          podNamespace: namespace,
+          podPort: port,
+          localPort: localPort,
+        });
+      }
+    } catch (err) {
+      // Do nothing.
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <IonAlert
+        isOpen={showPortLocalInput}
+        onDidDismiss={() => setShowPortLocalInput(false)}
+        header="Port"
+        message="Enter the local port number"
+        inputs={[
+          {
+            name: 'localPort',
+            type: 'number',
+            value: 0,
+          },
+        ]}
+        buttons={[
+          { text: 'Cancel', role: 'cancel', handler: () => setShowPortLocalInput(false) },
+          { text: 'Start', handler: (data) => portForward(parseInt(data.localPort)) },
+        ]}
+      />
+
+      <IonChip className="unset-chip-height" onClick={() => setShowPortLocalInput(true)}>
+        {children}
+      </IonChip>
+    </React.Fragment>
+  );
+};
+
+export default Port;

--- a/src/components/resources/misc/Port.tsx
+++ b/src/components/resources/misc/Port.tsx
@@ -1,4 +1,4 @@
-import { IonAlert, IonChip } from '@ionic/react';
+import { IonAlert, IonChip, IonToast } from '@ionic/react';
 import { V1PodList } from '@kubernetes/client-node';
 import React, { useContext, useState, ReactElement } from 'react';
 
@@ -8,6 +8,7 @@ import { AppContext } from '../../../utils/context';
 import { PortForwardingContext } from '../../../utils/portforwarding';
 
 interface IPortProps {
+  enabled: boolean;
   name: string;
   namespace: string;
   selector: string;
@@ -15,10 +16,18 @@ interface IPortProps {
   children: ReactElement;
 }
 
-const Port: React.FunctionComponent<IPortProps> = ({ name, namespace, selector, port, children }: IPortProps) => {
+const Port: React.FunctionComponent<IPortProps> = ({
+  enabled,
+  name,
+  namespace,
+  selector,
+  port,
+  children,
+}: IPortProps) => {
   const context = useContext<IContext>(AppContext);
   const portForwardingContext = useContext<IPortForwardingContext>(PortForwardingContext);
   const [showPortLocalInput, setShowPortLocalInput] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
 
   const portForward = async (localPort: number) => {
     try {
@@ -50,7 +59,7 @@ const Port: React.FunctionComponent<IPortProps> = ({ name, namespace, selector, 
         });
       }
     } catch (err) {
-      // Do nothing.
+      setError(`Error: ${err.message}`);
     }
   };
 
@@ -74,7 +83,9 @@ const Port: React.FunctionComponent<IPortProps> = ({ name, namespace, selector, 
         ]}
       />
 
-      <IonChip className="unset-chip-height" onClick={() => setShowPortLocalInput(true)}>
+      <IonToast isOpen={error !== ''} onDidDismiss={() => setError('')} message={error} duration={3000} />
+
+      <IonChip className="unset-chip-height" onClick={enabled ? () => setShowPortLocalInput(true) : undefined}>
         {children}
       </IonChip>
     </React.Fragment>

--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -37,6 +37,7 @@ import Editor from '../../../../misc/Editor';
 import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
 import AddLogs from '../../../../terminal/AddLogs';
 import AddShell from '../../../../terminal/AddShell';
+import Port from '../../Port';
 import Row from '../../template/Row';
 
 // getState returns the current state of the given container. This is used for the list view for init containers and
@@ -232,15 +233,23 @@ const Container: React.FunctionComponent<IContainerProps> = ({
                         obj={container}
                         objKey="ports"
                         title="Ports"
-                        value={(ports) => (
-                          <ul className="no-margin-list">
-                            {ports.map((port: V1ContainerPort, index) => (
-                              <li key={index}>
-                                {port.containerPort} {port.name ? `(${port.name})` : ''}
-                              </li>
-                            ))}
-                          </ul>
-                        )}
+                        value={(ports) =>
+                          ports.map((port: V1ContainerPort, index: number) => {
+                            return (
+                              <Port
+                                key={index}
+                                name={name ? name : ''}
+                                namespace={namespace ? namespace : ''}
+                                selector=""
+                                port={port.containerPort}
+                              >
+                                <IonLabel>
+                                  {port.containerPort} {port.name ? `(${port.name})` : ''}
+                                </IonLabel>
+                              </Port>
+                            );
+                          })
+                        }
                       />
                     </IonGrid>
                   </IonCardContent>

--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -238,6 +238,9 @@ const Container: React.FunctionComponent<IContainerProps> = ({
                             return (
                               <Port
                                 key={index}
+                                enabled={
+                                  status !== undefined && (port.protocol === undefined || port.protocol === 'TCP')
+                                }
                                 name={name ? name : ''}
                                 namespace={namespace ? namespace : ''}
                                 selector=""

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -76,13 +76,14 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                     return (
                       <Port
                         key={index}
+                        enabled={port.protocol === undefined || port.protocol === 'TCP'}
                         name={item.metadata && item.metadata.name ? item.metadata.name : ''}
                         namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
                         selector=""
                         port={port.containerPort}
                       >
                         <IonLabel>
-                          {port.containerPort} {port.name ? `(${port.name})` : ''}
+                          {container.name}: {port.containerPort} {port.name ? `(${port.name})` : ''}
                         </IonLabel>
                       </Port>
                     );

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -1,5 +1,5 @@
-import { IonCol, IonGrid, IonRow } from '@ionic/react';
-import { V1Pod } from '@kubernetes/client-node';
+import { IonCol, IonGrid, IonLabel, IonRow } from '@ionic/react';
+import { V1Container, V1ContainerPort, V1Pod } from '@kubernetes/client-node';
 import React, { useContext, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -12,6 +12,7 @@ import Affinities from '../../misc/podTemplate/affinities/Affinities';
 import Containers from '../../misc/podTemplate/containers/Containers';
 import Tolerations from '../../misc/podTemplate/tolerations/Tolerations';
 import Volumes from '../../misc/podTemplate/volumes/Volumes';
+import Port from '../../misc/Port';
 import Conditions from '../../misc/template/Conditions';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
@@ -64,6 +65,34 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
           <Row obj={item} objKey="spec.serviceAccountName" title="Service Account" />
           <Row obj={item} objKey="spec.restartPolicy" title="Restart Policy" />
           <Row obj={item} objKey="spec.terminationGracePeriodSeconds" title="Termination Grace Period Seconds" />
+          <Row
+            obj={item}
+            objKey="spec.containers"
+            title="Ports"
+            value={(containers) =>
+              containers.map((container: V1Container) => {
+                if (container.ports) {
+                  return container.ports.map((port: V1ContainerPort, index: number) => {
+                    return (
+                      <Port
+                        key={index}
+                        name={item.metadata && item.metadata.name ? item.metadata.name : ''}
+                        namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
+                        selector=""
+                        port={port.containerPort}
+                      >
+                        <IonLabel>
+                          {port.containerPort} {port.name ? `(${port.name})` : ''}
+                        </IonLabel>
+                      </Port>
+                    );
+                  });
+                }
+
+                return null;
+              })
+            }
+          />
         </Configuration>
 
         <Status>

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -290,6 +290,25 @@ export interface IPodMetricsList {
   metadata?: V1ListMeta;
 }
 
+export interface IPortForwarding {
+  id: string;
+  podName: string;
+  podNamespace: string;
+  podPort: number;
+  localPort: number;
+}
+
+export interface IPortForwardingContext {
+  portForwardings: IPortForwarding[];
+  add: (portForwarding: IPortForwarding) => Promise<void>;
+}
+
+export interface IPortForwardingResponse {
+  id: string;
+  podPort: number;
+  localPort: number;
+}
+
 export interface ITerminal {
   name: string;
   shell?: Terminal;

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -298,6 +298,10 @@ export interface IPortForwarding {
   localPort: number;
 }
 
+export interface IPortForwardingActiveSessions {
+  [key: string]: IPortForwardingResponse;
+}
+
 export interface IPortForwardingContext {
   portForwardings: IPortForwarding[];
   add: (portForwarding: IPortForwarding) => Promise<void>;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -15,6 +15,7 @@ import {
   IGoogleProject,
   IGoogleTokensAPIResponse,
   IOIDCProviderTokenAPIResponse,
+  IPortForwardingActiveSessions,
   IPortForwardingResponse,
   ITerminalResponse,
   TSyncType,
@@ -380,6 +381,31 @@ export const kubernetesExecRequest = async (url: string, cluster: ICluster): Pro
         password: cluster ? cluster.password : '',
         insecureSkipTLSVerify: cluster ? cluster.insecureSkipTLSVerify : false,
       }),
+    });
+
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.message);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+// kubernetesPortForwardingActiveSessions returns all active port forwarding sessions.
+export const kubernetesPortForwardingActiveSessions = async (): Promise<IPortForwardingActiveSessions> => {
+  try {
+    await checkServer();
+
+    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding/sessions`, {
+      method: 'get',
     });
 
     const json = await response.json();

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,17 +6,18 @@ import {
   IAWSCluster,
   IAzureCluster,
   ICluster,
+  IClusterAuthProviderAWS,
+  IClusterAuthProviderAzure,
+  IClusterAuthProviderGoogle,
+  IClusterAuthProviderOIDC,
   IClusters,
   IGoogleCluster,
   IGoogleProject,
   IGoogleTokensAPIResponse,
   IOIDCProviderTokenAPIResponse,
+  IPortForwardingResponse,
   ITerminalResponse,
   TSyncType,
-  IClusterAuthProviderAWS,
-  IClusterAuthProviderAzure,
-  IClusterAuthProviderGoogle,
-  IClusterAuthProviderOIDC,
 } from '../declarations';
 import { GOOGLE_REDIRECT_URI, OIDC_REDIRECT_URL_WEB, SERVER } from './constants';
 import { isJSON } from './helpers';
@@ -386,6 +387,79 @@ export const kubernetesExecRequest = async (url: string, cluster: ICluster): Pro
     if (response.status >= 200 && response.status < 300) {
       return json;
     } else {
+      if (json.error) {
+        throw new Error(json.message);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+// kubernetesPortForwardingRequest initialize the port forwarding to a pod. The generated session id which is returned
+// can be used to close the port forwarding.
+export const kubernetesPortForwardingRequest = async (
+  url: string,
+  podPort: number,
+  localPort: number,
+  cluster: ICluster,
+): Promise<IPortForwardingResponse> => {
+  try {
+    await checkServer();
+
+    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding`, {
+      method: 'post',
+      body: JSON.stringify({
+        server: SERVER,
+        cluster: cluster ? cluster.id : '',
+        url: cluster ? cluster.url + url : '',
+        certificateAuthorityData: cluster ? cluster.certificateAuthorityData : '',
+        clientCertificateData: cluster ? cluster.clientCertificateData : '',
+        clientKeyData: cluster ? cluster.clientKeyData : '',
+        token: cluster ? cluster.token : '',
+        username: cluster ? cluster.username : '',
+        password: cluster ? cluster.password : '',
+        insecureSkipTLSVerify: cluster ? cluster.insecureSkipTLSVerify : false,
+        podPort: podPort,
+        localPort: localPort,
+      }),
+    });
+
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.message);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+// kubernetesPortForwardingStopRequest closes a formaly opened port by the session id.
+export const kubernetesPortForwardingStopRequest = async (id: string): Promise<boolean> => {
+  try {
+    await checkServer();
+
+    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding/stop`, {
+      method: 'post',
+      body: JSON.stringify({
+        id: id,
+      }),
+    });
+
+    if (response.status >= 200 && response.status < 300) {
+      return true;
+    } else {
+      const json = await response.json();
+
       if (json.error) {
         throw new Error(json.message);
       } else {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -404,7 +404,7 @@ export const kubernetesPortForwardingActiveSessions = async (): Promise<IPortFor
   try {
     await checkServer();
 
-    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding/sessions`, {
+    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding`, {
       method: 'get',
     });
 
@@ -474,8 +474,8 @@ export const kubernetesPortForwardingStopRequest = async (id: string): Promise<b
   try {
     await checkServer();
 
-    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding/stop`, {
-      method: 'post',
+    const response = await fetch(`${SERVER}/api/kubernetes/portforwarding`, {
+      method: 'delete',
       body: JSON.stringify({
         id: id,
       }),

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -39,6 +39,8 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
   const [error, setError] = useState<string>('');
   const [message, setMessage] = useState<string>('');
   const [messagePort, setMessagePort] = useState<number>(0);
+  const [showPortForwardingActions, setShowPortForwardingActions] = useState<boolean>(false);
+  const [selectedPortForwarding, setSelectedPortForwarding] = useState<number>(0);
 
   const add = async (portForwarding: IPortForwarding) => {
     try {
@@ -86,7 +88,9 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
       buttons.push({
         text: `${portForwardings[i].localPort}:${portForwardings[i].podPort} ${portForwardings[i].podName}`,
         handler: () => {
-          remove(i);
+          setShowPortForwardings(false);
+          setSelectedPortForwarding(i);
+          setShowPortForwardingActions(true);
         },
       });
     }
@@ -149,8 +153,44 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
       <IonActionSheet
         isOpen={showPortForwardings}
         onDidDismiss={() => setShowPortForwardings(false)}
-        header="Stop Port Forwarding"
+        header="Port Forwardings"
         buttons={buttons}
+      />
+      <IonActionSheet
+        isOpen={showPortForwardingActions}
+        onDidDismiss={() => setShowPortForwardingActions(false)}
+        header="Select Action"
+        buttons={[
+          {
+            text: 'Open',
+            handler: () => {
+              if (isPlatform('electron')) {
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
+                window
+                  .require('electron')
+                  .shell.openExternal(`http://localhost:${portForwardings[selectedPortForwarding].localPort}`);
+              } else {
+                window.open(
+                  `http://localhost:${portForwardings[selectedPortForwarding].localPort}`,
+                  '_system',
+                  'location=yes',
+                );
+              }
+            },
+          },
+          {
+            text: 'Copy',
+            handler: () => {
+              Clipboard.write({ string: `${portForwardings[selectedPortForwarding].localPort}` });
+            },
+          },
+          {
+            text: 'Stop',
+            handler: () => {
+              remove(selectedPortForwarding);
+            },
+          },
+        ]}
       />
     </PortForwardingContext.Provider>
   );

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -1,0 +1,157 @@
+import { Plugins } from '@capacitor/core';
+import { ActionSheetButton, IonActionSheet, IonFab, IonFabButton, IonIcon, IonToast, isPlatform } from '@ionic/react';
+import { repeatOutline } from 'ionicons/icons';
+import React, { useContext, useState, ReactElement } from 'react';
+
+import { IContext, IPortForwarding, IPortForwardingContext } from '../declarations';
+import { kubernetesPortForwardingRequest, kubernetesPortForwardingStopRequest } from './api';
+import { AppContext } from './context';
+
+const { Clipboard } = Plugins;
+
+// Creates a Context object. When React renders a component that subscribes to this Context object it will read the
+// current context value from the closest matching Provider above it in the tree.
+export const PortForwardingContext = React.createContext<IPortForwardingContext>({
+  portForwardings: [],
+
+  add: () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return new Promise(() => {});
+  },
+});
+
+// A React component that subscribes to context changes. This lets you subscribe to a context within a function
+// component.
+export const PortForwardingContextConsumer = PortForwardingContext.Consumer;
+
+interface IPortForwardingContextProvider {
+  children: ReactElement;
+}
+
+// Every Context object comes with a Provider React component that allows consuming components to subscribe to context
+// changes.
+export const PortForwardingContextProvider: React.FunctionComponent<IPortForwardingContextProvider> = ({
+  children,
+}: IPortForwardingContextProvider) => {
+  const context = useContext<IContext>(AppContext);
+  const [showPortForwardings, setShowPortForwardings] = useState<boolean>(false);
+  const [portForwardings, setPortForwardings] = useState<IPortForwarding[]>([]);
+  const [error, setError] = useState<string>('');
+  const [message, setMessage] = useState<string>('');
+  const [messagePort, setMessagePort] = useState<number>(0);
+
+  const add = async (portForwarding: IPortForwarding) => {
+    try {
+      const pf = await kubernetesPortForwardingRequest(
+        `/api/v1/namespaces/${portForwarding.podNamespace}/pods/${portForwarding.podName}/portforward`,
+        portForwarding.podPort,
+        portForwarding.localPort,
+        await context.kubernetesAuthWrapper(''),
+      );
+
+      portForwarding.id = pf.id;
+      portForwarding.localPort = pf.localPort;
+
+      setPortForwardings([...portForwardings, portForwarding]);
+      setMessagePort(portForwarding.localPort);
+      setMessage(
+        `Start Port Forwarding for ${portForwarding.podName} (${portForwarding.localPort}:${portForwarding.podPort})`,
+      );
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const remove = async (index: number) => {
+    try {
+      await kubernetesPortForwardingStopRequest(portForwardings[index].id);
+
+      if (portForwardings.length > 1) {
+        const copy = [...portForwardings];
+        copy.splice(index, 1);
+        setPortForwardings(copy);
+      } else {
+        setShowPortForwardings(false);
+        setPortForwardings([]);
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const generateButtons = (): ActionSheetButton[] => {
+    const buttons: ActionSheetButton[] = [];
+
+    for (let i = 0; i < portForwardings.length; i++) {
+      buttons.push({
+        text: `${portForwardings[i].localPort}:${portForwardings[i].podPort} ${portForwardings[i].podName}`,
+        handler: () => {
+          remove(i);
+        },
+      });
+    }
+
+    return buttons;
+  };
+
+  const buttons = generateButtons();
+
+  return (
+    <PortForwardingContext.Provider
+      value={{
+        portForwardings: portForwardings,
+
+        add: add,
+      }}
+    >
+      {!showPortForwardings && portForwardings.length > 0 ? (
+        <IonFab vertical="bottom" horizontal="end" slot="fixed" style={{ bottom: '76px' }}>
+          <IonFabButton onClick={() => setShowPortForwardings(true)}>
+            <IonIcon icon={repeatOutline} color="#326ce5" />
+          </IonFabButton>
+        </IonFab>
+      ) : null}
+
+      {children}
+
+      <IonToast isOpen={error !== ''} onDidDismiss={() => setError('')} message={`Error: ${error}`} duration={3000} />
+      <IonToast
+        isOpen={message !== ''}
+        onDidDismiss={() => {
+          setMessage('');
+          setMessagePort(0);
+        }}
+        message={message}
+        duration={6000}
+        buttons={[
+          {
+            side: 'end',
+            text: 'Open',
+            handler: () => {
+              if (isPlatform('electron')) {
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
+                window.require('electron').shell.openExternal(`http://localhost:${messagePort}`);
+              } else {
+                window.open(`http://localhost:${messagePort}`, '_system', 'location=yes');
+              }
+            },
+          },
+          {
+            side: 'end',
+            text: 'Copy',
+            handler: () => {
+              Clipboard.write({ string: `${messagePort}` });
+            },
+          },
+        ]}
+      />
+
+      <IonActionSheet
+        isOpen={showPortForwardings}
+        onDidDismiss={() => setShowPortForwardings(false)}
+        header="Stop Port Forwarding"
+        buttons={buttons}
+      />
+    </PortForwardingContext.Provider>
+  );
+};

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -160,8 +160,15 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
           setMessagePort(0);
         }}
         message={message}
-        duration={6000}
+        duration={3000}
         buttons={[
+          {
+            side: 'end',
+            text: 'Copy',
+            handler: () => {
+              Clipboard.write({ string: `${messagePort}` });
+            },
+          },
           {
             side: 'end',
             text: 'Open',
@@ -172,13 +179,6 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
               } else {
                 window.open(`http://localhost:${messagePort}`, '_system', 'location=yes');
               }
-            },
-          },
-          {
-            side: 'end',
-            text: 'Copy',
-            handler: () => {
-              Clipboard.write({ string: `${messagePort}` });
             },
           },
         ]}
@@ -196,6 +196,18 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
         header="Select Action"
         buttons={[
           {
+            text: 'Stop',
+            handler: () => {
+              remove(selectedPortForwarding);
+            },
+          },
+          {
+            text: 'Copy',
+            handler: () => {
+              Clipboard.write({ string: `${portForwardings[selectedPortForwarding].localPort}` });
+            },
+          },
+          {
             text: 'Open',
             handler: () => {
               if (isPlatform('electron')) {
@@ -210,18 +222,6 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
                   'location=yes',
                 );
               }
-            },
-          },
-          {
-            text: 'Copy',
-            handler: () => {
-              Clipboard.write({ string: `${portForwardings[selectedPortForwarding].localPort}` });
-            },
-          },
-          {
-            text: 'Stop',
-            handler: () => {
-              remove(selectedPortForwarding);
             },
           },
         ]}


### PR DESCRIPTION
- When the user selects a port of a Pod, Container or Service he see an option to start a port forwarding session to the selected port.
- If the user selects a service, a list of all Pods is requested which are matching the selector and the first Pod in the list is used for the port forwarding.
- The user can set a local port which should be used or he can choose 0 and a random port is selected.

Closes #152.