### PR TITLE
Fix terminal tabs for long container names

### DIFF
--- a/src/components/plugins/terminal/Terminals.tsx
+++ b/src/components/plugins/terminal/Terminals.tsx
@@ -127,7 +127,7 @@ const Terminals: React.FunctionComponent<ITerminalsProps> = ({
                   >
                     <IonIcon slot="icon-only" icon={close} className="terminal-tab-close-button-color" />
                   </IonButton>
-                  <IonLabel>{terminal.name}</IonLabel>
+                  <IonLabel className="terminal-tab-label">{terminal.name}</IonLabel>
                 </IonSegmentButton>
               );
             })}

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -170,6 +170,12 @@ ion-avatar {
   --padding-end: 0px;
 }
 
+.terminal-tab-label {
+  max-width: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .segment-button-layout-icon-end.segment-button-checked .terminal-tab-close-button-color {
   color: var(--ion-color-primary);
 }


### PR DESCRIPTION
When the container name is very long the close button wasn't shown, so that a user wasn't able to close the tab. This is now fixed by settings the maximum width of the label and to hide the text which would overflow.

Fixes #213.