### PR TITLE
Add close button to terminal tabs

### DIFF
--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -127,7 +127,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                   >
                     <IonIcon slot="icon-only" icon={close} className="terminal-tab-close-button-color" />
                   </IonButton>
-                  <IonLabel className="terminal-tab-label">{terminal.name} iajsdoi ajsoidj aoisjd ioajs doij</IonLabel>
+                  <IonLabel className="terminal-tab-label">{terminal.name}</IonLabel>
                 </IonSegmentButton>
               );
             })}

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -5,7 +5,6 @@ import {
   IonHeader,
   IonIcon,
   IonItem,
-  IonItemDivider,
   IonItemGroup,
   IonLabel,
   IonList,

--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -103,26 +103,6 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                   <IonLabel>Select</IonLabel>
                 </IonItem>
               </IonItemGroup>
-              <IonItemGroup>
-                <IonItemDivider>
-                  <IonLabel>Close</IonLabel>
-                </IonItemDivider>
-                {terminals.map((terminal, index) => {
-                  return (
-                    <IonItem
-                      key={index}
-                      button={true}
-                      detail={false}
-                      onClick={() => {
-                        setShowPopover(false);
-                        removeTerminal(index);
-                      }}
-                    >
-                      <IonLabel>{terminal.name}</IonLabel>
-                    </IonItem>
-                  );
-                })}
-              </IonItemGroup>
             </IonList>
           </IonPopover>
         </IonToolbar>
@@ -136,8 +116,19 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
           >
             {terminals.map((terminal, index) => {
               return (
-                <IonSegmentButton key={index} value={`term_${index}`}>
-                  <IonLabel>{terminal.name}</IonLabel>
+                <IonSegmentButton key={index} value={`term_${index}`} layout="icon-end">
+                  <IonButton
+                    fill="clear"
+                    className="terminal-tab-close-button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      removeTerminal(index);
+                    }}
+                  >
+                    <IonIcon slot="icon-only" icon={close} className="terminal-tab-close-button-color" />
+                  </IonButton>
+                  <IonLabel className="terminal-tab-label">{terminal.name} iajsdoi ajsoidj aoisjd ioajs doij</IonLabel>
                 </IonSegmentButton>
               );
             })}

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -147,3 +147,27 @@ ion-avatar {
   width: 100%;
   cursor: pointer;
 }
+
+/* Terminal
+   Customization for the terminal */
+.terminal-tab-close-button {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 4px 2px;
+}
+
+.segment-button-layout-icon-end.segment-button-checked .terminal-tab-close-button-color {
+  color: var(--ion-color-primary);
+}
+
+.segment-button-layout-icon-end .terminal-tab-close-button-color {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.terminal-tab-label {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: calc(100% - 112px);
+}


### PR DESCRIPTION
To handle the closing of terminal tabs in a better way, each tab now have it's own button for closing.

Closes #157.

![Bildschirmfoto 2020-08-26 um 20 59 29](https://user-images.githubusercontent.com/18552168/91345281-69faf880-e7df-11ea-9873-0b461e23a94f.png)
