### PR TITLE
Add option to select shell for terminal

### DIFF
--- a/pkg/electron/kubernetes.go
+++ b/pkg/electron/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -94,6 +95,14 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	shell := ""
+	requestURL, err := url.Parse(request.URL)
+	if err == nil {
+		commands, ok := requestURL.Query()["command"]
+		if ok || len(commands[0]) >= 1 {
+			shell = commands[0]
+		}
+	}
+
 	go api.WaitForTerminal(config, clientset, &request, shell, sessionID)
 
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})

--- a/pkg/mobile/kubernetes.go
+++ b/pkg/mobile/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -95,6 +96,14 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	shell := ""
+	requestURL, err := url.Parse(request.URL)
+	if err == nil {
+		commands, ok := requestURL.Query()["command"]
+		if ok || len(commands[0]) >= 1 {
+			shell = commands[0]
+		}
+	}
+
 	go api.WaitForTerminal(config, clientset, &request, shell, sessionID)
 
 	middleware.Write(w, r, api.TerminalResponse{ID: sessionID})

--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -80,7 +80,7 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
       <IonActionSheet
         isOpen={showActionSheetOptions}
         onDidDismiss={() => setShowActionSheetOptions(false)}
-        header="Select a Option"
+        header="Select an Option"
         buttons={[
           {
             text: `Last ${LOG_TAIL_LINES} Log Lines`,

--- a/src/components/resources/misc/modify/LogsItem.tsx
+++ b/src/components/resources/misc/modify/LogsItem.tsx
@@ -19,6 +19,9 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
+  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
+  const [showActionSheetOptions, setShowActionSheetOptions] = useState<boolean>(false);
+
   const generateButtons = (): ActionSheetButton[] => {
     const buttons: ActionSheetButton[] = [];
 
@@ -28,6 +31,7 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
           text: container.name,
           handler: () => {
             setContainer(container.name);
+            setShowActionSheetOptions(true);
           },
         });
       }
@@ -49,9 +53,6 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
   };
 
   const buttons = generateButtons();
-
-  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
-  const [showActionSheetOptions, setShowActionSheetOptions] = useState<boolean>(false);
   const [container, setContainer] = useState<string>(
     buttons.length === 1 ? (buttons[0].text ? buttons[0].text : '') : '',
   );
