### PR TITLE
Prepare support for bookmarks

### DIFF
--- a/src/components/menu/Clusters.tsx
+++ b/src/components/menu/Clusters.tsx
@@ -50,9 +50,9 @@ const Clusters: React.FunctionComponent<RouteComponentProps> = ({ history, locat
               disabled={location.pathname.startsWith('/settings/clusters')}
               value={cluster.id}
               onIonChange={(e) => changeCluster(e.detail.value)}
-              interface={isPlatform('hybrid') || width < 992 ? 'action-sheet' : 'popover'}
+              interface={isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? 'action-sheet' : 'popover'}
               interfaceOptions={
-                isPlatform('hybrid') || width < 992
+                isPlatform('hybrid') || isPlatform('mobile') || width < 992
                   ? {
                       header: 'Select Cluster',
                     }

--- a/src/components/resources/DetailsPage.tsx
+++ b/src/components/resources/DetailsPage.tsx
@@ -1,19 +1,15 @@
 import { RefresherEventDetail } from '@ionic/core';
 import {
   IonBackButton,
-  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
-  IonIcon,
   IonPage,
   IonProgressBar,
   IonRefresher,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
-import { refresh } from 'ionicons/icons';
 import React, { memo, useContext } from 'react';
 import { useQuery } from 'react-query';
 import { RouteComponentProps } from 'react-router';
@@ -70,13 +66,9 @@ const DetailsPage: React.FunctionComponent<IDetailsPageProps> = ({ match }: IDet
           </IonButtons>
           <IonTitle>{data && data.metadata ? data.metadata.name : ''}</IonTitle>
           <IonButtons slot="primary">
-            {!isPlatform('hybrid') ? (
-              <IonButton onClick={() => refetch()}>
-                <IonIcon slot="icon-only" icon={refresh} />
-              </IonButton>
-            ) : null}
             {data ? (
               <Details
+                refresh={refetch}
                 type={match.params.type}
                 item={data}
                 url={page.detailsURL(

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -1,10 +1,8 @@
 import { RefresherEventDetail } from '@ionic/core';
 import {
-  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
-  IonIcon,
   IonInfiniteScroll,
   IonInfiniteScrollContent,
   IonItemDivider,
@@ -18,9 +16,7 @@ import {
   IonSearchbar,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
-import { refresh } from 'ionicons/icons';
 import React, { memo, useContext, useState } from 'react';
 import { useInfiniteQuery } from 'react-query';
 import { RouteComponentProps } from 'react-router';
@@ -31,6 +27,7 @@ import { AppContext } from '../../utils/context';
 import { isNamespaced } from '../../utils/helpers';
 import { resources } from '../../utils/resources';
 import LoadingErrorCard from '../misc/LoadingErrorCard';
+import Details from './misc/list/Details';
 import Namespaces from './misc/list/Namespaces';
 import ItemOptions from './misc/details/ItemOptions';
 
@@ -109,12 +106,8 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
           </IonButtons>
           <IonTitle>{page.pluralText}</IonTitle>
           <IonButtons slot="primary">
-            {!isPlatform('hybrid') ? (
-              <IonButton onClick={() => refetch()}>
-                <IonIcon slot="icon-only" icon={refresh} />
-              </IonButton>
-            ) : null}
             {isNamespaced(match.params.type) ? <Namespaces /> : null}
+            <Details refresh={refetch} />
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage.tsx
@@ -1,11 +1,9 @@
 import { RefresherEventDetail } from '@ionic/core';
 import {
   IonBackButton,
-  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
-  IonIcon,
   IonGrid,
   IonPage,
   IonProgressBar,
@@ -13,9 +11,7 @@ import {
   IonRow,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
-import { refresh } from 'ionicons/icons';
 import React, { memo, useContext } from 'react';
 import { useQuery } from 'react-query';
 import { RouteComponentProps } from 'react-router';
@@ -96,13 +92,9 @@ const CustomResourcesDetailsPage: React.FunctionComponent<ICustomResourcesDetail
           </IonButtons>
           <IonTitle>{match.params.crname}</IonTitle>
           <IonButtons slot="primary">
-            {!isPlatform('hybrid') ? (
-              <IonButton onClick={() => refetch()}>
-                <IonIcon slot="icon-only" icon={refresh} />
-              </IonButton>
-            ) : null}
             {data ? (
               <Details
+                refresh={refetch}
                 type="customresources"
                 item={data}
                 url={getURL(

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -1,11 +1,9 @@
 import { RefresherEventDetail } from '@ionic/core';
 import {
   IonBackButton,
-  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
-  IonIcon,
   IonInfiniteScroll,
   IonInfiniteScrollContent,
   IonItemDivider,
@@ -18,9 +16,7 @@ import {
   IonSearchbar,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
-import { refresh } from 'ionicons/icons';
 import React, { memo, useContext, useState } from 'react';
 import { useInfiniteQuery } from 'react-query';
 import { RouteComponentProps } from 'react-router';
@@ -28,6 +24,7 @@ import { RouteComponentProps } from 'react-router';
 import { IContext } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
+import Details from '../../misc/list/Details';
 import Namespaces from '../../misc/list/Namespaces';
 import LoadingErrorCard from '../../../misc/LoadingErrorCard';
 import ItemOptions from '../../misc/details/ItemOptions';
@@ -118,12 +115,8 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
           </IonButtons>
           <IonTitle>{match.params.name}</IonTitle>
           <IonButtons slot="primary">
-            {!isPlatform('hybrid') ? (
-              <IonButton onClick={() => refetch()}>
-                <IonIcon slot="icon-only" icon={refresh} />
-              </IonButton>
-            ) : null}
             <Namespaces />
+            <Details refresh={refetch} />
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/src/components/resources/misc/details/Details.tsx
+++ b/src/components/resources/misc/details/Details.tsx
@@ -1,5 +1,5 @@
-import { IonButton, IonIcon, IonList, IonPopover, isPlatform } from '@ionic/react';
-import { ellipsisHorizontal, ellipsisVertical } from 'ionicons/icons';
+import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover, isPlatform } from '@ionic/react';
+import { ellipsisHorizontal, ellipsisVertical, refresh as refreshIcon } from 'ionicons/icons';
 import React, { useState } from 'react';
 
 import useWindowWidth from '../../../../utils/useWindowWidth';
@@ -15,13 +15,14 @@ import ViewItem, { ViewItemActivator } from './ViewItem';
 type TShow = '' | 'delete' | 'edit' | 'logs' | 'restart' | 'scale' | 'shell' | 'ssh' | 'view';
 
 interface IDetailsProps {
+  refresh: () => void;
   type: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any;
   url: string;
 }
 
-const Details: React.FunctionComponent<IDetailsProps> = ({ type, item, url }: IDetailsProps) => {
+const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, type, item, url }: IDetailsProps) => {
   const [show, setShow] = useState<TShow>('');
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
@@ -36,6 +37,17 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ type, item, url }: ID
     <React.Fragment>
       <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
         <IonList>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={() => {
+              refresh();
+              showType('');
+            }}
+          >
+            <IonIcon slot="end" color="primary" icon={refreshIcon} />
+            <IonLabel>Refresh</IonLabel>
+          </IonItem>
           {type === 'deployments' ||
           type === 'statefulsets' ||
           type === 'replicationcontrollers' ||
@@ -45,13 +57,13 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ type, item, url }: ID
           {type === 'deployments' || type === 'statefulsets' || type === 'daemonsets' ? (
             <RestartItemActivator activator="item" onClick={() => showType('restart')} />
           ) : null}
-          {(isPlatform('hybrid') || width < 992) && type === 'pods' ? (
+          {(isPlatform('hybrid') || isPlatform('mobile') || width < 992) && type === 'pods' ? (
             <LogsItemActivator activator="item" onClick={() => showType('logs')} />
           ) : null}
-          {(isPlatform('hybrid') || width < 992) && type === 'pods' ? (
+          {(isPlatform('hybrid') || isPlatform('mobile') || width < 992) && type === 'pods' ? (
             <ShellItemActivator activator="item" onClick={() => showType('shell')} />
           ) : null}
-          {(isPlatform('hybrid') || width < 992) && type === 'nodes' ? (
+          {(isPlatform('hybrid') || isPlatform('mobile') || width < 992) && type === 'nodes' ? (
             <SSHItemActivator activator="item" onClick={() => showType('ssh')} item={item} />
           ) : null}
           <ViewItemActivator activator="item" onClick={() => showType('view')} />

--- a/src/components/resources/misc/list/Details.tsx
+++ b/src/components/resources/misc/list/Details.tsx
@@ -1,0 +1,53 @@
+import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover } from '@ionic/react';
+import { ellipsisHorizontal, ellipsisVertical, refresh as refreshIcon } from 'ionicons/icons';
+import React, { useState } from 'react';
+
+type TShow = '';
+
+interface IDetailsProps {
+  refresh: () => void;
+}
+
+const Details: React.FunctionComponent<IDetailsProps> = ({ refresh }: IDetailsProps) => {
+  const [, setShow] = useState<TShow>('');
+  const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [popoverEvent, setPopoverEvent] = useState();
+
+  const showType = (type: TShow) => {
+    setShowPopover(false);
+    setShow(type);
+  };
+
+  return (
+    <React.Fragment>
+      <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
+        <IonList>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={() => {
+              refresh();
+              showType('');
+            }}
+          >
+            <IonIcon slot="end" color="primary" icon={refreshIcon} />
+            <IonLabel>Refresh</IonLabel>
+          </IonItem>
+        </IonList>
+      </IonPopover>
+
+      <IonButton
+        onClick={(e) => {
+          e.persist();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          setPopoverEvent(e as any);
+          setShowPopover(true);
+        }}
+      >
+        <IonIcon slot="icon-only" ios={ellipsisHorizontal} md={ellipsisVertical} />
+      </IonButton>
+    </React.Fragment>
+  );
+};
+
+export default Details;

--- a/src/components/resources/workloads/pods/containers/Containers.tsx
+++ b/src/components/resources/workloads/pods/containers/Containers.tsx
@@ -53,7 +53,7 @@ const Containers: React.FunctionComponent<IContainersProps> = ({
           <IonCardTitle>{title}</IonCardTitle>
         </IonCardHeader>
         <IonCardContent>
-          {isPlatform('hybrid') || width < 992 ? (
+          {isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? (
             <IonList>
               {containers.map((container, index) => (
                 <Container


### PR DESCRIPTION
- To introduce the new bookmarks option, we have to remove the refresh button from the list and details page and move this option to the details menu. Since there wasn't a details menu for the list page this was also added.
- The new bookmark button will be available via the details menu.
- We also adjusted the determination when to use the mobile layout. Therefor we are checking the platform for `mobile` to have a more native feeling when the web version of kubenav is opened on a mobile device.

This PR prepares the implementation for #160.