### PR TITLE
Fix port forwarding for services with target port

### DIFF
--- a/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/services/ServiceDetails.tsx
@@ -60,6 +60,7 @@ const ServiceDetails: React.FunctionComponent<IServiceDetailsProps> = ({ item, t
                         : ''
                     }
                     port={port.port}
+                    targetPort={port.targetPort}
                   >
                     <IonLabel>
                       {port.name ? `${port.name} ` : ''}


### PR DESCRIPTION
If a service specifies a target port, we have to use this instead of the service port, because they can differ. When the target port is a number we can directly use them and in case of a string we have to find the port number first.

Fixes #179.