### PR TITLE
Fix error while scale replicas

### DIFF
--- a/src/components/resources/misc/details/ScaleItem.tsx
+++ b/src/components/resources/misc/details/ScaleItem.tsx
@@ -81,7 +81,7 @@ const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, 
         ]}
         buttons={[
           { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
-          { text: 'Scale', handler: (data) => handleScale(data.replicas) },
+          { text: 'Scale', handler: (data) => handleScale(data.replicas ? data.replicas : 0) },
         ]}
       />
     </React.Fragment>


### PR DESCRIPTION
In some cases the scaling of the replicas of a Deployment, StatefulSet or a ReplicaSet throws an error, because the number of replicas which is returned from the IonAlert was an empty string instead of a number. This is now fixed, by using 0 instead of an empty string.

Fixes #207.