### PR TITLE
Fix terminal tabs for mobile devices

### DIFF
--- a/src/components/terminal/Terminals.tsx
+++ b/src/components/terminal/Terminals.tsx
@@ -115,7 +115,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
           >
             {terminals.map((terminal, index) => {
               return (
-                <IonSegmentButton key={index} value={`term_${index}`} layout="icon-end">
+                <IonSegmentButton key={index} mode="md" value={`term_${index}`} layout="icon-end">
                   <IonButton
                     fill="clear"
                     className="terminal-tab-close-button"
@@ -127,7 +127,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                   >
                     <IonIcon slot="icon-only" icon={close} className="terminal-tab-close-button-color" />
                   </IonButton>
-                  <IonLabel className="terminal-tab-label">{terminal.name}</IonLabel>
+                  <IonLabel>{terminal.name}</IonLabel>
                 </IonSegmentButton>
               );
             })}

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -160,7 +160,7 @@ ion-avatar {
 }
 
 .segment-button-layout-icon-end .terminal-tab-close-button-color {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(var(--ion-color-light-contrast-rgb), 0.6);
 }
 
 /* Fix layout for using IonLabel together with IonRange in IonItem

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -151,10 +151,8 @@ ion-avatar {
 /* Terminal
    Customization for the terminal */
 .terminal-tab-close-button {
-  position: absolute;
-  right: 0;
-  top: 0;
-  margin: 4px 2px;
+  --padding-start: 0px;
+  --padding-end: 0px;
 }
 
 .segment-button-layout-icon-end.segment-button-checked .terminal-tab-close-button-color {
@@ -163,13 +161,6 @@ ion-avatar {
 
 .segment-button-layout-icon-end .terminal-tab-close-button-color {
   color: rgba(255, 255, 255, 0.6);
-}
-
-.terminal-tab-label {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  max-width: calc(100% - 112px);
 }
 
 /* Fix layout for using IonLabel together with IonRange in IonItem


### PR DESCRIPTION
Because of the absolute positioning of the close button it was possible that the container name wasn't displayed on a tab. Now the close button is displayed inline with the container name which fixes the problem.

Fixes #166.