### PR TITLE
Support Prometheus metrics for several resources

### DIFF
--- a/pkg/handlers/plugins/prometheus/prometheus.go
+++ b/pkg/handlers/plugins/prometheus/prometheus.go
@@ -194,10 +194,25 @@ func RunQueries(address string, timeout time.Duration, requestData map[string]in
 				}
 
 				for _, stream := range data {
-					results = append(results, Result{
-						Label:  query.Label,
-						Values: stream.Values,
-					})
+					var labels map[string]string
+					labels = make(map[string]string)
+
+					for key, value := range stream.Metric {
+						labels[string(key)] = string(value)
+					}
+
+					label, err := queryInterpolation(query.Label, labels)
+					if err != nil {
+						results = append(results, Result{
+							Label:  query.Label,
+							Values: stream.Values,
+						})
+					} else {
+						results = append(results, Result{
+							Label:  label,
+							Values: stream.Values,
+						})
+					}
 				}
 			}
 

--- a/src/components/plugins/prometheus/ChartDetailsArea.tsx
+++ b/src/components/plugins/prometheus/ChartDetailsArea.tsx
@@ -36,6 +36,11 @@ const colorsDark = [
   '#477be8',
 ];
 
+const getColor = (index: number, darkMode: boolean): string => {
+  const colors = darkMode ? colorsDark : colorsLight;
+  return colors[index % colors.length];
+};
+
 export interface IPrometheusResult {
   label: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,8 +109,8 @@ const ChartDetailsArea: React.FunctionComponent<IChartDetailsAreaProps> = ({
                 dataKey="value"
                 data={serie.data}
                 name={serie.name}
-                stroke={isDarkMode(context.settings.theme) ? colorsDark[index] : colorsLight[index]}
-                fill={isDarkMode(context.settings.theme) ? colorsDark[index] : colorsLight[index]}
+                stroke={getColor(index, isDarkMode(context.settings.theme))}
+                fill={getColor(index, isDarkMode(context.settings.theme))}
                 fillOpacity={0.2}
               />
             ))}

--- a/src/components/resources/cluster/nodes/Metrics.tsx
+++ b/src/components/resources/cluster/nodes/Metrics.tsx
@@ -1,0 +1,29 @@
+import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonList, IonRow } from '@ionic/react';
+import React from 'react';
+
+import MetricsNodeDetails from './MetricsNodeDetails';
+
+interface IMetricsProps {
+  name: string;
+}
+
+const Metrics: React.FunctionComponent<IMetricsProps> = ({ name }: IMetricsProps) => {
+  return (
+    <IonRow>
+      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="6" sizeXl="12">
+        <IonCard>
+          <IonCardHeader>
+            <IonCardTitle>More Metrics</IonCardTitle>
+          </IonCardHeader>
+          <IonCardContent>
+            <IonList>
+              <MetricsNodeDetails name={name} />
+            </IonList>
+          </IonCardContent>
+        </IonCard>
+      </IonCol>
+    </IonRow>
+  );
+};
+
+export default Metrics;

