### PR TITLE
Close item options and popovers after selection

### DIFF
--- a/src/components/resources/cluster/nodes/AddSSH.tsx
+++ b/src/components/resources/cluster/nodes/AddSSH.tsx
@@ -2,10 +2,10 @@ import { IonChip, IonIcon, IonLabel } from '@ionic/react';
 import { terminal } from 'ionicons/icons';
 import React, { useContext } from 'react';
 
-import { IContext, ITerminalContext } from '../../../declarations';
-import { AppContext } from '../../../utils/context';
-import { TerminalContext } from '../../../utils/terminal';
-import { addSSH } from './helpers';
+import { IContext, ITerminalContext } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
+import { TerminalContext } from '../../../../utils/terminal';
+import { addSSH } from '../../../plugins/terminal/helpers';
 
 interface IAddSSHProps {
   type: string;

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -11,7 +11,6 @@ import { formatResourceValue } from '../../../../utils/helpers';
 import Dashboard from '../../../plugins/prometheus/Dashboard';
 import DashboardItem from '../../../plugins/prometheus/DashboardItem';
 import DashboardList from '../../../plugins/prometheus/DashboardList';
-import AddSSH from '../../../plugins/terminal/AddSSH';
 import IonCardEqualHeight from '../../../misc/IonCardEqualHeight';
 import List from '../../misc/list/List';
 import Conditions from '../../misc/template/Conditions';
@@ -19,6 +18,7 @@ import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';
 import Row from '../../misc/template/Row';
 import Status from '../../misc/template/Status';
+import AddSSH from './AddSSH';
 import { getStatus } from './nodeHelpers';
 
 interface INodeDetailsProps extends RouteComponentProps {

--- a/src/components/resources/misc/details/DeleteItem.tsx
+++ b/src/components/resources/misc/details/DeleteItem.tsx
@@ -6,17 +6,50 @@ import { IContext, TActivator } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 
-interface IDeleteItemProps {
+interface IDeleteItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
+}
+
+export const DeleteItemActivator: React.FunctionComponent<IDeleteItemActivatorProps> = ({
+  activator,
+  onClick,
+}: IDeleteItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="danger" onClick={onClick}>
+        <IonIcon slot="start" icon={trash} />
+        Delete
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={trash} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={trash} />
+        <IonLabel>Delete</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface IDeleteItemProps {
+  show: boolean;
+  hide: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any;
   url: string;
+  closeAction?: () => void;
 }
 
-const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ activator, item, url }: IDeleteItemProps) => {
+const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ show, hide, item, url }: IDeleteItemProps) => {
   const context = useContext<IContext>(AppContext);
 
-  const [showAlert, setShowAlert] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const handleDelete = async () => {
@@ -29,26 +62,6 @@ const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ activator, item
 
   return (
     <React.Fragment>
-      {activator === 'item-option' ? (
-        <IonItemOption color="danger" onClick={() => setShowAlert(true)}>
-          <IonIcon slot="start" icon={trash} />
-          Delete
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton onClick={() => setShowAlert(true)}>
-          <IonIcon slot="icon-only" icon={trash} />
-        </IonButton>
-      ) : null}
-
-      {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
-          <IonIcon slot="end" color="primary" icon={trash} />
-          <IonLabel>Delete</IonLabel>
-        </IonItem>
-      ) : null}
-
       {error !== '' ? (
         <IonAlert
           isOpen={error !== ''}
@@ -60,14 +73,14 @@ const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ activator, item
       ) : null}
 
       <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
+        isOpen={show}
+        onDidDismiss={hide}
         header={item.metadata ? item.metadata.name : ''}
         message={`Do you really want to delete ${
           item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
         }${item.metadata ? item.metadata.name : ''}?`}
         buttons={[
-          { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
+          { text: 'Cancel', role: 'cancel', handler: hide },
           { text: 'Delete', cssClass: 'delete-button', handler: () => handleDelete() },
         ]}
       />

--- a/src/components/resources/misc/details/Details.tsx
+++ b/src/components/resources/misc/details/Details.tsx
@@ -3,14 +3,16 @@ import { ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
 import React, { useState } from 'react';
 
 import useWindowWidth from '../../../../utils/useWindowWidth';
-import DeleteItem from './DeleteItem';
-import EditItem from './EditItem';
-import LogsItem from './LogsItem';
-import RestartItem from './RestartItem';
-import ScaleItem from './ScaleItem';
-import ShellItem from './ShellItem';
-import SSHItem from './SSHItem';
-import ViewItem from './ViewItem';
+import DeleteItem, { DeleteItemActivator } from './DeleteItem';
+import EditItem, { EditItemActivator } from './EditItem';
+import LogsItem, { LogsItemActivator } from './LogsItem';
+import RestartItem, { RestartItemActivator } from './RestartItem';
+import ScaleItem, { ScaleItemActivator } from './ScaleItem';
+import ShellItem, { ShellItemActivator } from './ShellItem';
+import SSHItem, { SSHItemActivator } from './SSHItem';
+import ViewItem, { ViewItemActivator } from './ViewItem';
+
+type TShow = '' | 'delete' | 'edit' | 'logs' | 'restart' | 'scale' | 'shell' | 'ssh' | 'view';
 
 interface IDetailsProps {
   type: string;
@@ -20,9 +22,15 @@ interface IDetailsProps {
 }
 
 const Details: React.FunctionComponent<IDetailsProps> = ({ type, item, url }: IDetailsProps) => {
+  const [show, setShow] = useState<TShow>('');
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
   const width = useWindowWidth();
+
+  const showType = (type: TShow) => {
+    setShowPopover(false);
+    setShow(type);
+  };
 
   return (
     <React.Fragment>
@@ -32,23 +40,34 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ type, item, url }: ID
           type === 'statefulsets' ||
           type === 'replicationcontrollers' ||
           type === 'replicasets' ? (
-            <ScaleItem activator="item" item={item} url={url} />
+            <ScaleItemActivator activator="item" onClick={() => showType('scale')} />
           ) : null}
           {type === 'deployments' || type === 'statefulsets' || type === 'daemonsets' ? (
-            <RestartItem activator="item" item={item} url={url} />
+            <RestartItemActivator activator="item" onClick={() => showType('restart')} />
           ) : null}
           {(isPlatform('hybrid') || width < 992) && type === 'pods' ? (
-            <LogsItem activator="item" item={item} url={url} />
+            <LogsItemActivator activator="item" onClick={() => showType('logs')} />
           ) : null}
           {(isPlatform('hybrid') || width < 992) && type === 'pods' ? (
-            <ShellItem activator="item" item={item} url={url} />
+            <ShellItemActivator activator="item" onClick={() => showType('shell')} />
           ) : null}
-          {(isPlatform('hybrid') || width < 992) && type === 'nodes' ? <SSHItem activator="item" item={item} /> : null}
-          <ViewItem activator="item" item={item} />
-          <EditItem activator="item" item={item} url={url} />
-          <DeleteItem activator="item" item={item} url={url} />
+          {(isPlatform('hybrid') || width < 992) && type === 'nodes' ? (
+            <SSHItemActivator activator="item" onClick={() => showType('ssh')} item={item} />
+          ) : null}
+          <ViewItemActivator activator="item" onClick={() => showType('view')} />
+          <EditItemActivator activator="item" onClick={() => showType('edit')} />
+          <DeleteItemActivator activator="item" onClick={() => showType('delete')} />
         </IonList>
       </IonPopover>
+
+      <ScaleItem show={show === 'scale'} hide={() => setShow('')} item={item} url={url} />
+      <RestartItem show={show === 'restart'} hide={() => setShow('')} item={item} url={url} />
+      <LogsItem show={show === 'logs'} hide={() => setShow('')} item={item} url={url} />
+      <ShellItem show={show === 'shell'} hide={() => setShow('')} item={item} url={url} />
+      <SSHItem show={show === 'ssh'} hide={() => setShow('')} item={item} />
+      <ViewItem show={show === 'view'} hide={() => setShow('')} item={item} />
+      <EditItem show={show === 'edit'} hide={() => setShow('')} item={item} url={url} />
+      <DeleteItem show={show === 'delete'} hide={() => setShow('')} item={item} url={url} />
 
       <IonButton
         onClick={(e) => {

--- a/src/components/resources/misc/details/EditItem.tsx
+++ b/src/components/resources/misc/details/EditItem.tsx
@@ -22,17 +22,49 @@ import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 import Editor from '../../../misc/Editor';
 
-interface IEditItemProps {
+interface IEditItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
+}
+
+export const EditItemActivator: React.FunctionComponent<IEditItemActivatorProps> = ({
+  activator,
+  onClick,
+}: IEditItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="primary" onClick={onClick}>
+        <IonIcon slot="start" icon={create} />
+        Edit
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={create} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={create} />
+        <IonLabel>Edit</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface IEditItemProps {
+  show: boolean;
+  hide: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any;
   url: string;
 }
 
-const EditItem: React.FunctionComponent<IEditItemProps> = ({ activator, item, url }: IEditItemProps) => {
+const EditItem: React.FunctionComponent<IEditItemProps> = ({ show, hide, item, url }: IEditItemProps) => {
   const context = useContext<IContext>(AppContext);
 
-  const [showModal, setShowModal] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [value, setValue] = useState<string>(yaml.safeDump(item));
 
@@ -48,7 +80,7 @@ const EditItem: React.FunctionComponent<IEditItemProps> = ({ activator, item, ur
           context.settings,
           await context.kubernetesAuthWrapper(''),
         );
-        setShowModal(false);
+        hide();
       }
     } catch (err) {
       setError(err);
@@ -67,31 +99,11 @@ const EditItem: React.FunctionComponent<IEditItemProps> = ({ activator, item, ur
         />
       ) : null}
 
-      {activator === 'item-option' ? (
-        <IonItemOption color="primary" onClick={() => setShowModal(true)}>
-          <IonIcon slot="start" icon={create} />
-          Edit
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton onClick={() => setShowModal(true)}>
-          <IonIcon slot="icon-only" icon={create} />
-        </IonButton>
-      ) : null}
-
-      {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowModal(true)}>
-          <IonIcon slot="end" color="primary" icon={create} />
-          <IonLabel>Edit</IonLabel>
-        </IonItem>
-      ) : null}
-
-      <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
+      <IonModal isOpen={show} onDidDismiss={hide}>
         <IonHeader>
           <IonToolbar>
             <IonButtons slot="start">
-              <IonButton onClick={() => setShowModal(false)}>
+              <IonButton onClick={hide}>
                 <IonIcon slot="icon-only" icon={close} />
               </IonButton>
             </IonButtons>

--- a/src/components/resources/misc/details/ItemOptions.tsx
+++ b/src/components/resources/misc/details/ItemOptions.tsx
@@ -1,8 +1,10 @@
 import { IonItemOptions, IonItemSliding } from '@ionic/react';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useRef, useState } from 'react';
 
-import DeleteItem from './DeleteItem';
-import ViewItem from './ViewItem';
+import DeleteItem, { DeleteItemActivator } from './DeleteItem';
+import ViewItem, { ViewItemActivator } from './ViewItem';
+
+type TShow = '' | 'delete' | 'view';
 
 interface IItemOptionsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,13 +14,27 @@ interface IItemOptionsProps {
 }
 
 const ItemOptions: React.FunctionComponent<IItemOptionsProps> = ({ item, url, children }: IItemOptionsProps) => {
+  const itemSlidingRef = useRef<HTMLIonItemSlidingElement>(null);
+  const [show, setShow] = useState<TShow>('');
+
+  const showAction = (type: TShow) => {
+    if (itemSlidingRef && itemSlidingRef.current) {
+      itemSlidingRef.current.close();
+    }
+
+    setShow(type);
+  };
+
   return (
-    <IonItemSliding>
+    <IonItemSliding ref={itemSlidingRef}>
       {children}
 
       <IonItemOptions side="end">
-        <ViewItem activator="item-option" item={item} />
-        <DeleteItem activator="item-option" item={item} url={url} />
+        <ViewItemActivator activator="item-option" onClick={() => showAction('view')} />
+        <ViewItem show={show === 'view'} hide={() => setShow('')} item={item} />
+
+        <DeleteItemActivator activator="item-option" onClick={() => showAction('delete')} />
+        <DeleteItem show={show === 'delete'} hide={() => setShow('')} item={item} url={url} />
       </IonItemOptions>
     </IonItemSliding>
   );

--- a/src/components/resources/misc/details/RestartItem.tsx
+++ b/src/components/resources/misc/details/RestartItem.tsx
@@ -8,16 +8,48 @@ import { IContext, TActivator } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 
-interface IRestartItemProps {
+interface IRestartItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
+}
+
+export const RestartItemActivator: React.FunctionComponent<IRestartItemActivatorProps> = ({
+  activator,
+  onClick,
+}: IRestartItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="danger" onClick={onClick}>
+        <IonIcon slot="start" icon={reload} />
+        Restart
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={reload} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={reload} />
+        <IonLabel>Restart</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface IRestartItemProps {
+  show: boolean;
+  hide: () => void;
   item: V1DaemonSet | V1Deployment | V1StatefulSet;
   url: string;
 }
 
-const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, item, url }: IRestartItemProps) => {
+const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ show, hide, item, url }: IRestartItemProps) => {
   const context = useContext<IContext>(AppContext);
 
-  const [showAlert, setShowAlert] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const handleRestart = async () => {
@@ -48,26 +80,6 @@ const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, it
 
   return (
     <React.Fragment>
-      {activator === 'item-option' ? (
-        <IonItemOption color="danger" onClick={() => setShowAlert(true)}>
-          <IonIcon slot="start" icon={reload} />
-          Restart
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton onClick={() => setShowAlert(true)}>
-          <IonIcon slot="icon-only" icon={reload} />
-        </IonButton>
-      ) : null}
-
-      {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
-          <IonIcon slot="end" color="primary" icon={reload} />
-          <IonLabel>Restart</IonLabel>
-        </IonItem>
-      ) : null}
-
       {error !== '' ? (
         <IonAlert
           isOpen={error !== ''}
@@ -79,14 +91,14 @@ const RestartItem: React.FunctionComponent<IRestartItemProps> = ({ activator, it
       ) : null}
 
       <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
+        isOpen={show}
+        onDidDismiss={hide}
         header={item.metadata ? item.metadata.name : ''}
         message={`Do you really want to restart ${
           item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
         }${item.metadata ? item.metadata.name : ''}?`}
         buttons={[
-          { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
+          { text: 'Cancel', role: 'cancel', handler: hide },
           { text: 'Restart', handler: () => handleRestart() },
         ]}
       />

--- a/src/components/resources/misc/details/SSHItem.tsx
+++ b/src/components/resources/misc/details/SSHItem.tsx
@@ -1,76 +1,91 @@
 import { ActionSheetButton, IonActionSheet, IonIcon, IonItem, IonLabel } from '@ionic/react';
 import { V1Node } from '@kubernetes/client-node';
 import { terminal } from 'ionicons/icons';
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 
 import { IContext, ITerminalContext, TActivator } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
 import { TerminalContext } from '../../../../utils/terminal';
 import { addSSH } from '../../../plugins/terminal/helpers';
 
-interface ISSHItemProps {
+const generateButtons = (item: V1Node, context: IContext, terminalContext: ITerminalContext): ActionSheetButton[] => {
+  const buttons: ActionSheetButton[] = [];
+
+  if (item.status && item.status.addresses) {
+    for (const address of item.status.addresses) {
+      buttons.push({
+        text: address.address,
+        handler: () => {
+          addSSH(
+            context,
+            terminalContext,
+            item.metadata && item.metadata.name ? item.metadata.name : '',
+            address.address,
+          );
+        },
+      });
+    }
+  }
+
+  return buttons;
+};
+
+interface ISSHItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
   item: V1Node;
 }
 
-const SSHItem: React.FunctionComponent<ISSHItemProps> = ({ activator, item }: ISSHItemProps) => {
+export const SSHItemActivator: React.FunctionComponent<ISSHItemActivatorProps> = ({
+  activator,
+  onClick,
+  item,
+}: ISSHItemActivatorProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const [showActionSheet, setShowActionSheet] = useState<boolean>(false);
+  const buttons = generateButtons(item, context, terminalContext);
 
-  const generateButtons = (): ActionSheetButton[] => {
-    const buttons: ActionSheetButton[] = [];
+  if (activator === 'item') {
+    return (
+      <IonItem
+        button={true}
+        detail={false}
+        onClick={() =>
+          buttons.length === 1
+            ? addSSH(
+                context,
+                terminalContext,
+                item.metadata && item.metadata.name ? item.metadata.name : '',
+                buttons[0].text ? buttons[0].text : '',
+              )
+            : onClick()
+        }
+      >
+        <IonIcon slot="end" color="primary" icon={terminal} />
+        <IonLabel>SSH</IonLabel>
+      </IonItem>
+    );
+  } else {
+    return null;
+  }
+};
 
-    if (item.status && item.status.addresses) {
-      for (const address of item.status.addresses) {
-        buttons.push({
-          text: address.address,
-          handler: () => {
-            addSSH(
-              context,
-              terminalContext,
-              item.metadata && item.metadata.name ? item.metadata.name : '',
-              address.address,
-            );
-          },
-        });
-      }
-    }
+interface ISSHItemProps {
+  show: boolean;
+  hide: () => void;
+  item: V1Node;
+}
 
-    return buttons;
-  };
+const SSHItem: React.FunctionComponent<ISSHItemProps> = ({ show, hide, item }: ISSHItemProps) => {
+  const context = useContext<IContext>(AppContext);
+  const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
-  const buttons = generateButtons();
+  const buttons = generateButtons(item, context, terminalContext);
 
   return (
     <React.Fragment>
-      {activator === 'item' ? (
-        <IonItem
-          button={true}
-          detail={false}
-          onClick={() =>
-            buttons.length === 1
-              ? addSSH(
-                  context,
-                  terminalContext,
-                  item.metadata && item.metadata.name ? item.metadata.name : '',
-                  buttons[0].text ? buttons[0].text : '',
-                )
-              : setShowActionSheet(true)
-          }
-        >
-          <IonIcon slot="end" color="primary" icon={terminal} />
-          <IonLabel>SSH</IonLabel>
-        </IonItem>
-      ) : null}
-
-      <IonActionSheet
-        isOpen={showActionSheet}
-        onDidDismiss={() => setShowActionSheet(false)}
-        header="Select IP Address"
-        buttons={buttons}
-      />
+      <IonActionSheet isOpen={show} onDidDismiss={hide} header="Select IP Address" buttons={buttons} />
     </React.Fragment>
   );
 };

--- a/src/components/resources/misc/details/ScaleItem.tsx
+++ b/src/components/resources/misc/details/ScaleItem.tsx
@@ -7,16 +7,48 @@ import { IContext, TActivator } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 
-interface IScaleItemProps {
+interface IScaleItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
+}
+
+export const ScaleItemActivator: React.FunctionComponent<IScaleItemActivatorProps> = ({
+  activator,
+  onClick,
+}: IScaleItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="danger" onClick={onClick}>
+        <IonIcon slot="start" icon={copy} />
+        Scale
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={copy} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={copy} />
+        <IonLabel>Scale</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface IScaleItemProps {
+  show: boolean;
+  hide: () => void;
   item: V1Deployment | V1StatefulSet | V1ReplicaSet | V1ReplicationController;
   url: string;
 }
 
-const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, url }: IScaleItemProps) => {
+const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ show, hide, item, url }: IScaleItemProps) => {
   const context = useContext<IContext>(AppContext);
 
-  const [showAlert, setShowAlert] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const handleScale = async (replicas: number) => {
@@ -35,26 +67,6 @@ const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, 
 
   return (
     <React.Fragment>
-      {activator === 'item-option' ? (
-        <IonItemOption color="danger" onClick={() => setShowAlert(true)}>
-          <IonIcon slot="start" icon={copy} />
-          Scale
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton onClick={() => setShowAlert(true)}>
-          <IonIcon slot="icon-only" icon={copy} />
-        </IonButton>
-      ) : null}
-
-      {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowAlert(true)}>
-          <IonIcon slot="end" color="primary" icon={copy} />
-          <IonLabel>Scale</IonLabel>
-        </IonItem>
-      ) : null}
-
       {error !== '' ? (
         <IonAlert
           isOpen={error !== ''}
@@ -66,8 +78,8 @@ const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, 
       ) : null}
 
       <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
+        isOpen={show}
+        onDidDismiss={hide}
         header={item.metadata ? item.metadata.name : ''}
         message={`Enter a new number of replicas for ${
           item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
@@ -80,7 +92,7 @@ const ScaleItem: React.FunctionComponent<IScaleItemProps> = ({ activator, item, 
           },
         ]}
         buttons={[
-          { text: 'Cancel', role: 'cancel', handler: () => setShowAlert(false) },
+          { text: 'Cancel', role: 'cancel', handler: hide },
           { text: 'Scale', handler: (data) => handleScale(data.replicas ? data.replicas : 0) },
         ]}
       />

--- a/src/components/resources/misc/details/ViewItem.tsx
+++ b/src/components/resources/misc/details/ViewItem.tsx
@@ -15,22 +15,53 @@ import {
 } from '@ionic/react';
 import { close, documentText } from 'ionicons/icons';
 import yaml from 'js-yaml';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { TActivator } from '../../../../declarations';
 import Editor from '../../../misc/Editor';
 
 const { Filesystem } = Plugins;
 
-interface IViewYAMLItemProps {
+interface IViewItemActivatorProps {
   activator: TActivator;
+  onClick: () => void;
+}
+
+export const ViewItemActivator: React.FunctionComponent<IViewItemActivatorProps> = ({
+  activator,
+  onClick,
+}: IViewItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="primary" onClick={onClick}>
+        <IonIcon slot="start" icon={documentText} />
+        View
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={documentText} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={documentText} />
+        <IonLabel>View</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface IViewItemProps {
+  show: boolean;
+  hide: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any;
 }
 
-const ViewYAMLItem: React.FunctionComponent<IViewYAMLItemProps> = ({ activator, item }: IViewYAMLItemProps) => {
-  const [showModal, setShowModal] = useState<boolean>(false);
-
+const ViewItem: React.FunctionComponent<IViewItemProps> = ({ show, hide, item }: IViewItemProps) => {
   const handleExport = async () => {
     if (isPlatform('hybrid')) {
       try {
@@ -53,31 +84,11 @@ const ViewYAMLItem: React.FunctionComponent<IViewYAMLItemProps> = ({ activator, 
 
   return (
     <React.Fragment>
-      {activator === 'item-option' ? (
-        <IonItemOption color="primary" onClick={() => setShowModal(true)}>
-          <IonIcon slot="start" icon={documentText} />
-          View
-        </IonItemOption>
-      ) : null}
-
-      {activator === 'button' ? (
-        <IonButton onClick={() => setShowModal(true)}>
-          <IonIcon slot="icon-only" icon={documentText} />
-        </IonButton>
-      ) : null}
-
-      {activator === 'item' ? (
-        <IonItem button={true} detail={false} onClick={() => setShowModal(true)}>
-          <IonIcon slot="end" color="primary" icon={documentText} />
-          <IonLabel>View</IonLabel>
-        </IonItem>
-      ) : null}
-
-      <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)}>
+      <IonModal isOpen={show} onDidDismiss={hide}>
         <IonHeader>
           <IonToolbar>
             <IonButtons slot="start">
-              <IonButton onClick={() => setShowModal(false)}>
+              <IonButton onClick={hide}>
                 <IonIcon slot="icon-only" icon={close} />
               </IonButton>
             </IonButtons>
@@ -95,4 +106,4 @@ const ViewYAMLItem: React.FunctionComponent<IViewYAMLItemProps> = ({ activator, 
   );
 };
 
-export default ViewYAMLItem;
+export default ViewItem;

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -10,7 +10,7 @@ import { IS_INCLUSTER } from '../../../../utils/constants';
 import { AppContext } from '../../../../utils/context';
 import Dashboard from '../../../plugins/prometheus/Dashboard';
 import List from '../../misc/list/List';
-import Containers from './Containers';
+import Containers from './containers/Containers';
 import Conditions from '../../misc/template/Conditions';
 import Configuration from '../../misc/template/Configuration';
 import Metadata from '../../misc/template/Metadata';

--- a/src/components/resources/workloads/pods/containers/AddLogs.tsx
+++ b/src/components/resources/workloads/pods/containers/AddLogs.tsx
@@ -2,20 +2,27 @@ import { IonButton, IonIcon, IonItem, IonItemOption, IonLabel, IonList, IonPopov
 import { list } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
-import { IContext, ITerminalContext, TActivator } from '../../../declarations';
-import { LOG_TAIL_LINES } from '../../../utils/constants';
-import { AppContext } from '../../../utils/context';
-import { TerminalContext } from '../../../utils/terminal';
-import { addLogs } from './helpers';
+import { IContext, ITerminalContext, TActivator } from '../../../../../declarations';
+import { LOG_TAIL_LINES } from '../../../../../utils/constants';
+import { AppContext } from '../../../../../utils/context';
+import { TerminalContext } from '../../../../../utils/terminal';
+import { addLogs } from '../../../../plugins/terminal/helpers';
 
 interface IAddLogsProps {
   activator: TActivator;
   namespace: string;
   pod: string;
   container: string;
+  closeItemSliding?: () => void;
 }
 
-const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace, pod, container }: IAddLogsProps) => {
+const AddLogs: React.FunctionComponent<IAddLogsProps> = ({
+  activator,
+  namespace,
+  pod,
+  container,
+  closeItemSliding,
+}: IAddLogsProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
 
@@ -34,6 +41,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, false);
             }}
           >
@@ -45,6 +55,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addLogs(context, terminalContext, url, container, false, 0, false);
             }}
           >
@@ -56,6 +69,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addLogs(context, terminalContext, url, container, true, LOG_TAIL_LINES, false);
             }}
           >
@@ -67,6 +83,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addLogs(context, terminalContext, url, container, true, 0, false);
             }}
           >
@@ -78,6 +97,9 @@ const AddLogs: React.FunctionComponent<IAddLogsProps> = ({ activator, namespace,
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addLogs(context, terminalContext, url, container, false, LOG_TAIL_LINES, true);
             }}
           >

--- a/src/components/resources/workloads/pods/containers/AddShell.tsx
+++ b/src/components/resources/workloads/pods/containers/AddShell.tsx
@@ -2,16 +2,17 @@ import { IonButton, IonIcon, IonItem, IonItemOption, IonLabel, IonList, IonPopov
 import { terminal } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
-import { IContext, ITerminalContext, TActivator } from '../../../declarations';
-import { AppContext } from '../../../utils/context';
-import { TerminalContext } from '../../../utils/terminal';
-import { addShell } from './helpers';
+import { IContext, ITerminalContext, TActivator } from '../../../../../declarations';
+import { AppContext } from '../../../../../utils/context';
+import { TerminalContext } from '../../../../../utils/terminal';
+import { addShell } from '../../../../plugins/terminal/helpers';
 
 interface IAddShellProps {
   activator: TActivator;
   namespace: string;
   pod: string;
   container: string;
+  closeItemSliding?: () => void;
 }
 
 const AddShell: React.FunctionComponent<IAddShellProps> = ({
@@ -19,6 +20,7 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
   namespace,
   pod,
   container,
+  closeItemSliding,
 }: IAddShellProps) => {
   const context = useContext<IContext>(AppContext);
   const terminalContext = useContext<ITerminalContext>(TerminalContext);
@@ -38,6 +40,9 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addShell(context, terminalContext, url, container, 'bash');
             }}
           >
@@ -49,6 +54,9 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addShell(context, terminalContext, url, container, 'sh');
             }}
           >
@@ -60,6 +68,9 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addShell(context, terminalContext, url, container, 'powershell');
             }}
           >
@@ -71,6 +82,9 @@ const AddShell: React.FunctionComponent<IAddShellProps> = ({
             onClick={(e) => {
               e.stopPropagation();
               setShowPopover(false);
+              if (closeItemSliding) {
+                closeItemSliding();
+              }
               addShell(context, terminalContext, url, container, 'cmd');
             }}
           >

--- a/src/components/resources/workloads/pods/containers/Container.tsx
+++ b/src/components/resources/workloads/pods/containers/Container.tsx
@@ -1,13 +1,13 @@
 import { IonIcon, IonItem, IonItemOptions, IonItemSliding, IonLabel } from '@ionic/react';
 import { V1Container, V1ContainerStatus } from '@kubernetes/client-node';
 import { checkmark, close } from 'ionicons/icons';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
-import { IContainerMetrics } from '../../../../declarations';
-import { formatResourceValue } from '../../../../utils/helpers';
-import AddLogs from '../../../plugins/terminal/AddLogs';
-import AddShell from '../../../plugins/terminal/AddShell';
-import ContainerDetails from './ContainerDetails';
+import { IContainerMetrics } from '../../../../../declarations';
+import { formatResourceValue } from '../../../../../utils/helpers';
+import AddLogs from './AddLogs';
+import AddShell from './AddShell';
+import Details from './Details';
 
 // getState returns the current state of the given container. This is used for the list view for init containers and
 // containers.
@@ -44,7 +44,14 @@ const Container: React.FunctionComponent<IContainerProps> = ({
   namespace,
   status,
 }: IContainerProps) => {
+  const itemSlidingRef = useRef<HTMLIonItemSlidingElement>(null);
   const [showDetailsModal, setShowDetailsModal] = useState(false);
+
+  const closeItemSliding = () => {
+    if (itemSlidingRef && itemSlidingRef.current) {
+      itemSlidingRef.current.close();
+    }
+  };
 
   let resources: string[] = [];
 
@@ -144,7 +151,7 @@ const Container: React.FunctionComponent<IContainerProps> = ({
           </td>
         </tr>
       ) : (
-        <IonItemSliding>
+        <IonItemSliding ref={itemSlidingRef}>
           <IonItem button={true} onClick={() => setShowDetailsModal(true)}>
             <IonLabel>
               <h2>{container.name}</h2>
@@ -195,17 +202,29 @@ const Container: React.FunctionComponent<IContainerProps> = ({
           {name && namespace ? (
             <IonItemOptions side="end">
               {logs ? (
-                <AddLogs activator="item-option" namespace={namespace} pod={name} container={container.name} />
+                <AddLogs
+                  activator="item-option"
+                  namespace={namespace}
+                  pod={name}
+                  container={container.name}
+                  closeItemSliding={closeItemSliding}
+                />
               ) : null}
               {terminal ? (
-                <AddShell activator="item-option" namespace={namespace} pod={name} container={container.name} />
+                <AddShell
+                  activator="item-option"
+                  namespace={namespace}
+                  pod={name}
+                  container={container.name}
+                  closeItemSliding={closeItemSliding}
+                />
               ) : null}
             </IonItemOptions>
           ) : null}
         </IonItemSliding>
       )}
 
-      <ContainerDetails
+      <Details
         name={name}
         namespace={namespace}
         container={container}

--- a/src/components/resources/workloads/pods/containers/Containers.tsx
+++ b/src/components/resources/workloads/pods/containers/Containers.tsx
@@ -2,9 +2,9 @@ import { IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonList, isPlatfor
 import { V1Container, V1ContainerStatus } from '@kubernetes/client-node';
 import React from 'react';
 
-import { IContainerMetrics } from '../../../../declarations';
-import useWindowWidth from '../../../../utils/useWindowWidth';
-import IonCardEqualHeight from '../../../misc/IonCardEqualHeight';
+import { IContainerMetrics } from '../../../../../declarations';
+import useWindowWidth from '../../../../../utils/useWindowWidth';
+import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
 import Container from './Container';
 
 interface IContainersProps {

--- a/src/components/resources/workloads/pods/containers/Details.tsx
+++ b/src/components/resources/workloads/pods/containers/Details.tsx
@@ -26,13 +26,13 @@ import { close } from 'ionicons/icons';
 import yaml from 'js-yaml';
 import React from 'react';
 
-import { IS_INCLUSTER } from '../../../../utils/constants';
-import Editor from '../../../misc/Editor';
-import IonCardEqualHeight from '../../../misc/IonCardEqualHeight';
-import Row from '../../misc/template/Row';
-import Port from '../../misc/template/Port';
+import { IS_INCLUSTER } from '../../../../../utils/constants';
+import Editor from '../../../../misc/Editor';
+import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
+import Row from '../../../misc/template/Row';
+import Port from '../../../misc/template/Port';
 
-interface IContainerProps {
+interface IDetailsProps {
   name?: string;
   namespace?: string;
   container: V1Container;
@@ -41,14 +41,14 @@ interface IContainerProps {
   setShowModal: (value: boolean) => void;
 }
 
-const Container: React.FunctionComponent<IContainerProps> = ({
+const Details: React.FunctionComponent<IDetailsProps> = ({
   name,
   namespace,
   container,
   status,
   showModal,
   setShowModal,
-}: IContainerProps) => {
+}: IDetailsProps) => {
   const containerState = (state: V1ContainerState): string => {
     if (state.running) {
       return `Started at ${state.running.startedAt}`;
@@ -295,4 +295,4 @@ const Container: React.FunctionComponent<IContainerProps> = ({
   );
 };
 
-export default Container;
+export default Details;

--- a/src/components/settings/clusters/ClusterItem.tsx
+++ b/src/components/settings/clusters/ClusterItem.tsx
@@ -1,6 +1,6 @@
 import { IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, isPlatform } from '@ionic/react';
 import { radioButtonOff, radioButtonOn, trash } from 'ionicons/icons';
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import { useQuery } from 'react-query';
 
 import { ICluster, IContext } from '../../../declarations';
@@ -14,6 +14,14 @@ interface IClusterItemProps {
 
 const ClusterItem: React.FunctionComponent<IClusterItemProps> = ({ cluster }: IClusterItemProps) => {
   const context = useContext<IContext>(AppContext);
+
+  const itemSlidingRef = useRef<HTMLIonItemSlidingElement>(null);
+
+  const closeItemSliding = () => {
+    if (itemSlidingRef && itemSlidingRef.current) {
+      itemSlidingRef.current.close();
+    }
+  };
 
   const { data } = useQuery<boolean, Error>(
     ['ClusterItem', cluster],
@@ -43,7 +51,7 @@ const ClusterItem: React.FunctionComponent<IClusterItemProps> = ({ cluster }: IC
   };
 
   return (
-    <IonItemSliding>
+    <IonItemSliding ref={itemSlidingRef}>
       <IonItem button={true} onClick={() => changeCluster(cluster.id)}>
         <IonIcon
           slot="end"
@@ -52,10 +60,16 @@ const ClusterItem: React.FunctionComponent<IClusterItemProps> = ({ cluster }: IC
         />
         <IonLabel>{cluster.name}</IonLabel>
       </IonItem>
-      {isPlatform('hybrid') ? (
+      {isPlatform('hybrid') || true ? (
         <IonItemOptions side="end">
-          <EditCluster cluster={cluster} />
-          <IonItemOption color="danger" onClick={() => context.deleteCluster(cluster.id)}>
+          <EditCluster cluster={cluster} closeItemSliding={closeItemSliding} />
+          <IonItemOption
+            color="danger"
+            onClick={() => {
+              closeItemSliding();
+              context.deleteCluster(cluster.id);
+            }}
+          >
             <IonIcon slot="start" icon={trash} />
             Delete
           </IonItemOption>

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -42,9 +42,10 @@ import { saveTemporaryCredentials } from '../../../utils/storage';
 
 interface IEditClusterProps {
   cluster: ICluster;
+  closeItemSliding: () => void;
 }
 
-const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IEditClusterProps) => {
+const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, closeItemSliding }: IEditClusterProps) => {
   const context = useContext<IContext>(AppContext);
 
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -241,7 +242,13 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster }: IE
         />
       ) : null}
 
-      <IonItemOption color="primary" onClick={() => setShowModal(true)}>
+      <IonItemOption
+        color="primary"
+        onClick={() => {
+          closeItemSliding();
+          setShowModal(true);
+        }}
+      >
         <IonIcon slot="start" icon={create} />
         Edit
       </IonItemOption>


### PR DESCRIPTION
To improve the usability of kubenav, the shown item options and popovers are now closed when the user selects an action. Until now they were still shown in the background, so that a user had to close them manually.

This is relevant for the details popup the resource options in list views (YAML view and delete action) and the container items at the pod details page.