### PR TITLE
Add Terminal settings, disable port forwarding, customize cluster name

### DIFF
--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -62,7 +62,7 @@ var rootCmd = &cobra.Command{
 		log.Infof(version.BuildContext())
 
 		// Create the client for the interaction with the Kubernetes API.
-		client, err := kube.NewClient(false, kubeconfigFlag, kubeconfigIncludeFlag, kubeconfigExcludeFlag)
+		client, err := kube.NewClient(false, "", kubeconfigFlag, kubeconfigIncludeFlag, kubeconfigExcludeFlag)
 		if err != nil {
 			log.WithError(err).Fatalf("Could not create Kubernetes client")
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ var (
 	debugFlag             bool
 	debugIonicFlag        string
 	inclusterFlag         bool
+	inclusterNameFlag     string
 	kubeconfigFlag        string
 	kubeconfigIncludeFlag string
 	kubeconfigExcludeFlag string
@@ -46,7 +47,7 @@ var rootCmd = &cobra.Command{
 		log.Infof(version.BuildContext())
 
 		// Create the client for the interaction with the Kubernetes API.
-		client, err := kube.NewClient(inclusterFlag, kubeconfigFlag, kubeconfigIncludeFlag, kubeconfigExcludeFlag)
+		client, err := kube.NewClient(inclusterFlag, inclusterNameFlag, kubeconfigFlag, kubeconfigIncludeFlag, kubeconfigExcludeFlag)
 		if err != nil {
 			log.WithError(err).Fatalf("Could not create Kubernetes client")
 		}
@@ -98,6 +99,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "Enable debug mode.")
 	rootCmd.PersistentFlags().StringVar(&debugIonicFlag, "debug.ionic", "build", "Path to the Ionic app.")
 	rootCmd.PersistentFlags().BoolVar(&inclusterFlag, "incluster", false, "Use the in cluster configuration.")
+	rootCmd.PersistentFlags().StringVar(&inclusterNameFlag, "incluster.name", "kubenav", "The name which should be displayed when using the incluster flag.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfigFlag, "kubeconfig", "", "Optional Kubeconfig file.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfigIncludeFlag, "kubeconfig.include", "", "Comma separated list of globs to include in the Kubeconfig.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfigExcludeFlag, "kubeconfig.exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '--kubeconfig.include' flag.")

--- a/pkg/electron/kube/config.go
+++ b/pkg/electron/kube/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 // loadInClusterConfig loads the Kubeconfig from the in cluster configuration.
-func loadInClusterConfig() (clientcmd.ClientConfig, error) {
+func loadInClusterConfig(name string) (clientcmd.ClientConfig, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -23,22 +23,22 @@ func loadInClusterConfig() (clientcmd.ClientConfig, error) {
 	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
-		CurrentContext: "kubenav",
+		CurrentContext: name,
 		Contexts: map[string]*clientcmdapi.Context{
-			"kubenav": {
-				Cluster:   "kubenav",
-				AuthInfo:  "kubenav",
+			name: {
+				Cluster:   name,
+				AuthInfo:  name,
 				Namespace: "default",
 			},
 		},
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"kubenav": {
+			name: {
 				Server:               config.Host,
 				CertificateAuthority: config.TLSClientConfig.CAFile,
 			},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"kubenav": {
+			name: {
 				Token:     config.BearerToken,
 				TokenFile: config.BearerTokenFile,
 			},

--- a/pkg/electron/kube/kube.go
+++ b/pkg/electron/kube/kube.go
@@ -37,12 +37,12 @@ type Cluster struct {
 }
 
 // NewClient returns a new API client for a Kubernetes cluster.
-func NewClient(incluster bool, kubeconfig, kubeconfigInclude, kubeconfigExclude string) (*Client, error) {
+func NewClient(incluster bool, inclusterName, kubeconfig, kubeconfigInclude, kubeconfigExclude string) (*Client, error) {
 	var config clientcmd.ClientConfig
 	var err error
 
 	if incluster {
-		config, err = loadInClusterConfig()
+		config, err = loadInClusterConfig(inclusterName)
 		if err != nil {
 			return nil, err
 		}

--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
@@ -3,6 +3,7 @@ import { V1LoadBalancerIngress, V1Service, V1ServicePort } from '@kubernetes/cli
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IS_SERVER } from '../../../../utils/constants';
 import { matchLabels } from '../../../../utils/helpers';
 import List from '../../misc/List';
 import Port from '../../misc/Port';
@@ -48,7 +49,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
                 return (
                   <Port
                     key={index}
-                    enabled={port.protocol === undefined || port.protocol === 'TCP'}
+                    enabled={!IS_SERVER && (port.protocol === undefined || port.protocol === 'TCP')}
                     name=""
                     namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
                     selector={

--- a/src/components/resources/misc/podTemplate/containers/Container.tsx
+++ b/src/components/resources/misc/podTemplate/containers/Container.tsx
@@ -32,6 +32,7 @@ import yaml from 'js-yaml';
 import React, { useState } from 'react';
 
 import { IContainerMetrics } from '../../../../../declarations';
+import { IS_SERVER } from '../../../../../utils/constants';
 import { formatResourceValue } from '../../../../../utils/helpers';
 import Editor from '../../../../misc/Editor';
 import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
@@ -239,7 +240,9 @@ const Container: React.FunctionComponent<IContainerProps> = ({
                               <Port
                                 key={index}
                                 enabled={
-                                  status !== undefined && (port.protocol === undefined || port.protocol === 'TCP')
+                                  !IS_SERVER &&
+                                  status !== undefined &&
+                                  (port.protocol === undefined || port.protocol === 'TCP')
                                 }
                                 name={name ? name : ''}
                                 namespace={namespace ? namespace : ''}

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { IContext, IPodMetrics } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
+import { IS_SERVER } from '../../../../utils/constants';
 import { AppContext } from '../../../../utils/context';
 import Permissions from '../../configAndStorage/serviceAccounts/Permissions';
 import List from '../../misc/List';
@@ -76,7 +77,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                     return (
                       <Port
                         key={index}
-                        enabled={port.protocol === undefined || port.protocol === 'TCP'}
+                        enabled={!IS_SERVER && (port.protocol === undefined || port.protocol === 'TCP')}
                         name={item.metadata && item.metadata.name ? item.metadata.name : ''}
                         namespace={item.metadata && item.metadata.namespace ? item.metadata.namespace : ''}
                         selector=""

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -23,88 +23,12 @@ import { AppContext } from '../../utils/context';
 const GeneralPage: React.FunctionComponent = () => {
   const context = useContext<IContext>(AppContext);
 
-  const changeTimeout = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: parseInt(event.target.value),
-      sshKey: context.settings.sshKey,
-      sshPort: context.settings.sshPort,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: context.settings.proxyAddress,
-    });
+  const handleValueChange = (event) => {
+    context.editSettings({ ...context.settings, [event.target.name]: event.target.value });
   };
 
-  const toggleDarkMode = (event) => {
-    context.editSettings({
-      darkMode: event.detail.checked,
-      timeout: context.settings.timeout,
-      sshKey: context.settings.sshKey,
-      sshPort: context.settings.sshPort,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: context.settings.proxyAddress,
-    });
-  };
-
-  const changeSSHKey = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: context.settings.timeout,
-      sshKey: event.target.value,
-      sshPort: context.settings.sshPort,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: context.settings.proxyAddress,
-    });
-  };
-
-  const changeSSHPort = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: context.settings.timeout,
-      sshKey: context.settings.sshKey,
-      sshPort: event.target.value,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: context.settings.proxyAddress,
-    });
-  };
-
-  const changeSSHUser = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: context.settings.timeout,
-      sshKey: context.settings.sshKey,
-      sshPort: context.settings.sshPort,
-      sshUser: event.target.value,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: context.settings.proxyAddress,
-    });
-  };
-
-  const toggleProxyEnabled = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: context.settings.timeout,
-      sshKey: context.settings.sshKey,
-      sshPort: context.settings.sshPort,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: event.detail.checked,
-      proxyAddress: context.settings.proxyAddress,
-    });
-  };
-
-  const changeProxyAddress = (event) => {
-    context.editSettings({
-      darkMode: context.settings.darkMode,
-      timeout: context.settings.timeout,
-      sshKey: context.settings.sshKey,
-      sshPort: context.settings.sshPort,
-      sshUser: context.settings.sshUser,
-      proxyEnabled: context.settings.proxyEnabled,
-      proxyAddress: event.target.value,
-    });
+  const handleToggleChange = (event) => {
+    context.editSettings({ ...context.settings, [event.target.name]: event.detail.checked });
   };
 
   return (
@@ -125,11 +49,42 @@ const GeneralPage: React.FunctionComponent = () => {
             </IonItemDivider>
             <IonItem>
               <IonLabel>Dark Mode</IonLabel>
-              <IonToggle checked={context.settings.darkMode} onIonChange={toggleDarkMode} />
+              <IonToggle name="darkMode" checked={context.settings.darkMode} onIonChange={handleToggleChange} />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Timeout (in seconds)</IonLabel>
-              <IonInput type="number" required={true} value={context.settings.timeout} onInput={changeTimeout} />
+              <IonInput
+                type="number"
+                required={true}
+                name="timeout"
+                value={context.settings.timeout}
+                onInput={handleValueChange}
+              />
+            </IonItem>
+          </IonItemGroup>
+          <IonItemGroup>
+            <IonItemDivider>
+              <IonLabel>Terminal</IonLabel>
+            </IonItemDivider>
+            <IonItem>
+              <IonLabel position="stacked">Font Size</IonLabel>
+              <IonInput
+                type="number"
+                required={true}
+                name="terminalFontSize"
+                value={context.settings.terminalFontSize}
+                onInput={handleValueChange}
+              />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Scrollback</IonLabel>
+              <IonInput
+                type="number"
+                required={true}
+                name="terminalScrollback"
+                value={context.settings.terminalScrollback}
+                onInput={handleValueChange}
+              />
             </IonItem>
           </IonItemGroup>
 
@@ -139,15 +94,27 @@ const GeneralPage: React.FunctionComponent = () => {
             </IonItemDivider>
             <IonItem>
               <IonLabel position="stacked">Port</IonLabel>
-              <IonInput type="text" required={true} value={context.settings.sshPort} onInput={changeSSHPort} />
+              <IonInput
+                type="text"
+                required={true}
+                name="sshPort"
+                value={context.settings.sshPort}
+                onInput={handleValueChange}
+              />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Private Key</IonLabel>
-              <IonTextarea autoGrow={true} value={context.settings.sshKey} onInput={changeSSHKey} />
+              <IonTextarea autoGrow={true} name="sshKey" value={context.settings.sshKey} onInput={handleValueChange} />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">User</IonLabel>
-              <IonInput type="text" required={true} value={context.settings.sshUser} onInput={changeSSHUser} />
+              <IonInput
+                type="text"
+                required={true}
+                name="sshUser"
+                value={context.settings.sshUser}
+                onInput={handleValueChange}
+              />
             </IonItem>
           </IonItemGroup>
 
@@ -157,7 +124,7 @@ const GeneralPage: React.FunctionComponent = () => {
             </IonItemDivider>
             <IonItem>
               <IonLabel>Enabled</IonLabel>
-              <IonToggle checked={context.settings.proxyEnabled} onIonChange={toggleProxyEnabled} />
+              <IonToggle name="proxyEnabled" checked={context.settings.proxyEnabled} onIonChange={handleToggleChange} />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Address</IonLabel>
@@ -165,8 +132,9 @@ const GeneralPage: React.FunctionComponent = () => {
                 type="text"
                 required={true}
                 placeholder="http://localhost:8888"
+                name="proxyAddress"
                 value={context.settings.proxyAddress}
-                onInput={changeProxyAddress}
+                onInput={handleValueChange}
               />
             </IonItem>
           </IonItemGroup>

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -11,7 +11,13 @@ export const addShell = async (
   url: string,
   container: string,
 ): Promise<void> => {
-  const term = new Terminal(SHELL_TERMINAL_OPTIONS(context.settings.darkMode));
+  const term = new Terminal(
+    SHELL_TERMINAL_OPTIONS(
+      context.settings.terminalFontSize,
+      context.settings.terminalScrollback,
+      context.settings.darkMode,
+    ),
+  );
 
   try {
     if (context.clusters && context.cluster) {
@@ -80,7 +86,13 @@ export const addLogs = async (
   tailLines: number,
   follow: boolean,
 ): Promise<void> => {
-  const term = new Terminal(LOG_TERMINAL_OPTIONS(context.settings.darkMode));
+  const term = new Terminal(
+    LOG_TERMINAL_OPTIONS(
+      context.settings.terminalFontSize,
+      context.settings.terminalScrollback,
+      context.settings.darkMode,
+    ),
+  );
 
   if (context.clusters && context.cluster) {
     if (follow) {
@@ -156,7 +168,13 @@ export const addSSH = async (
   node: string,
   ip: string,
 ): Promise<void> => {
-  const term = new Terminal(SHELL_TERMINAL_OPTIONS(context.settings.darkMode));
+  const term = new Terminal(
+    SHELL_TERMINAL_OPTIONS(
+      context.settings.terminalFontSize,
+      context.settings.terminalScrollback,
+      context.settings.darkMode,
+    ),
+  );
 
   try {
     if (context.clusters && context.cluster) {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -46,6 +46,8 @@ export interface IAppSettings {
   sshUser: string;
   proxyEnabled: boolean;
   proxyAddress: string;
+  terminalFontSize: number;
+  terminalScrollback: number;
 }
 
 export interface IAWSCluster {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,6 +3,7 @@ import { ITerminalOptions } from 'xterm';
 import { IAppSettings } from '../declarations';
 
 export const CUSTOM_URI_SCHEME = 'io.kubenav.kubenav';
+export const IS_SERVER = process.env.REACT_APP_SERVER === 'true' ? true : false;
 export const SERVER = process.env.REACT_APP_SERVER === 'true' ? '' : 'http://localhost:14122';
 export const VERSION = process.env.REACT_APP_VERSION;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_SETTINGS: IAppSettings = {
   sshUser: '',
   proxyEnabled: false,
   proxyAddress: '',
+  terminalFontSize: 12,
+  terminalScrollback: 10000,
 };
 
 export const GOOGLE_OAUTH2_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -30,24 +32,24 @@ export const STORAGE_SETTINGS = 'settings';
 export const STORAGE_TEMPORARY_CREDENTIALS = 'temporary_credentials';
 
 export const LOG_TAIL_LINES = 1000;
-export const LOG_TERMINAL_OPTIONS = (darkMode: boolean): ITerminalOptions => {
+export const LOG_TERMINAL_OPTIONS = (fontSize: number, scrollback: number, darkMode: boolean): ITerminalOptions => {
   return {
-    fontSize: 12,
+    fontSize: fontSize,
     bellStyle: 'sound',
     cursorBlink: true,
     disableStdin: true,
     convertEol: true,
-    scrollback: 10000,
+    scrollback: scrollback,
     theme: darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
   };
 };
 
-export const SHELL_TERMINAL_OPTIONS = (darkMode: boolean): ITerminalOptions => {
+export const SHELL_TERMINAL_OPTIONS = (fontSize: number, scrollback: number, darkMode: boolean): ITerminalOptions => {
   return {
-    fontSize: 12,
+    fontSize: fontSize,
     bellStyle: 'sound',
     cursorBlink: true,
-    scrollback: 10000,
+    scrollback: scrollback,
     theme: darkMode ? TERMINAL_DARK_THEME : TERMINAL_LIGHT_THEME,
   };
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -135,6 +135,10 @@ export const readSettings = (): IAppSettings => {
       sshUser: settings.sshUser ? settings.sshUser : DEFAULT_SETTINGS.sshUser,
       proxyEnabled: settings.hasOwnProperty('proxyEnabled') ? settings.proxyEnabled : DEFAULT_SETTINGS.proxyEnabled,
       proxyAddress: settings.proxyAddress ? settings.proxyAddress : DEFAULT_SETTINGS.proxyAddress,
+      terminalFontSize: settings.terminalFontSize ? settings.terminalFontSize : DEFAULT_SETTINGS.terminalFontSize,
+      terminalScrollback: settings.terminalScrollback
+        ? settings.terminalScrollback
+        : DEFAULT_SETTINGS.terminalScrollback,
     };
   }
 


### PR DESCRIPTION
- The terminal settings for the font size and the number of scrollback lines can now be changed in the general settings page. Closes #161.
- The port forwarding isn't usable when kubenav is deployed in a Kubernetes cluster. Therefor the port forwarding is now disabled for the incluster mode.
- When the `--incluster` mode is used, the displayed cluster name in the frontend was always `kubenav`. This can now be overwritten with the `--incluster.name` flag.

![Bildschirmfoto 2020-08-28 um 08 21 44](https://user-images.githubusercontent.com/18552168/91528203-885c1380-e907-11ea-9768-0b530411c70f.png)