--- a/src/components/resources/cluster/nodes/MetricsNodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/MetricsNodeDetails.tsx
@@ -1,0 +1,220 @@
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { close } from 'ionicons/icons';
+import React, { useState } from 'react';
+
+import Dashboard from '../../../plugins/prometheus/Dashboard';
+
+interface IMetricsNodeDetailsProps {
+  name: string;
+}
+
+const MetricsNodeDetails: React.FunctionComponent<IMetricsNodeDetailsProps> = ({ name }: IMetricsNodeDetailsProps) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <React.Fragment>
+      <IonItem button={true} onClick={() => setShowModal(true)}>
+        <IonLabel>
+          <h2>Node Details</h2>
+        </IonLabel>
+      </IonItem>
+
+      <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
+        <IonHeader>
+          <IonToolbar>
+            <IonButtons slot="start">
+              <IonButton onClick={() => setShowModal(false)}>
+                <IonIcon slot="icon-only" icon={close} />
+              </IonButton>
+            </IonButtons>
+            <IonTitle>Node Details</IonTitle>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent>
+          <Dashboard
+            title="Node Details"
+            charts={[
+              {
+                title: 'System Load',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: 'Load 1m',
+                    query: `max(node_load1{job="node-exporter", instance="${name}"})`,
+                  },
+                  {
+                    label: 'Load 5m',
+                    query: `max(node_load5{job="node-exporter", instance="${name}"})`,
+                  },
+                  {
+                    label: 'Load 15m',
+                    query: `max(node_load15{job="node-exporter", instance="${name}"})`,
+                  },
+                  {
+                    label: 'Cores',
+                    query: `count(count(node_cpu_seconds_total{job="node-exporter", instance="${name}"}) by (cpu))`,
+                  },
+                ],
+              },
+              {
+                title: 'Usage per Core',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: '{{ .cpu }}',
+                    query: `sum by (cpu) (irate(node_cpu_seconds_total{job="node-exporter", mode!="idle", instance="${name}"}[5m]))`,
+                  },
+                ],
+              },
+              {
+                title: 'CPU Usage (in Percent)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: 'Usage',
+                    query: `max (sum by (cpu) (irate(node_cpu_seconds_total{job="node-exporter", mode!="idle", instance="${name}"}[2m])) ) * 100`,
+                  },
+                ],
+              },
+              {
+                title: 'Memory Usage (in GiB)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: 'Used',
+                    query: `max(node_memory_MemTotal_bytes{job="node-exporter", instance="${name}"} - node_memory_MemFree_bytes{job="node-exporter", instance="${name}"} - node_memory_Buffers_bytes{job="node-exporter", instance="${name}"} - node_memory_Cached_bytes{job="node-exporter", instance="${name}"}) / 1024 / 1024 / 1024`,
+                  },
+                  {
+                    label: 'Buffers',
+                    query: `max(node_memory_Buffers_bytes{job="node-exporter", instance="${name}"}) / 1024 / 1024 / 1024`,
+                  },
+                  {
+                    label: 'Cached',
+                    query: `max(node_memory_Cached_bytes{job="node-exporter", instance="${name}"}) / 1024 / 1024 / 1024`,
+                  },
+                  {
+                    label: 'Free',
+                    query: `max(node_memory_MemFree_bytes{job="node-exporter", instance="${name}"}) / 1024 / 1024 / 1024`,
+                  },
+                ],
+              },
+              {
+                title: 'Network Received (in MiB)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: '{{ .device }}',
+                    query: `rate(node_network_receive_bytes_total{job="node-exporter", instance="${name}", device!~"lo"}[5m]) / 1024 / 1024`,
+                  },
+                ],
+              },
+              {
+                title: 'Network Transmitted (in MiB)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: '{{ .device }}',
+                    query: `rate(node_network_transmit_bytes_total{job="node-exporter", instance="${name}", device!~"lo"}[5m]) / 1024 / 1024`,
+                  },
+                ],
+              },
+              {
+                title: 'Disk I/O (in MiB)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: 'Read',
+                    query: `max(rate(node_disk_read_bytes_total{job="node-exporter", instance="${name}"}[2m])) / 1024 / 1024`,
+                  },
+                  {
+                    label: 'Write',
+                    query: `max(rate(node_disk_written_bytes_total{job="node-exporter", instance="${name}"}[2m])) / 1024 / 1024`,
+                  },
+                ],
+              },
+              {
+                title: 'Disk Space Usage (in Percent)',
+                size: {
+                  xs: '12',
+                  sm: '12',
+                  md: '12',
+                  lg: '12',
+                  xl: '6',
+                },
+                type: 'area',
+                queries: [
+                  {
+                    label: '{{ .device }}',
+                    query: `max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs", instance="${name}"} - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs", instance="${name}"}) / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs", instance="${name}"}) * 100`,
+                  },
+                ],
+              },
+            ]}
+          />
+        </IonContent>
+      </IonModal>
+    </React.Fragment>
+  );
+};
+
+export default MetricsNodeDetails;

--- a/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeDetails.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumes/PersistentVolumeDetails.tsx
@@ -1,8 +1,11 @@
 import { IonGrid, IonRow } from '@ionic/react';
 import { V1PersistentVolume } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
@@ -19,6 +22,8 @@ const PersistentVolumeDetails: React.FunctionComponent<IPersistentVolumeDetailsP
   item,
   type,
 }: IPersistentVolumeDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   return (
     <IonGrid>
       <IonRow>
@@ -65,6 +70,33 @@ const PersistentVolumeDetails: React.FunctionComponent<IPersistentVolumeDetailsP
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Capacity (in GiB)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Capacity',
+                  query: `kube_persistentvolume_capacity_bytes{persistentvolume="${
+                    item.metadata ? item.metadata.name : ''
+                  }"} / 1024 / 1024 / 1024`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );

