### PR TITLE
Refresh list in details view

### DIFF
--- a/src/components/plugins/prometheus/Dashboard.tsx
+++ b/src/components/plugins/prometheus/Dashboard.tsx
@@ -119,31 +119,33 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({ title, variables,
             ) : !isError && data ? (
               <IonRow>
                 {data && data.variables
-                  ? data.variables.map((variable, index) => (
-                      <IonCol key={index}>
-                        <IonItem>
-                          <IonLabel>{variable.name}</IonLabel>
-                          <IonSelect
-                            interface="popover"
-                            value={variable.value}
-                            onIonChange={(e) => {
-                              if (selectedVariables && data.variables) {
-                                const tmpVariales = data.variables;
-                                tmpVariales[index].value = e.detail.value;
-                                setSelectedVariables(tmpVariales);
-                                refetch();
-                              }
-                            }}
-                          >
-                            {variable.values.map((value) => (
-                              <IonSelectOption key={value} value={value}>
-                                {value}
-                              </IonSelectOption>
-                            ))}
-                          </IonSelect>
-                        </IonItem>
-                      </IonCol>
-                    ))
+                  ? data.variables.map((variable, index) =>
+                      variable.value && variable.values ? (
+                        <IonCol key={index}>
+                          <IonItem>
+                            <IonLabel>{variable.name}</IonLabel>
+                            <IonSelect
+                              interface="popover"
+                              value={variable.value}
+                              onIonChange={(e) => {
+                                if (selectedVariables && data.variables) {
+                                  const tmpVariales = data.variables;
+                                  tmpVariales[index].value = e.detail.value;
+                                  setSelectedVariables(tmpVariales);
+                                  refetch();
+                                }
+                              }}
+                            >
+                              {variable.values.map((value) => (
+                                <IonSelectOption key={value} value={value}>
+                                  {value}
+                                </IonSelectOption>
+                              ))}
+                            </IonSelect>
+                          </IonItem>
+                        </IonCol>
+                      ) : null,
+                    )
                   : null}
 
                 <IonCol>

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -177,7 +177,7 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
                   ))
                 : null}
               <IonInfiniteScroll
-                threshold="10%"
+                threshold="25%"
                 disabled={!canFetchMore || (isFetchingMore as boolean)}
                 onIonInfinite={loadMore}
               >

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -188,7 +188,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
                   ))
                 : null}
               <IonInfiniteScroll
-                threshold="10%"
+                threshold="25%"
                 disabled={!canFetchMore || (isFetchingMore as boolean)}
                 onIonInfinite={loadMore}
               >

--- a/src/components/resources/misc/list/List.tsx
+++ b/src/components/resources/misc/list/List.tsx
@@ -43,7 +43,7 @@ const List: React.FunctionComponent<IListProps> = ({
         context.settings,
         await context.kubernetesAuthWrapper(''),
       ),
-    context.settings.queryConfig,
+    { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
   );
 
   if (data && data.items && data.items.filter(filter ? filter : () => true).length > 0) {


### PR DESCRIPTION
- Refresh lists in details page of a Deployment, StatefulSet, Pod, etc. Fixes #218.
- Make infinite scrolling a bit smoother, by triggering the `fetchMore` function earlier.
- Add a null check for variable values to the `Dashboard` component.