### PR TITLE
Add cluster overview page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,8 @@ import '@ionic/react/css/text-transformation.css';
 import '@ionic/react/css/typography.css';
 
 import BookmarksPage from './components/bookmarks/BookmarksPage';
-import HomePage from './components/HomePage';
 import Menu from './components/menu/Menu';
+import OverviewPage from './components/overview/OverviewPage';
 import CustomResourcesDetailsPage from './components/resources/cluster/customResourceDefinitions/CustomResourcesDetailsPage';
 import CustomResourcesListPage from './components/resources/cluster/customResourceDefinitions/CustomResourcesListPage';
 import DetailsPage from './components/resources/DetailsPage';
@@ -49,7 +49,7 @@ const App: React.FunctionComponent = () => (
             <IonSplitPane contentId="main" className={isPlatform('hybrid') ? '' : 'menu-width'}>
               <Menu sections={resources} />
               <IonRouterOutlet id="main">
-                <Route path="/" component={HomePage} exact={true} />
+                <Route path="/" component={OverviewPage} exact={true} />
                 <Route path="/bookmarks" component={BookmarksPage} exact={true} />
                 <Route path="/resources/:section/:type" component={ListPage} exact={true} />
                 <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -88,6 +88,14 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location
         <IonList>
           {context.clusters && Object.keys(context.clusters).length <= 1 ? null : <Clusters />}
           <IonMenuToggle autoHide={false}>
+            <IonItem routerLink="/" routerDirection="root">
+              <IonAvatar slot="start">
+                <img alt="Overview" src="/assets/icons/kubernetes/kubernetes.png" />
+              </IonAvatar>
+              <IonLabel>Overview</IonLabel>
+            </IonItem>
+          </IonMenuToggle>
+          <IonMenuToggle autoHide={false}>
             <IonItem routerLink="/bookmarks" routerDirection="root">
               <IonAvatar slot="start">
                 <img alt="Bookmarks" src="/assets/icons/misc/bookmarks.png" />

--- a/src/components/overview/ClusterMetric.tsx
+++ b/src/components/overview/ClusterMetric.tsx
@@ -1,0 +1,54 @@
+import { IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonRow } from '@ionic/react';
+import React from 'react';
+import { RadialBar, RadialBarChart, ResponsiveContainer } from 'recharts';
+
+import IonCardEqualHeight from '../misc/IonCardEqualHeight';
+
+export interface IMetric {
+  name: string;
+  value: number;
+  fill: string;
+}
+
+interface IClusterMetricProps {
+  title: string;
+  data?: IMetric[];
+  unit: string;
+}
+
+const ClusterMetric: React.FunctionComponent<IClusterMetricProps> = ({ title, data, unit }: IClusterMetricProps) => {
+  return (
+    <IonCardEqualHeight>
+      <IonCardHeader>
+        <IonCardTitle>{title}</IonCardTitle>
+      </IonCardHeader>
+      <IonCardContent>
+        <div style={{ height: '250px', width: '100%' }}>
+          <ResponsiveContainer>
+            <RadialBarChart innerRadius="25%" barSize={5} data={data} startAngle={90} endAngle={-270}>
+              <RadialBar minAngle={15} background={true} dataKey="value" />
+            </RadialBarChart>
+          </ResponsiveContainer>
+        </div>
+        {data && data.length > 0
+          ? data.map((metric, index) => (
+              <IonRow key={index}>
+                <IonCol size="auto">
+                  <span style={{ backgroundColor: metric.fill }}>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                </IonCol>
+                <IonCol size="auto">
+                  <b>{metric.name}:</b>
+                </IonCol>
+                <IonCol>
+                  {metric.value}
+                  {unit}
+                </IonCol>
+              </IonRow>
+            ))
+          : null}
+      </IonCardContent>
+    </IonCardEqualHeight>
+  );
+};
+
+export default ClusterMetric;

--- a/src/components/overview/ClusterMetrics.tsx
+++ b/src/components/overview/ClusterMetrics.tsx
@@ -53,7 +53,7 @@ const ClusterMetrics: React.FunctionComponent = () => {
       try {
         const nodeMetrics: INodeMetricsList = await kubernetesRequest(
           'GET',
-          `/apis/metrics.k8s.io/v1beta1/nodes`,
+          '/apis/metrics.k8s.io/v1beta1/nodes',
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),
@@ -61,7 +61,7 @@ const ClusterMetrics: React.FunctionComponent = () => {
 
         const nodeList: V1NodeList = await kubernetesRequest(
           'GET',
-          `/api/v1/nodes`,
+          '/api/v1/nodes',
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),
@@ -69,7 +69,7 @@ const ClusterMetrics: React.FunctionComponent = () => {
 
         const podList: V1PodList = await kubernetesRequest(
           'GET',
-          `/api/v1/pods`,
+          '/api/v1/pods',
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),

--- a/src/components/overview/ClusterMetrics.tsx
+++ b/src/components/overview/ClusterMetrics.tsx
@@ -1,0 +1,182 @@
+import { IonCol, IonRow } from '@ionic/react';
+import { V1Container, V1NodeList, V1PodList } from '@kubernetes/client-node';
+import React, { memo, useContext } from 'react';
+import { useQuery } from 'react-query';
+
+import { IContext, INodeMetricsList } from '../../declarations';
+import { kubernetesRequest } from '../../utils/api';
+import { AppContext } from '../../utils/context';
+import { formatResourceValue, isDarkMode } from '../../utils/helpers';
+import ClusterMetric, { IMetric } from './ClusterMetric';
+
+const podResources = (containers: V1Container[]): number[] => {
+  let cpuRequests = 0;
+  let cpuLimits = 0;
+  let memoryRequests = 0;
+  let memoryLimits = 0;
+
+  for (const container of containers) {
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu')) {
+      cpuRequests = cpuRequests + parseInt(formatResourceValue('cpu', container.resources.requests['cpu']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu')) {
+      cpuLimits = cpuLimits + parseInt(formatResourceValue('cpu', container.resources.limits['cpu']));
+    }
+
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('memory')) {
+      memoryRequests = memoryRequests + parseInt(formatResourceValue('memory', container.resources.requests['memory']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory')) {
+      memoryLimits = memoryLimits + parseInt(formatResourceValue('memory', container.resources.limits['memory']));
+    }
+  }
+
+  return [cpuRequests, cpuLimits, memoryRequests, memoryLimits];
+};
+
+interface IMetrics {
+  cpu: IMetric[];
+  memory: IMetric[];
+  pods: IMetric[];
+}
+
+const ClusterMetrics: React.FunctionComponent = () => {
+  const context = useContext<IContext>(AppContext);
+  const cluster = context.currentCluster();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = useQuery<IMetrics, Error>(
+    ['ClusterMetrics', cluster ? cluster.id : ''],
+    async () => {
+      try {
+        const nodeMetrics: INodeMetricsList = await kubernetesRequest(
+          'GET',
+          `/apis/metrics.k8s.io/v1beta1/nodes`,
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        const nodeList: V1NodeList = await kubernetesRequest(
+          'GET',
+          `/api/v1/nodes`,
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        const podList: V1PodList = await kubernetesRequest(
+          'GET',
+          `/api/v1/pods`,
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        let cpuUsage = 0;
+        let memoryUsage = 0;
+        for (const metric of nodeMetrics.items) {
+          cpuUsage = cpuUsage + parseInt(formatResourceValue('cpu', metric.usage ? metric.usage['cpu'] : '0'));
+          memoryUsage =
+            memoryUsage + parseInt(formatResourceValue('memory', metric.usage ? metric.usage['memory'] : '0'));
+        }
+
+        let cpuCapacity = 0;
+        let memoryCapacity = 0;
+        let podsCapacity = 0;
+        for (const node of nodeList.items) {
+          cpuCapacity =
+            cpuCapacity +
+            parseInt(
+              formatResourceValue(
+                'cpu',
+                node.status && node.status.capacity && node.status.capacity['cpu'] ? node.status.capacity['cpu'] : '0',
+              ),
+            );
+          memoryCapacity =
+            memoryCapacity +
+            parseInt(
+              formatResourceValue(
+                'memory',
+                node.status && node.status.capacity && node.status.capacity['memory']
+                  ? node.status.capacity['memory']
+                  : '0',
+              ),
+            );
+          podsCapacity =
+            podsCapacity +
+            parseInt(
+              formatResourceValue(
+                'memory',
+                node.status && node.status.capacity && node.status.capacity['pods']
+                  ? node.status.capacity['pods']
+                  : '0',
+              ),
+            );
+        }
+
+        const podsUsage = podList.items.length;
+
+        let cpuRequest = 0;
+        let cpuLimit = 0;
+        let memoryRequest = 0;
+        let memoryLimit = 0;
+        for (const pod of podList.items) {
+          if (pod.spec) {
+            const resources = podResources(pod.spec.containers);
+            cpuRequest = cpuRequest + resources[0];
+            cpuLimit = cpuLimit + resources[1];
+            memoryRequest = memoryRequest + resources[2];
+            memoryLimit = memoryLimit + resources[3];
+          }
+        }
+
+        return {
+          cpu: [
+            { name: 'Capacity', value: cpuCapacity, fill: isDarkMode(context.settings.theme) ? '#50c8ff' : '#0cd1e8' },
+            { name: 'Usage', value: cpuUsage, fill: isDarkMode(context.settings.theme) ? '#2fdf75' : '#10dc60' },
+            { name: 'Request', value: cpuRequest, fill: isDarkMode(context.settings.theme) ? '#ffd534' : '#ffce00' },
+            { name: 'Limit', value: cpuLimit, fill: isDarkMode(context.settings.theme) ? '#ff4961' : '#f04141' },
+          ],
+          memory: [
+            {
+              name: 'Capacity',
+              value: memoryCapacity,
+              fill: isDarkMode(context.settings.theme) ? '#50c8ff' : '#0cd1e8',
+            },
+            { name: 'Usage', value: memoryUsage, fill: isDarkMode(context.settings.theme) ? '#2fdf75' : '#10dc60' },
+            { name: 'Request', value: memoryRequest, fill: isDarkMode(context.settings.theme) ? '#ffd534' : '#ffce00' },
+            { name: 'Limit', value: memoryLimit, fill: isDarkMode(context.settings.theme) ? '#ff4961' : '#f04141' },
+          ],
+          pods: [
+            { name: 'Capacity', value: podsCapacity, fill: isDarkMode(context.settings.theme) ? '#50c8ff' : '#0cd1e8' },
+            { name: 'Usage', value: podsUsage, fill: isDarkMode(context.settings.theme) ? '#2fdf75' : '#10dc60' },
+          ],
+        };
+      } catch (err) {
+        throw err;
+      }
+    },
+    { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
+  );
+
+  return (
+    <IonRow>
+      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+        <ClusterMetric title="CPU" data={data && data.cpu ? data.cpu : undefined} unit="m" />
+      </IonCol>
+      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+        <ClusterMetric title="Memory" data={data && data.memory ? data.memory : undefined} unit="Mi" />
+      </IonCol>
+      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+        <ClusterMetric title="Pods" data={data && data.pods ? data.pods : undefined} unit="" />
+      </IonCol>
+    </IonRow>
+  );
+};
+
+export default memo(ClusterMetrics, (): boolean => {
+  return true;
+});

--- a/src/components/overview/OverviewPage.tsx
+++ b/src/components/overview/OverviewPage.tsx
@@ -7,21 +7,22 @@ import {
   IonCardSubtitle,
   IonCardTitle,
   IonContent,
+  IonGrid,
   IonHeader,
-  IonList,
   IonMenuButton,
   IonPage,
+  IonRow,
   IonTitle,
   IonToolbar,
 } from '@ionic/react';
 import React, { memo, useContext } from 'react';
 
-import { IContext } from '../declarations';
-import { AppContext } from '../utils/context';
-import { resources } from '../utils/resources';
-import Sections from './menu/Sections';
+import { IContext } from '../../declarations';
+import { AppContext } from '../../utils/context';
+import List from '../resources/misc/list/List';
+import ClusterMetrics from './ClusterMetrics';
 
-const HomePage: React.FunctionComponent = () => {
+const OverviewPage: React.FunctionComponent = () => {
   const context = useContext<IContext>(AppContext);
 
   return (
@@ -31,28 +32,25 @@ const HomePage: React.FunctionComponent = () => {
           <IonButtons slot="start">
             <IonMenuButton />
           </IonButtons>
-          <IonTitle>Home</IonTitle>
+          <IonTitle>Overview</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent>
         {context.clusters && context.cluster ? (
-          <IonCard>
-            <img alt="kubenav" src="/assets/card-header.png" />
-            <IonCardHeader>
-              <IonCardSubtitle>Welcome to kubenav</IonCardSubtitle>
-              <IonCardTitle>Explore your Kubernetes Clusters</IonCardTitle>
-            </IonCardHeader>
-            <IonCardContent>
-              <p className="paragraph-margin-bottom">
-                Welcome back to the kubenav app. You are ready to explore your Kubernetes clusters. To get an overview
-                of your running Nodes, Deployments, Pods and Containers select the corresponding item from the menu or
-                from below.
-              </p>
-              <IonList>
-                <Sections sections={resources} isMenu={false} />
-              </IonList>
-            </IonCardContent>
-          </IonCard>
+          <IonGrid>
+            <ClusterMetrics />
+
+            <IonRow>
+              <List
+                name="Warnings"
+                section="cluster"
+                type="events"
+                namespace=""
+                parent=""
+                selector="fieldSelector=type=Warning"
+              />
+            </IonRow>
+          </IonGrid>
         ) : (
           <IonCard>
             <img alt="kubenav" src="/assets/card-header.png" />
@@ -77,6 +75,6 @@ const HomePage: React.FunctionComponent = () => {
   );
 };
 
-export default memo(HomePage, (): boolean => {
+export default memo(OverviewPage, (): boolean => {
   return true;
 });

--- a/src/components/overview/OverviewPage.tsx
+++ b/src/components/overview/OverviewPage.tsx
@@ -11,7 +11,6 @@ import {
   IonHeader,
   IonMenuButton,
   IonPage,
-  IonRow,
   IonTitle,
   IonToolbar,
 } from '@ionic/react';
@@ -19,7 +18,7 @@ import React, { memo, useContext } from 'react';
 
 import { IContext } from '../../declarations';
 import { AppContext } from '../../utils/context';
-import List from '../resources/misc/list/List';
+import Warnings from './Warnings';
 import ClusterMetrics from './ClusterMetrics';
 
 const OverviewPage: React.FunctionComponent = () => {
@@ -39,17 +38,7 @@ const OverviewPage: React.FunctionComponent = () => {
         {context.clusters && context.cluster ? (
           <IonGrid>
             <ClusterMetrics />
-
-            <IonRow>
-              <List
-                name="Warnings"
-                section="cluster"
-                type="events"
-                namespace=""
-                parent=""
-                selector="fieldSelector=type=Warning"
-              />
-            </IonRow>
+            <Warnings />
           </IonGrid>
         ) : (
           <IonCard>

--- a/src/components/overview/Warnings.tsx
+++ b/src/components/overview/Warnings.tsx
@@ -1,0 +1,164 @@
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonCol,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonRouterLink,
+  IonRow,
+  isPlatform,
+} from '@ionic/react';
+import { V1EventList } from '@kubernetes/client-node';
+import React, { useContext } from 'react';
+import { useQuery } from 'react-query';
+
+import { IContext } from '../../declarations';
+import { kubernetesRequest } from '../../utils/api';
+import { AppContext } from '../../utils/context';
+import useWindowWidth from '../../utils/useWindowWidth';
+
+interface IEvent {
+  name: string;
+  routerLink: string;
+  reason: string;
+  message: string;
+}
+
+const Warnings: React.FunctionComponent = () => {
+  const context = useContext<IContext>(AppContext);
+  const width = useWindowWidth();
+
+  const { data } = useQuery<IEvent[], Error>(
+    ['OverviewWarnings'],
+    async () => {
+      try {
+        const eventList: V1EventList = await kubernetesRequest(
+          'GET',
+          '/api/v1/events?limit=100&fieldSelector=type=Warning',
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        const events: IEvent[] = [];
+        for (const event of eventList.items) {
+          const name = event.metadata.name
+            ? event.metadata.name.split('.').length > 0
+              ? event.metadata.name.split('.')[0]
+              : event.metadata.name
+            : '';
+
+          if (events.map((e) => e.name).indexOf(name) === -1) {
+            let routerLink = '';
+            if (event.involvedObject.kind === 'CronJob') {
+              routerLink = `/resources/workloads/cronjobs/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'DaemonSet') {
+              routerLink = `/resources/workloads/daemonsets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'Deployment') {
+              routerLink = `/resources/workloads/deployments/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'Job') {
+              routerLink = `/resources/workloads/jobs/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'Pod') {
+              routerLink = `/resources/workloads/pods/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'ReplicaSet') {
+              routerLink = `/resources/workloads/replicasets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'ReplicationController') {
+              routerLink = `/resources/workloads/replicationcontrollers/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'StatefulSet') {
+              routerLink = `/resources/workloads/statefulsets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            } else if (event.involvedObject.kind === 'HorizontalPodAutoscaler') {
+              routerLink = `/resources/discovery-and-loadbalancing/horizontalpodautoscalers/${event.involvedObject.namespace}/${event.involvedObject.name}`;
+            }
+
+            events.push({
+              name: name,
+              routerLink: routerLink,
+              reason: event.reason ? event.reason : '',
+              message: event.message ? event.message : '',
+            });
+          }
+        }
+
+        return events;
+      } catch (err) {
+        throw err;
+      }
+    },
+    { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
+  );
+
+  return (
+    <IonRow>
+      <IonCol>
+        <IonCard>
+          <IonCardHeader>
+            <IonCardTitle>Warnings</IonCardTitle>
+          </IonCardHeader>
+          <IonCardContent>
+            {isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? (
+              <IonList>
+                {data && data.length > 0
+                  ? data.map((event, index) => {
+                      return (
+                        <IonItem
+                          key={index}
+                          routerLink={event.routerLink === '' ? undefined : event.routerLink}
+                          routerDirection="forward"
+                        >
+                          <IonLabel class="ion-text-wrap">
+                            <h2>{event.name}</h2>
+                            <p>
+                              {event.reason ? `${event.reason}: ` : ''}
+                              {event.message}
+                            </p>
+                          </IonLabel>
+                        </IonItem>
+                      );
+                    })
+                  : null}
+              </IonList>
+            ) : (
+              <div className="table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Reason</th>
+                      <th>Message</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data && data.length > 0
+                      ? data.map((event, index) => {
+                          return (
+                            <tr key={index}>
+                              <td>
+                                {event.routerLink === '' ? (
+                                  event.name
+                                ) : (
+                                  <IonRouterLink routerLink={event.routerLink} routerDirection="forward">
+                                    {event.name}
+                                  </IonRouterLink>
+                                )}
+                              </td>
+                              <td>{event.reason}</td>
+                              <td>{event.message}</td>
+                            </tr>
+                          );
+                        })
+                      : null}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </IonCardContent>
+        </IonCard>
+      </IonCol>
+    </IonRow>
+  );
+};
+
+export default Warnings;

--- a/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
+++ b/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
@@ -45,6 +45,37 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
           title="Metrics"
           charts={[
             {
+              title: 'CPU Usage',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '6',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Current',
+                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
+                    item.metadata ? item.metadata.name : ''
+                  }", image!="", container!="", container!="POD"}[4m]))`,
+                },
+                {
+                  label: 'Requested',
+                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                    item.metadata ? item.metadata.name : ''
+                  }", resource="cpu", container!=""})`,
+                },
+                {
+                  label: 'Limit',
+                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                    item.metadata ? item.metadata.name : ''
+                  }", resource="cpu", container!=""})`,
+                },
+              ],
+            },
+            {
               title: 'Memory Usage (in MiB)',
               size: {
                 xs: '12',
@@ -78,37 +109,6 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
                   query: `sum(container_memory_cache{job="kubelet", namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", container!="", container!="POD"}) / 1024 / 1024`,
-                },
-              ],
-            },
-            {
-              title: 'CPU Usage',
-              size: {
-                xs: '12',
-                sm: '12',
-                md: '12',
-                lg: '12',
-                xl: '6',
-              },
-              type: 'area',
-              queries: [
-                {
-                  label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
-                    item.metadata ? item.metadata.name : ''
-                  }", image!="", container!="", container!="POD"}[4m]))`,
-                },
-                {
-                  label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
-                    item.metadata ? item.metadata.name : ''
-                  }", resource="cpu", container!=""})`,
-                },
-                {
-                  label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
-                    item.metadata ? item.metadata.name : ''
-                  }", resource="cpu", container!=""})`,
                 },
               ],
             },

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -180,6 +180,43 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
           title="Metrics"
           charts={[
             {
+              title: 'CPU Usage',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '6',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Current',
+                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", node="${
+                    item.metadata ? item.metadata.name : ''
+                  }", image!="", container!="", container!="POD"}[4m]))`,
+                },
+                {
+                  label: 'Requested',
+                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", node="${
+                    item.metadata ? item.metadata.name : ''
+                  }", resource="cpu", container!=""})`,
+                },
+                {
+                  label: 'Limit',
+                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", node="${
+                    item.metadata ? item.metadata.name : ''
+                  }", resource="cpu", container!=""})`,
+                },
+                {
+                  label: 'Allocatable',
+                  query: `sum(kube_node_status_allocatable_cpu_cores{job="kube-state-metrics", node="${
+                    item.metadata ? item.metadata.name : ''
+                  }"})`,
+                },
+              ],
+            },
+            {
               title: 'Memory Usage (in GiB)',
               size: {
                 xs: '12',
@@ -219,43 +256,6 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
                   query: `sum(kube_node_status_allocatable_memory_bytes{job="kube-state-metrics", node="${
                     item.metadata ? item.metadata.name : ''
                   }"}) / 1024 / 1024 / 1024`,
-                },
-              ],
-            },
-            {
-              title: 'CPU Usage',
-              size: {
-                xs: '12',
-                sm: '12',
-                md: '12',
-                lg: '12',
-                xl: '6',
-              },
-              type: 'area',
-              queries: [
-                {
-                  label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }", image!="", container!="", container!="POD"}[4m]))`,
-                },
-                {
-                  label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }", resource="cpu", container!=""})`,
-                },
-                {
-                  label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }", resource="cpu", container!=""})`,
-                },
-                {
-                  label: 'Allocatable',
-                  query: `sum(kube_node_status_allocatable_cpu_cores{job="kube-state-metrics", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }"})`,
                 },
               ],
             },

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -200,6 +200,43 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
           ]}
           charts={[
             {
+              title: 'CPU Usage',
+              size: {
+                xs: '12',
+                sm: '12',
+                md: '12',
+                lg: '12',
+                xl: '6',
+              },
+              type: 'area',
+              queries: [
+                {
+                  label: 'Current',
+                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", image!="", pod="${
+                    item.metadata ? item.metadata.name : ''
+                  }", container=~"{{ .Container }}", container!="POD"}[4m]))`,
+                },
+                {
+                  label: 'Requested',
+                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", resource="cpu", pod="${
+                    item.metadata ? item.metadata.name : ''
+                  }", container=~"{{ .Container }}"})`,
+                },
+                {
+                  label: 'Limit',
+                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                    item.metadata ? item.metadata.namespace : ''
+                  }", resource="cpu", pod="${
+                    item.metadata ? item.metadata.name : ''
+                  }", container=~"{{ .Container }}"})`,
+                },
+              ],
+            },
+            {
               title: 'Memory Usage (in MiB)',
               size: {
                 xs: '12',
@@ -241,43 +278,6 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                   }", pod="${
                     item.metadata ? item.metadata.name : ''
                   }", container=~"{{ .Container }}", container!="POD"}) / 1024 / 1024`,
-                },
-              ],
-            },
-            {
-              title: 'CPU Usage',
-              size: {
-                xs: '12',
-                sm: '12',
-                md: '12',
-                lg: '12',
-                xl: '6',
-              },
-              type: 'area',
-              queries: [
-                {
-                  label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
-                    item.metadata ? item.metadata.namespace : ''
-                  }", image!="", pod="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}", container!="POD"}[4m]))`,
-                },
-                {
-                  label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
-                    item.metadata ? item.metadata.namespace : ''
-                  }", resource="cpu", pod="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}"})`,
-                },
-                {
-                  label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
-                    item.metadata ? item.metadata.namespace : ''
-                  }", resource="cpu", pod="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}"})`,
                 },
               ],
             },


### PR DESCRIPTION
This PR adds a cluster overview page which contains the CPU, Memory and Pod usage in the currently selected cluster. The page also contains a list of all Events where the `type` is `warning`.

The overview page replaces the former `HomePage`, if a user hasn't created a cluster the link to the cluster page is shown.

Since we are always showing the CPU metrics before the Memory metrics, we also changed the order of the charts for Prometheus metrics.

<img width="1339" alt="Bildschirmfoto 2020-10-04 um 20 09 45" src="https://user-images.githubusercontent.com/18552168/95023531-e0600580-067d-11eb-966c-608b2d401a15.png">
