### PR TITLE
Several small fixes and improvements

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config">
 
@@ -49,6 +50,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- Camera, Photos, input file -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <!-- Network API -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -75,6 +75,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -86,14 +86,14 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location
       </IonHeader>
       <IonContent>
         <IonList>
-          {IS_INCLUSTER || (context.clusters && Object.keys(context.clusters).length === 1) ? null : <Clusters />}
+          {context.clusters && Object.keys(context.clusters).length <= 1 ? null : <Clusters />}
 
           <Sections sections={sections} isMenu={true} />
 
           <IonListHeader mode="md">
             <IonLabel>Settings</IonLabel>
           </IonListHeader>
-          {IS_INCLUSTER ? null : (
+          {IS_INCLUSTER && context.clusters && Object.keys(context.clusters).length <= 1 ? null : (
             <IonMenuToggle autoHide={false}>
               <IonItem routerLink="/settings/clusters" routerDirection="root">
                 <IonAvatar slot="start">

--- a/src/components/plugins/prometheus/Dashboard.tsx
+++ b/src/components/plugins/prometheus/Dashboard.tsx
@@ -149,6 +149,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                         <IonItem>
                           <IonLabel>{variable}</IonLabel>
                           <IonSelect
+                            interface="popover"
                             value={selectedVariables[variable]}
                             onIonChange={(e) =>
                               setSelectedVariables((prevState) => ({ ...prevState, [variable]: e.detail.value }))
@@ -168,7 +169,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                 <IonCol>
                   <IonItem>
                     <IonLabel>Time</IonLabel>
-                    <IonSelect value={timeDiff} onIonChange={(e) => setTimeDiff(e.detail.value)}>
+                    <IonSelect interface="popover" value={timeDiff} onIonChange={(e) => setTimeDiff(e.detail.value)}>
                       <IonSelectOption value={300}>Last 5 minutes</IonSelectOption>
                       <IonSelectOption value={900}>Last 15 minutes</IonSelectOption>
                       <IonSelectOption value={1800}>Last 30 minutes</IonSelectOption>

--- a/src/components/resources/misc/details/ViewItem.tsx
+++ b/src/components/resources/misc/details/ViewItem.tsx
@@ -1,3 +1,4 @@
+import { Plugins, FilesystemDirectory, FilesystemEncoding } from '@capacitor/core';
 import {
   IonButton,
   IonButtons,
@@ -10,6 +11,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
+  isPlatform,
 } from '@ionic/react';
 import { close, documentText } from 'ionicons/icons';
 import yaml from 'js-yaml';
@@ -17,6 +19,8 @@ import React, { useState } from 'react';
 
 import { TActivator } from '../../../../declarations';
 import Editor from '../../../misc/Editor';
+
+const { Filesystem } = Plugins;
 
 interface IViewYAMLItemProps {
   activator: TActivator;
@@ -26,6 +30,26 @@ interface IViewYAMLItemProps {
 
 const ViewYAMLItem: React.FunctionComponent<IViewYAMLItemProps> = ({ activator, item }: IViewYAMLItemProps) => {
   const [showModal, setShowModal] = useState<boolean>(false);
+
+  const handleExport = async () => {
+    if (isPlatform('hybrid')) {
+      try {
+        await Filesystem.writeFile({
+          path: `${item.metadata ? item.metadata.name : 'export'}.yaml`,
+          data: yaml.safeDump(item),
+          directory: FilesystemDirectory.Documents,
+          encoding: FilesystemEncoding.UTF8,
+        });
+      } catch (err) {}
+    } else {
+      const element = document.createElement('a');
+      const file = new Blob([yaml.safeDump(item)], { type: 'text/yaml' });
+      element.href = URL.createObjectURL(file);
+      element.download = `${item.metadata ? item.metadata.name : 'export'}.yaml`;
+      document.body.appendChild(element);
+      element.click();
+    }
+  };
 
   return (
     <React.Fragment>
@@ -58,6 +82,9 @@ const ViewYAMLItem: React.FunctionComponent<IViewYAMLItemProps> = ({ activator, 
               </IonButton>
             </IonButtons>
             <IonTitle>{item.metadata ? item.metadata.name : ''}</IonTitle>
+            <IonButtons slot="primary">
+              <IonButton onClick={() => handleExport()}>Export</IonButton>
+            </IonButtons>
           </IonToolbar>
         </IonHeader>
         <IonContent>

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -192,14 +192,28 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
       {context.settings.prometheusEnabled ? (
         <Dashboard
           title="Metrics"
-          variables={{
-            Container: [item.spec ? item.spec.containers.map((container) => container.name).join('|') : ''].concat(
-              item.spec && item.spec.containers ? item.spec.containers.map((container) => container.name) : [],
-            ),
-          }}
-          initialVariables={{
-            Container: item.spec ? item.spec.containers.map((container) => container.name).join('|') : '',
-          }}
+          variables={
+            item.spec
+              ? {
+                  Container:
+                    item.spec.containers.length === 1
+                      ? item.spec.containers.map((container) => container.name)
+                      : [item.spec.containers.map((container) => container.name).join('|')].concat(
+                          item.spec.containers.map((container) => container.name),
+                        ),
+                }
+              : undefined
+          }
+          initialVariables={
+            item.spec
+              ? {
+                  Container:
+                    item.spec.containers.length === 1
+                      ? item.spec.containers.map((container) => container.name)[0]
+                      : item.spec.containers.map((container) => container.name).join('|'),
+                }
+              : undefined
+          }
           charts={[
             {
               title: 'Memory Usage (in MiB)',

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -193,7 +193,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
         <Dashboard
           title="Metrics"
           variables={
-            item.spec
+            item.spec && item.spec.containers
               ? {
                   Container:
                     item.spec.containers.length === 1
@@ -205,7 +205,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               : undefined
           }
           initialVariables={
-            item.spec
+            item.spec && item.spec.containers
               ? {
                   Container:
                     item.spec.containers.length === 1


### PR DESCRIPTION
- **Disable active sessions request for incluster mode:** Port forwarding isn't supported when kubenav is deployed in a Kubernetes cluster, so that we can disable the polling request for active port forwarding sessions, which is executed every 10 seconds.
- **Hide clusters menu item:** Hide the clusters menu item to select the active cluster, when there is only one cluster configured.
- **Fix Prometheus plugin for pod metrics:** Do not show a container twice, when a pod only have one container in the container selection. Use a popover instead of an alert component to select a variable or the time range in the Prometheus dashboard.
- **Fix the selection of a pod in a list:** When a pod was selected in the list of pods (e.g. from a deployment) kubenav crashed, because the properties of the pod were not checked properly.
- **Allow exporting of manifest files:** It is now possible to export the manifest file of a resource within the YAML view. Closes #177.