### PR TITLE
Fix terminal window resizing

### DIFF
--- a/src/components/plugins/terminal/Shell.tsx
+++ b/src/components/plugins/terminal/Shell.tsx
@@ -108,7 +108,9 @@ const Shell: React.FunctionComponent<IShellProps> = ({ showSearch, showSelect, t
   }, [showSelect]);
 
   const updateTerminalSize = () => {
-    fitAddon.fit();
+    setTimeout(() => {
+      fitAddon.fit();
+    }, 100);
   };
 
   const search = (event) => {


### PR DESCRIPTION
To make the resizing work on mobile, we have to add a very short timeout before calling the `fitAddon.fit()` function, which handles the resizing of the terminal.

Fixes #202.