--- a/src/components/resources/configAndStorage/podDisruptionBudgets/PodDisruptionBudgetDetails.tsx
+++ b/src/components/resources/configAndStorage/podDisruptionBudgets/PodDisruptionBudgetDetails.tsx
@@ -1,9 +1,12 @@
 import { IonChip, IonGrid, IonLabel, IonRow } from '@ionic/react';
 import { V1beta1PodDisruptionBudget } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
 import { labelSelector } from '../../../../utils/helpers';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
@@ -20,6 +23,8 @@ const PodDisruptionBudgetDetails: React.FunctionComponent<IPodDisruptionBudgetDe
   item,
   type,
 }: IPodDisruptionBudgetDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   return (
     <IonGrid>
       <IonRow>
@@ -95,6 +100,53 @@ const PodDisruptionBudgetDetails: React.FunctionComponent<IPodDisruptionBudgetDe
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Pods',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Desired',
+                  query: `kube_poddisruptionbudget_status_desired_healthy{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", poddisruptionbudget="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Current',
+                  query: `kube_poddisruptionbudget_status_current_healthy{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", poddisruptionbudget="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+
+                {
+                  label: 'Allowed Disruptions',
+                  query: `kube_poddisruptionbudget_status_pod_disruptions_allowed{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", poddisruptionbudget="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+
+                {
+                  label: 'Expected',
+                  query: `kube_poddisruptionbudget_status_expected_pods{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", poddisruptionbudget="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );

--- a/src/components/resources/discoveryAndLoadbalancing/endpoints/EndpointDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/endpoints/EndpointDetails.tsx
@@ -19,9 +19,12 @@ import {
   V1EndpointSubset,
   V1ObjectReference,
 } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import Metadata from '../../misc/template/Metadata';
 
 interface IEndpointDetailsProps extends RouteComponentProps {
@@ -31,6 +34,8 @@ interface IEndpointDetailsProps extends RouteComponentProps {
 }
 
 const EndpointDetails: React.FunctionComponent<IEndpointDetailsProps> = ({ item, type }: IEndpointDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   const itemLink = (ref: V1ObjectReference | undefined): string => {
     if (ref && ref.kind && ref.kind.toLowerCase() === 'pod') {
       return `/resources/workloads/pods/${ref.namespace ? ref.namespace : ''}/${ref.name ? ref.name : ''}`;
@@ -97,6 +102,39 @@ const EndpointDetails: React.FunctionComponent<IEndpointDetailsProps> = ({ item,
             );
           })}
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Addresses',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Available',
+                  query: `kube_endpoint_address_available{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", endpoint="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Not Ready',
+                  query: `kube_endpoint_address_not_ready{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", endpoint="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );

--- a/src/components/resources/discoveryAndLoadbalancing/horizontalpodautoscalers/HorizontalPodAutoscalerDetails.tsx
+++ b/src/components/resources/discoveryAndLoadbalancing/horizontalpodautoscalers/HorizontalPodAutoscalerDetails.tsx
@@ -20,9 +20,12 @@ import {
   V2beta1PodsMetricStatus,
   V2beta1ResourceMetricStatus,
 } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
 import Conditions from '../../misc/template/Conditions';
 import Configuration from '../../misc/template/Configuration';
@@ -165,6 +168,8 @@ const HorizontalPodAutoscalerDetails: React.FunctionComponent<IHorizontalPodAuto
   item,
   type,
 }: IHorizontalPodAutoscalerDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   return (
     <IonGrid>
       <IonRow>
@@ -230,6 +235,51 @@ const HorizontalPodAutoscalerDetails: React.FunctionComponent<IHorizontalPodAuto
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Replicas',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Desired',
+                  query: `kube_hpa_status_desired_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", hpa="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Current',
+                  query: `kube_hpa_status_current_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", hpa="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Min',
+                  query: `kube_hpa_spec_min_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", hpa="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Max',
+                  query: `kube_hpa_spec_max_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", hpa="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );

--- a/src/components/resources/workloads/daemonSets/DaemonSetDetails.tsx
+++ b/src/components/resources/workloads/daemonSets/DaemonSetDetails.tsx
@@ -1,9 +1,12 @@
 import { IonChip, IonGrid, IonLabel, IonRow } from '@ionic/react';
 import { V1DaemonSet, V1DaemonSetUpdateStrategy } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
 import { labelSelector } from '../../../../utils/helpers';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
@@ -17,6 +20,8 @@ interface IDaemonSetDetailsProps extends RouteComponentProps {
 }
 
 const DaemonSetDetails: React.FunctionComponent<IDaemonSetDetailsProps> = ({ item, type }: IDaemonSetDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   const updateStrategy = (strategy: V1DaemonSetUpdateStrategy): string => {
     if (strategy.rollingUpdate && strategy.rollingUpdate.maxUnavailable) {
       return `${strategy.type ? `${strategy.type}: ` : ''}Max Unavailable ${strategy.rollingUpdate.maxUnavailable}`;
@@ -103,6 +108,108 @@ const DaemonSetDetails: React.FunctionComponent<IDaemonSetDetailsProps> = ({ ite
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Number (Scheduled)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Desired',
+                  query: `kube_daemonset_status_desired_number_scheduled{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Current',
+                  query: `kube_daemonset_status_current_number_scheduled{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Misscheduled',
+                  query: `kube_daemonset_status_number_misscheduled{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+            {
+              title: 'Number (Ready)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '4',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Ready',
+                  query: `kube_daemonset_status_number_ready{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+            {
+              title: 'Number (Available)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '4',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Available',
+                  query: `kube_daemonset_status_number_available{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Unavailable',
+                  query: `kube_daemonset_status_number_unavailable{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+            {
+              title: 'Number (Updated)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '4',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Updated',
+                  query: `kube_daemonset_updated_number_scheduled{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", daemonset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );

--- a/src/components/resources/workloads/replicaSets/ReplicaSetDetails.tsx
+++ b/src/components/resources/workloads/replicaSets/ReplicaSetDetails.tsx
@@ -1,9 +1,12 @@
 import { IonChip, IonGrid, IonLabel, IonRow } from '@ionic/react';
 import { V1ReplicaSet } from '@kubernetes/client-node';
-import React from 'react';
+import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import { IContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
 import { labelSelector } from '../../../../utils/helpers';
+import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
 import Conditions from '../../misc/template/Conditions';
 import Configuration from '../../misc/template/Configuration';
@@ -21,6 +24,8 @@ const ReplicaSetDetails: React.FunctionComponent<IReplicaSetDetailsProps> = ({
   item,
   type,
 }: IReplicaSetDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   return (
     <IonGrid>
       <IonRow>
@@ -86,6 +91,58 @@ const ReplicaSetDetails: React.FunctionComponent<IReplicaSetDetailsProps> = ({
             selector={`fieldSelector=involvedObject.name=${item.metadata.name}`}
           />
         </IonRow>
+      ) : null}
+
+      {context.settings.prometheusEnabled ? (
+        <Dashboard
+          title="Metrics"
+          charts={[
+            {
+              title: 'Replicas',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Desired',
+                  query: `kube_replicaset_spec_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", replicaset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+                {
+                  label: 'Current',
+                  query: `kube_replicaset_status_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", replicaset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+            {
+              title: 'Replicas (Ready)',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '12',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Ready',
+                  query: `kube_replicaset_status_ready_replicas{namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", replicaset="${item.metadata ? item.metadata.name : ''}"}`,
+                },
+              ],
+            },
+          ]}
+        />
       ) : null}
     </IonGrid>
   );


### PR DESCRIPTION
We are adding support for Prometheus metrics for several resource. We are now supporting Deployments, StatefulSets, ReplicaSets, DaemonSets, Namespaces and Nodes.

- **DaemonSets:** Number of scheduled, ready, available and updated Pods.
- **Deployments:** Number of replicas, available and updated replicas.
- **ReplicaSets:** Number of replicas and ready replicas.
- **StatefulSets:** Number of replicas, ready and updated replicas.
- **Namespaces:** CPU and Memory usage of all Pods for the selected Namespace.
- **Nodes:** CPU, Memory and Pod usage of the selected Node. The nodes page also contains a detailed metrics section with metrics for Load, CPU, Memory, Disk and Network.

**Misc:**

- We are also adding support to use returned labels from the returned query as label in the chart.
- Fix a bug with the used colors in the chart, when the number of series is larger then the number of colors.