### PR TITLE
Improve naming of terminal tabs

### DIFF
--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -84,31 +84,76 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
           {
             text: `Last ${LOG_TAIL_LINES} Log Lines`,
             handler: () => {
-              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, false);
+              addLogs(
+                context,
+                terminalContext,
+                url,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                container,
+                false,
+                LOG_TAIL_LINES,
+                false,
+              );
             },
           },
           {
             text: 'All Log Lines',
             handler: () => {
-              addLogs(context, terminalContext, url, container, false, 0, false);
+              addLogs(
+                context,
+                terminalContext,
+                url,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                container,
+                false,
+                0,
+                false,
+              );
             },
           },
           {
             text: `Previous Last ${LOG_TAIL_LINES} Log Lines`,
             handler: () => {
-              addLogs(context, terminalContext, url, container, true, LOG_TAIL_LINES, false);
+              addLogs(
+                context,
+                terminalContext,
+                url,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                container,
+                true,
+                LOG_TAIL_LINES,
+                false,
+              );
             },
           },
           {
             text: 'All Previous Log Lines',
             handler: () => {
-              addLogs(context, terminalContext, url, container, true, 0, false);
+              addLogs(
+                context,
+                terminalContext,
+                url,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                container,
+                true,
+                0,
+                false,
+              );
             },
           },
           {
             text: 'Stream Log Lines',
             handler: () => {
-              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, true);
+              addLogs(
+                context,
+                terminalContext,
+                url,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                container,
+                false,
+                LOG_TAIL_LINES,
+                true,
+              );
             },
           },
         ]}

--- a/src/components/resources/misc/modify/ShellItem.tsx
+++ b/src/components/resources/misc/modify/ShellItem.tsx
@@ -28,7 +28,13 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         buttons.push({
           text: container.name,
           handler: () => {
-            addShell(context, terminalContext, url, container.name);
+            addShell(
+              context,
+              terminalContext,
+              url,
+              item.metadata && item.metadata.name ? item.metadata.name : '',
+              container.name,
+            );
           },
         });
       }
@@ -39,7 +45,13 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         buttons.push({
           text: container.name,
           handler: () => {
-            addShell(context, terminalContext, url, container.name);
+            addShell(
+              context,
+              terminalContext,
+              url,
+              item.metadata && item.metadata.name ? item.metadata.name : '',
+              container.name,
+            );
           },
         });
       }
@@ -58,7 +70,13 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
           detail={false}
           onClick={() =>
             buttons.length === 1
-              ? addShell(context, terminalContext, url, buttons[0].text ? buttons[0].text : '')
+              ? addShell(
+                  context,
+                  terminalContext,
+                  url,
+                  item.metadata && item.metadata.name ? item.metadata.name : '',
+                  buttons[0].text ? buttons[0].text : '',
+                )
               : setShowActionSheet(true)
           }
         >

--- a/src/components/terminal/AddLogs.tsx
+++ b/src/components/terminal/AddLogs.tsx
@@ -34,7 +34,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, false);
+              addLogs(context, terminalContext, url, pod, container, false, LOG_TAIL_LINES, false);
             }}
           >
             <IonLabel>{`Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
@@ -45,7 +45,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              addLogs(context, terminalContext, url, container, false, 0, false);
+              addLogs(context, terminalContext, url, pod, container, false, 0, false);
             }}
           >
             <IonLabel>All Log Lines</IonLabel>
@@ -56,7 +56,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              addLogs(context, terminalContext, url, container, true, LOG_TAIL_LINES, false);
+              addLogs(context, terminalContext, url, pod, container, true, LOG_TAIL_LINES, false);
             }}
           >
             <IonLabel>{`Previous Last ${LOG_TAIL_LINES} Log Lines`}</IonLabel>
@@ -67,7 +67,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              addLogs(context, terminalContext, url, container, true, 0, false);
+              addLogs(context, terminalContext, url, pod, container, true, 0, false);
             }}
           >
             <IonLabel>All Previous Log Lines</IonLabel>
@@ -78,7 +78,7 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
-              addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, true);
+              addLogs(context, terminalContext, url, pod, container, false, LOG_TAIL_LINES, true);
             }}
           >
             <IonLabel>Stream Log Lines</IonLabel>

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -27,7 +27,9 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
     return (
       <IonItemOption
         color="primary"
-        onClick={() => addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container)}
+        onClick={() =>
+          addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, pod, container)
+        }
       >
         <IonIcon slot="start" icon={terminal} />
         Term
@@ -40,7 +42,7 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
         slot="end"
         onClick={(e) => {
           e.stopPropagation();
-          addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container);
+          addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, pod, container);
         }}
       >
         <IonIcon slot="start" icon={terminal} />

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -110,6 +110,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                 {terminals.map((terminal, index) => {
                   return (
                     <IonItem
+                      class="item item-text-wrap"
                       key={index}
                       button={true}
                       detail={false}
@@ -118,7 +119,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                         removeTerminal(index);
                       }}
                     >
-                      <IonLabel>{terminal.name}</IonLabel>
+                      <p>{terminal.name}</p>
                     </IonItem>
                   );
                 })}
@@ -136,7 +137,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
           >
             {terminals.map((terminal, index) => {
               return (
-                <IonSegmentButton key={index} value={`term_${index}`}>
+                <IonSegmentButton key={index} style={{ maxWidth: 'none' }} value={`term_${index}`}>
                   <IonLabel>{terminal.name}</IonLabel>
                 </IonSegmentButton>
               );

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -9,6 +9,7 @@ export const addShell = async (
   context: IContext,
   terminalContext: ITerminalContext,
   url: string,
+  pod: string,
   container: string,
 ): Promise<void> => {
   const term = new Terminal(SHELL_TERMINAL_OPTIONS(context.settings.darkMode));
@@ -56,7 +57,7 @@ export const addShell = async (
       };
 
       terminalContext.add({
-        name: container,
+        name: `${pod} - ${container}`,
         shell: term,
         webSocket: webSocket,
       });
@@ -65,7 +66,7 @@ export const addShell = async (
     term.write(`${err.message}\n\r`);
 
     terminalContext.add({
-      name: container,
+      name: `${pod} - ${container}`,
       shell: term,
     });
   }
@@ -75,6 +76,7 @@ export const addLogs = async (
   context: IContext,
   terminalContext: ITerminalContext,
   url: string,
+  pod: string,
   container: string,
   previous: boolean,
   tailLines: number,
@@ -101,7 +103,7 @@ export const addLogs = async (
         };
 
         terminalContext.add({
-          name: container,
+          name: `${pod} - ${container}`,
           shell: term,
           eventSource: eventSource,
         });
@@ -109,7 +111,7 @@ export const addLogs = async (
         term.write(`${err.message}\n\r`);
 
         terminalContext.add({
-          name: container,
+          name: `${pod} - ${container}`,
           shell: term,
         });
       }
@@ -143,7 +145,7 @@ export const addLogs = async (
       }
 
       terminalContext.add({
-        name: container,
+        name: `${pod} - ${container}`,
         shell: term,
       });
     }


### PR DESCRIPTION
Currently it is not that easy to close the correct terminal tab, when there are multiple tabs with the same container name. Therefor we are adding the pod name to the tab name.

For multi-line rendering we have to remove the IonLabel from the popover where the tab can be closed. We also have to disable the max-width of a tab.

Closes #157.