### PR TITLE
Support automatic theme changing

### DIFF
--- a/src/components/misc/Editor.tsx
+++ b/src/components/misc/Editor.tsx
@@ -8,6 +8,7 @@ import 'ace-builds/src-noconflict/theme-nord_dark';
 
 import { IContext } from '../../declarations';
 import { AppContext } from '../../utils/context';
+import { isDarkMode } from '../../utils/helpers';
 
 interface IEditorProps {
   onChange?: (newValue: string) => void;
@@ -47,7 +48,7 @@ const Editor: React.FunctionComponent<IEditorProps> = ({
       }}
       showPrintMargin={false}
       tabSize={2}
-      theme={context.settings.darkMode ? 'nord_dark' : 'github'}
+      theme={isDarkMode(context.settings.theme) ? 'nord_dark' : 'github'}
       value={value}
       width="100%"
     />

--- a/src/components/plugins/prometheus/ChartDetailsArea.tsx
+++ b/src/components/plugins/prometheus/ChartDetailsArea.tsx
@@ -4,6 +4,7 @@ import { Area, AreaChart, Legend, ResponsiveContainer, XAxis, YAxis } from 'rech
 
 import { IContext } from '../../../declarations';
 import { AppContext } from '../../../utils/context';
+import { isDarkMode } from '../../../utils/helpers';
 
 const colorsLight = [
   '#10dc60',
@@ -103,8 +104,8 @@ const ChartDetailsArea: React.FunctionComponent<IChartDetailsAreaProps> = ({
                 dataKey="value"
                 data={serie.data}
                 name={serie.name}
-                stroke={context.settings.darkMode ? colorsDark[index] : colorsLight[index]}
-                fill={context.settings.darkMode ? colorsDark[index] : colorsLight[index]}
+                stroke={isDarkMode(context.settings.theme) ? colorsDark[index] : colorsLight[index]}
+                fill={isDarkMode(context.settings.theme) ? colorsDark[index] : colorsLight[index]}
                 fillOpacity={0.2}
               />
             ))}

--- a/src/components/plugins/terminal/helpers.ts
+++ b/src/components/plugins/terminal/helpers.ts
@@ -4,6 +4,7 @@ import { Terminal } from 'xterm';
 import { IContext, ITerminalContext } from '../../../declarations';
 import { kubernetesRequest, kubernetesExecRequest, kubernetesLogsRequest, sshRequest } from '../../../utils/api';
 import { INCLUSTER_URL, LOG_TERMINAL_OPTIONS, SHELL_TERMINAL_OPTIONS } from '../../../utils/constants';
+import { isDarkMode } from '../../../utils/helpers';
 
 export const addShell = async (
   context: IContext,
@@ -16,7 +17,7 @@ export const addShell = async (
     SHELL_TERMINAL_OPTIONS(
       context.settings.terminalFontSize,
       context.settings.terminalScrollback,
-      context.settings.darkMode,
+      isDarkMode(context.settings.theme),
     ),
   );
 
@@ -92,7 +93,7 @@ export const addLogs = async (
     LOG_TERMINAL_OPTIONS(
       context.settings.terminalFontSize,
       context.settings.terminalScrollback,
-      context.settings.darkMode,
+      isDarkMode(context.settings.theme),
     ),
   );
 
@@ -178,7 +179,7 @@ export const addSSH = async (
     SHELL_TERMINAL_OPTIONS(
       context.settings.terminalFontSize,
       context.settings.terminalScrollback,
-      context.settings.darkMode,
+      isDarkMode(context.settings.theme),
     ),
   );
 

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -11,6 +11,8 @@ import {
   IonMenuButton,
   IonPage,
   IonRange,
+  IonSelect,
+  IonSelectOption,
   IonTextarea,
   IonTitle,
   IonToggle,
@@ -41,6 +43,10 @@ const GeneralPage: React.FunctionComponent = () => {
     context.editSettings({ ...context.settings, [event.target.name]: event.detail.value });
   };
 
+  const handleSelect = (event) => {
+    context.editSettings({ ...context.settings, [event.target.name]: event.detail.value });
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -58,8 +64,12 @@ const GeneralPage: React.FunctionComponent = () => {
               <IonLabel>General</IonLabel>
             </IonItemDivider>
             <IonItem>
-              <IonLabel>Dark Mode</IonLabel>
-              <IonToggle name="darkMode" checked={context.settings.darkMode} onIonChange={handleToggleChange} />
+              <IonLabel>Theme</IonLabel>
+              <IonSelect value={context.settings.theme} name="theme" onIonChange={handleSelect} interface="popover">
+                <IonSelectOption value="system">System</IonSelectOption>
+                <IonSelectOption value="dark">Dark</IonSelectOption>
+                <IonSelectOption value="light">Light</IonSelectOption>
+              </IonSelect>
             </IonItem>
             <IonItem>
               <IonLabel className="label-for-range" position="stacked">

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -28,7 +28,7 @@ export interface IAppSections {
 }
 
 export interface IAppSettings {
-  darkMode: boolean;
+  theme: TTheme;
   timeout: number;
   sshKey: string;
   sshPort: string;
@@ -348,3 +348,5 @@ export type TActivator = 'block-button' | 'button' | 'item' | 'item-option';
 export type TAuthProvider = '' | 'aws' | 'azure' | 'google' | 'kubeconfig' | 'oidc';
 
 export type TSyncType = 'context' | 'namespace';
+
+export type TTheme = 'system' | 'dark' | 'light';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,7 +8,7 @@ export const IS_INCLUSTER = process.env.REACT_APP_INCLUSTER === 'true' ? true : 
 export const VERSION = process.env.REACT_APP_VERSION;
 
 export const DEFAULT_SETTINGS: IAppSettings = {
-  darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+  theme: 'system',
   timeout: 60,
   sshKey: '',
   sshPort: '22',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { V1LabelSelector, V1Subject } from '@kubernetes/client-node';
 
+import { TTheme } from '../declarations';
+
 // capitalize uppercase the first letter of a string
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const capitalize = (s: any) => {
@@ -89,6 +91,17 @@ export const isBase64 = (str: string): boolean => {
   return (
     firstPaddingChar === -1 || firstPaddingChar === len - 1 || (firstPaddingChar === len - 2 && str[len - 1] === '=')
   );
+};
+
+// isDarkMode checks the given theme value and returns a boolean value, which indicates if the dark mode should be used.
+export const isDarkMode = (theme: TTheme): boolean => {
+  if (theme === 'dark') {
+    return true;
+  } else if (theme === 'light') {
+    return false;
+  } else {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
 };
 
 // isJSON checks a given string if it is valid JSON.

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -127,8 +127,9 @@ export const readSettings = (): IAppSettings => {
 
   if (settingsFromStorage) {
     const settings = JSON.parse(settingsFromStorage);
+
     return {
-      darkMode: settings.hasOwnProperty('darkMode') ? settings.darkMode : DEFAULT_SETTINGS.darkMode,
+      theme: settings.theme ? settings.theme : DEFAULT_SETTINGS.theme,
       timeout: settings.timeout ? settings.timeout : DEFAULT_SETTINGS.timeout,
       sshKey: settings.sshKey ? settings.sshKey : DEFAULT_SETTINGS.sshKey,
       sshPort: settings.sshPort ? settings.sshPort : DEFAULT_SETTINGS.sshPort,


### PR DESCRIPTION
- This adds a new setting named theme. The user can choose between `system`, `dark` and `light`. If system is chosen, the theme of the app automatic changes, when the system theme is changed.
- The old dark mode setting was removed.
- This doesn't fix the problem that a theme change (manual and automatic) isn't applied to charts, terminals and editor windows.

Closes #167.