@@ -72,14 +73,14 @@ const LogsItem: React.FunctionComponent<ILogsItemProps> = ({ activator, item, ur
       <IonActionSheet
         isOpen={showActionSheetContainer}
         onDidDismiss={() => setShowActionSheetContainer(false)}
-        header="Select Container"
+        header="Select a Container"
         buttons={buttons}
       />
 
       <IonActionSheet
         isOpen={showActionSheetOptions}
         onDidDismiss={() => setShowActionSheetOptions(false)}
-        header="Select Option"
+        header="Select a Option"
         buttons={[
           {
             text: `Last ${LOG_TAIL_LINES} Log Lines`,

--- a/src/components/resources/misc/modify/ShellItem.tsx
+++ b/src/components/resources/misc/modify/ShellItem.tsx
@@ -18,7 +18,8 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
+  const [showActionSheetContainer, setShowActionSheetContainer] = useState<boolean>(false);
+  const [showActionSheetShell, setShowActionSheetShell] = useState<boolean>(false);
 
   const generateButtons = (): ActionSheetButton[] => {
     const buttons: ActionSheetButton[] = [];
@@ -28,7 +29,8 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         buttons.push({
           text: container.name,
           handler: () => {
-            addShell(context, terminalContext, url, container.name);
+            setContainer(container.name);
+            setShowActionSheetShell(true);
           },
         });
       }
@@ -39,7 +41,8 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         buttons.push({
           text: container.name,
           handler: () => {
-            addShell(context, terminalContext, url, container.name);
+            setContainer(container.name);
+            setShowActionSheetShell(true);
           },
         });
       }
@@ -49,6 +52,9 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
   };
 
   const buttons = generateButtons();
+  const [container, setContainer] = useState<string>(
+    buttons.length === 1 ? (buttons[0].text ? buttons[0].text : '') : '',
+  );
 
   return (
     <React.Fragment>
@@ -56,11 +62,7 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
         <IonItem
           button={true}
           detail={false}
-          onClick={() =>
-            buttons.length === 1
-              ? addShell(context, terminalContext, url, buttons[0].text ? buttons[0].text : '')
-              : setShowActionSheet(true)
-          }
+          onClick={() => (buttons.length === 1 ? setShowActionSheetShell(true) : setShowActionSheetContainer(true))}
         >
           <IonIcon slot="end" color="primary" icon={terminal} />
           <IonLabel>Shell</IonLabel>
@@ -68,10 +70,42 @@ const ShellItem: React.FunctionComponent<IShellItemProps> = ({ activator, item, 
       ) : null}
 
       <IonActionSheet
-        isOpen={showActionSheet}
-        onDidDismiss={() => setShowActionSheet(false)}
-        header="Select Container"
+        isOpen={showActionSheetContainer}
+        onDidDismiss={() => setShowActionSheetContainer(false)}
+        header="Select a Container"
         buttons={buttons}
+      />
+
+      <IonActionSheet
+        isOpen={showActionSheetShell}
+        onDidDismiss={() => setShowActionSheetShell(false)}
+        header="Select a Shell"
+        buttons={[
+          {
+            text: 'bash',
+            handler: () => {
+              addShell(context, terminalContext, url, container, 'bash');
+            },
+          },
+          {
+            text: 'sh',
+            handler: () => {
+              addShell(context, terminalContext, url, container, 'sh');
+            },
+          },
+          {
+            text: 'powershell',
+            handler: () => {
+              addShell(context, terminalContext, url, container, 'powershell');
+            },
+          },
+          {
+            text: 'cmd',
+            handler: () => {
+              addShell(context, terminalContext, url, container, 'cmd');
+            },
+          },
+        ]}
       />
     </React.Fragment>
   );

--- a/src/components/terminal/AddShell.tsx
+++ b/src/components/terminal/AddShell.tsx
@@ -1,6 +1,6 @@
-import { IonButton, IonIcon, IonItemOption } from '@ionic/react';
+import { IonButton, IonIcon, IonItem, IonItemOption, IonLabel, IonList, IonPopover } from '@ionic/react';
 import { terminal } from 'ionicons/icons';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
 import { IContext, ITerminalContext, TActivator } from '../../declarations';
 import { AppContext } from '../../utils/context';
@@ -23,31 +23,95 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  if (activator === 'item-option') {
-    return (
-      <IonItemOption
-        color="primary"
-        onClick={() => addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container)}
-      >
-        <IonIcon slot="start" icon={terminal} />
-        Term
-      </IonItemOption>
-    );
-  } else {
-    return (
-      <IonButton
-        fill="outline"
-        slot="end"
-        onClick={(e) => {
-          e.stopPropagation();
-          addShell(context, terminalContext, `/api/v1/namespaces/${namespace}/pods/${pod}`, container);
-        }}
-      >
-        <IonIcon slot="start" icon={terminal} />
-        Term
-      </IonButton>
-    );
-  }
+  const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [popoverEvent, setPopoverEvent] = useState();
+
+  const url = `/api/v1/namespaces/${namespace}/pods/${pod}`;
+
+  return (
+    <React.Fragment>
+      <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
+        <IonList>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowPopover(false);
+              addShell(context, terminalContext, url, container, 'bash');
+            }}
+          >
+            <IonLabel>bash</IonLabel>
+          </IonItem>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowPopover(false);
+              addShell(context, terminalContext, url, container, 'sh');
+            }}
+          >
+            <IonLabel>sh</IonLabel>
+          </IonItem>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowPopover(false);
+              addShell(context, terminalContext, url, container, 'powershell');
+            }}
+          >
+            <IonLabel>powershell</IonLabel>
+          </IonItem>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowPopover(false);
+              addShell(context, terminalContext, url, container, 'cmd');
+            }}
+          >
+            <IonLabel>cmd</IonLabel>
+          </IonItem>
+        </IonList>
+      </IonPopover>
+
+      {activator === 'item-option' ? (
+        <IonItemOption
+          color="primary"
+          onClick={(e) => {
+            e.persist();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setPopoverEvent(e as any);
+            setShowPopover(true);
+          }}
+        >
+          <IonIcon slot="start" icon={terminal} />
+          Term
+        </IonItemOption>
+      ) : null}
+
+      {activator === 'button' ? (
+        <IonButton
+          fill="outline"
+          slot="end"
+          onClick={(e) => {
+            e.stopPropagation();
+            e.persist();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setPopoverEvent(e as any);
+            setShowPopover(true);
+          }}
+        >
+          <IonIcon slot="start" icon={terminal} />
+          Term
+        </IonButton>
+      ) : null}
+    </React.Fragment>
+  );
 };
 
 export default AddShell;

--- a/src/components/terminal/helpers.ts
+++ b/src/components/terminal/helpers.ts
@@ -10,6 +10,7 @@ export const addShell = async (
   terminalContext: ITerminalContext,
   url: string,
   container: string,
+  shell: string,
 ): Promise<void> => {
   const term = new Terminal(
     SHELL_TERMINAL_OPTIONS(
@@ -22,7 +23,7 @@ export const addShell = async (
   try {
     if (context.clusters && context.cluster) {
       const { id } = await kubernetesExecRequest(
-        `${url}/exec?command=sh&container=${container}&stdin=true&stdout=true&stderr=true&tty=true`,
+        `${url}/exec?command=${shell}&container=${container}&stdin=true&stdout=true&stderr=true&tty=true`,
         await context.kubernetesAuthWrapper(''),
       );
 


### PR DESCRIPTION
The shell which should be used for the terminal can now be selected. After a user selects the terminal for a pod, he will be ask which shell he wants to use. The user can select between `bash`, `sh`, `powershell` and `cmd`.

Closes #172.