### PR TITLE
Add status for PVs and PVCs

### DIFF
--- a/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimItem.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { timeDifference } from '../../../../utils/helpers';
+import ItemStatus from '../../misc/template/ItemStatus';
 
 interface IPersistentVolumeClaimItemProps extends RouteComponentProps {
   item: V1PersistentVolumeClaim;
@@ -16,6 +17,14 @@ const PersistentVolumeClaimItem: React.FunctionComponent<IPersistentVolumeClaimI
   section,
   type,
 }: IPersistentVolumeClaimItemProps) => {
+  const status = (): string => {
+    if (item.status && item.status.phase === 'Bound') {
+      return 'success';
+    }
+
+    return 'warning';
+  };
+
   // - Phase: The current phase of PersistentVolumeClaim.
   // - Capacity: The actual resources of the underlying volume.
   // - Access Modes: The actual access modes the volume backing the PVC has.
@@ -27,6 +36,7 @@ const PersistentVolumeClaimItem: React.FunctionComponent<IPersistentVolumeClaimI
       }`}
       routerDirection="forward"
     >
+      <ItemStatus status={status()} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
         <p>

--- a/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeItem.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { timeDifference } from '../../../../utils/helpers';
+import ItemStatus from '../../misc/template/ItemStatus';
 
 interface IPersistentVolumeItemProps extends RouteComponentProps {
   item: V1PersistentVolume;
@@ -16,6 +17,18 @@ const PersistentVolumeItem: React.FunctionComponent<IPersistentVolumeItemProps> 
   section,
   type,
 }: IPersistentVolumeItemProps) => {
+  const status = (): string => {
+    if (item.status === undefined || item.status.phase === 'Released' || item.status.phase === 'Available') {
+      return 'warning';
+    }
+
+    if (item.status.phase === 'Failed') {
+      return 'danger';
+    }
+
+    return 'success';
+  };
+
   // - Phase: Indicates if a volume is available, bound to a claim, or released by a claim.
   // - Capacity: Resources of the volume.
   // - Access Modes: Contains all ways the volume can be mounted.
@@ -28,6 +41,7 @@ const PersistentVolumeItem: React.FunctionComponent<IPersistentVolumeItemProps> 
       }`}
       routerDirection="forward"
     >
+      <ItemStatus status={status()} />
       <IonLabel>
         <h2>{item.metadata ? item.metadata.name : ''}</h2>
         <p>


### PR DESCRIPTION
The list view for PVs and PVCs are now showing a status.

If the Persistent Volume is in the phase released or available the status is set to warning. When the phase is failed the status is set to error and for bound to success.

If the Persistent Volume Claim is in the phase bound the status is set to success. For all other cases the status is set to warning.