### PR TITLE
Add tooltip for container resource usage

### DIFF
--- a/src/components/resources/workloads/pods/Container.tsx
+++ b/src/components/resources/workloads/pods/Container.tsx
@@ -83,36 +83,54 @@ const Container: React.FunctionComponent<IContainerProps> = ({
           <td>{status && status.restartCount ? status.restartCount : 0}</td>
           <td>{status ? getState(status) : ''}</td>
           <td className="center">
-            {metrics && metrics.usage && metrics.usage.hasOwnProperty('cpu')
-              ? formatResourceValue('cpu', metrics.usage['cpu'])
-              : '-'}
+            <div className="tooltip">
+              {metrics && metrics.usage && metrics.usage.hasOwnProperty('cpu')
+                ? formatResourceValue('cpu', metrics.usage['cpu'])
+                : '-'}
+              <span className="tooltiptext">CPU Usage</span>
+            </div>
           </td>
           <td className="center">
-            {container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu')
-              ? formatResourceValue('cpu', container.resources.requests['cpu'])
-              : '-'}
+            <div className="tooltip">
+              {container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu')
+                ? formatResourceValue('cpu', container.resources.requests['cpu'])
+                : '-'}
+              <span className="tooltiptext">CPU Request</span>
+            </div>
           </td>
           <td className="center">
-            {container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu')
-              ? formatResourceValue('cpu', container.resources.limits['cpu'])
-              : '-'}
+            <div className="tooltip">
+              {container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu')
+                ? formatResourceValue('cpu', container.resources.limits['cpu'])
+                : '-'}
+              <span className="tooltiptext">CPU Limit</span>
+            </div>
           </td>
           <td className="center">
-            {metrics && metrics.usage && metrics.usage.hasOwnProperty('memory')
-              ? formatResourceValue('memory', metrics.usage['memory'])
-              : '-'}
+            <div className="tooltip">
+              {metrics && metrics.usage && metrics.usage.hasOwnProperty('memory')
+                ? formatResourceValue('memory', metrics.usage['memory'])
+                : '-'}
+              <span className="tooltiptext">Memory Usage</span>
+            </div>
           </td>
           <td className="center">
-            {container.resources &&
-            container.resources.requests &&
-            container.resources.requests.hasOwnProperty('memory')
-              ? formatResourceValue('memory', container.resources.requests['memory'])
-              : '-'}
+            <div className="tooltip">
+              {container.resources &&
+              container.resources.requests &&
+              container.resources.requests.hasOwnProperty('memory')
+                ? formatResourceValue('memory', container.resources.requests['memory'])
+                : '-'}
+              <span className="tooltiptext">Memory Request</span>
+            </div>
           </td>
           <td className="center">
-            {container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory')
-              ? formatResourceValue('memory', container.resources.limits['memory'])
-              : '-'}
+            <div className="tooltip">
+              {container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory')
+                ? formatResourceValue('memory', container.resources.limits['memory'])
+                : '-'}
+              <span className="tooltiptext">Memory Limit</span>
+            </div>
           </td>
           <td className="center">
             {logs && name && namespace ? (

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -183,3 +183,29 @@ ion-avatar {
 .label-for-range {
   min-height: 18px;
 }
+
+/* Tooltip
+   The tooltip css classes can be used to show additional information via tooltip, when a user hovers a component on
+   desktop. We are using the same colors as the IonToast component uses as background color and color. */
+.tooltip {
+  position: relative;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: var(--ion-color-step-800, #333333);
+  color: var(--ion-color-step-50, #f2f2f2);
+  text-align: center;
+  border-radius: 4px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -60px;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}


### PR DESCRIPTION
The container resource usage is shows three values for CPU and Memory. To make the meaning of each value more visible we are adding a tooltip which shows if the value if for the current usage, the request or the limit.

Closes #199.