### PR TITLE
Add possibility to disable Pod metrics in list view

### DIFF
--- a/src/components/resources/workloads/pods/PodItem.tsx
+++ b/src/components/resources/workloads/pods/PodItem.tsx
@@ -2,14 +2,13 @@ import { IonItem, IonLabel } from '@ionic/react';
 import { V1Pod } from '@kubernetes/client-node';
 import React, { useContext } from 'react';
 import { RouteComponentProps } from 'react-router';
-import { useQuery } from 'react-query';
 
-import { IContext, IPodMetrics } from '../../../../declarations';
-import { kubernetesRequest } from '../../../../utils/api';
+import { IContext } from '../../../../declarations';
 import { AppContext } from '../../../../utils/context';
 import { timeDifference } from '../../../../utils/helpers';
 import ItemStatus from '../../misc/template/ItemStatus';
-import { getReady, getResources, getRestarts, getStatus } from './podHelpers';
+import { getReady, getRestarts, getStatus } from './podHelpers';
+import PodItemMetrics from './PodItemMetrics';
 
 interface IPodItemProps extends RouteComponentProps {
   item: V1Pod;
@@ -19,22 +18,6 @@ interface IPodItemProps extends RouteComponentProps {
 
 const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }: IPodItemProps) => {
   const context = useContext<IContext>(AppContext);
-  const cluster = context.currentCluster();
-
-  const { data } = useQuery<IPodMetrics, Error>(
-    ['Pod', cluster ? cluster.id : '', item, type],
-    async () =>
-      await kubernetesRequest(
-        'GET',
-        `/apis/metrics.k8s.io/v1beta1/namespaces/${
-          item.metadata && item.metadata.namespace ? item.metadata.namespace : ''
-        }/pods/${item.metadata && item.metadata.name ? item.metadata.name : ''}`,
-        '',
-        context.settings,
-        await context.kubernetesAuthWrapper(''),
-      ),
-    { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
-  );
 
   const podStatus = getStatus(item);
 
@@ -68,11 +51,7 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
         <p>
           Ready: {getReady(item)} | Restarts: {getRestarts(item)} | Phase: {podStatus.phase}
           {podStatus.reason ? ` | Reason: ${podStatus.reason}` : ''}
-          {item.spec && item.spec.initContainers && item.spec.containers
-            ? ` | ${getResources(item.spec.initContainers.concat(item.spec.containers), data)}`
-            : item.spec && item.spec.containers
-            ? ` | ${getResources(item.spec.containers, data)}`
-            : ''}
+          {context.settings.showPodMetricsInListViews ? <PodItemMetrics item={item} type={type} /> : null}
           {item.metadata && item.metadata.creationTimestamp
             ? ` | Age: ${timeDifference(
                 new Date().getTime(),

--- a/src/components/resources/workloads/pods/PodItem.tsx
+++ b/src/components/resources/workloads/pods/PodItem.tsx
@@ -51,7 +51,7 @@ const PodItem: React.FunctionComponent<IPodItemProps> = ({ item, section, type }
         <p>
           Ready: {getReady(item)} | Restarts: {getRestarts(item)} | Phase: {podStatus.phase}
           {podStatus.reason ? ` | Reason: ${podStatus.reason}` : ''}
-          {context.settings.showPodMetricsInListViews ? <PodItemMetrics item={item} type={type} /> : null}
+          {context.settings.enablePodMetrics ? <PodItemMetrics item={item} type={type} /> : null}
           {item.metadata && item.metadata.creationTimestamp
             ? ` | Age: ${timeDifference(
                 new Date().getTime(),

--- a/src/components/resources/workloads/pods/PodItemMetrics.tsx
+++ b/src/components/resources/workloads/pods/PodItemMetrics.tsx
@@ -1,0 +1,45 @@
+import { V1Pod } from '@kubernetes/client-node';
+import React, { useContext } from 'react';
+import { useQuery } from 'react-query';
+
+import { IContext, IPodMetrics } from '../../../../declarations';
+import { kubernetesRequest } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+import { getResources } from './podHelpers';
+
+interface IPodItemMetricsProps {
+  item: V1Pod;
+  type: string;
+}
+
+const PodItemMetrics: React.FunctionComponent<IPodItemMetricsProps> = ({ item, type }: IPodItemMetricsProps) => {
+  const context = useContext<IContext>(AppContext);
+  const cluster = context.currentCluster();
+
+  const { data } = useQuery<IPodMetrics, Error>(
+    ['Pod', cluster ? cluster.id : '', item, type],
+    async () =>
+      await kubernetesRequest(
+        'GET',
+        `/apis/metrics.k8s.io/v1beta1/namespaces/${
+          item.metadata && item.metadata.namespace ? item.metadata.namespace : ''
+        }/pods/${item.metadata && item.metadata.name ? item.metadata.name : ''}`,
+        '',
+        context.settings,
+        await context.kubernetesAuthWrapper(''),
+      ),
+    { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
+  );
+
+  return (
+    <span>
+      {item.spec && item.spec.initContainers && item.spec.containers
+        ? ` | ${getResources(item.spec.initContainers.concat(item.spec.containers), data)}`
+        : item.spec && item.spec.containers
+        ? ` | ${getResources(item.spec.containers, data)}`
+        : ''}
+    </span>
+  );
+};
+
+export default PodItemMetrics;

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -121,10 +121,10 @@ const GeneralPage: React.FunctionComponent = () => {
               />
             </IonItem>
             <IonItem>
-              <IonLabel>Show Pod Metrics in List View</IonLabel>
+              <IonLabel>Enable Pod Metrics</IonLabel>
               <IonToggle
-                name="showPodMetricsInListViews"
-                checked={context.settings.showPodMetricsInListViews}
+                name="enablePodMetrics"
+                checked={context.settings.enablePodMetrics}
                 onIonChange={handleToggleChange}
               />
             </IonItem>

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -121,6 +121,14 @@ const GeneralPage: React.FunctionComponent = () => {
               />
             </IonItem>
             <IonItem>
+              <IonLabel>Show Pod Metrics in List View</IonLabel>
+              <IonToggle
+                name="showPodMetricsInListViews"
+                checked={context.settings.showPodMetricsInListViews}
+                onIonChange={handleToggleChange}
+              />
+            </IonItem>
+            <IonItem>
               <IonLabel className="label-for-range" position="stacked">
                 Refresh Interval (in seconds)
               </IonLabel>

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -33,6 +33,7 @@ export interface IAppSettings {
   timeout: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  showPodMetricsInListViews: boolean;
   queryRefetchInterval: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   queryConfig: QueryConfig<any, Error>;

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -33,7 +33,7 @@ export interface IAppSettings {
   timeout: number;
   terminalFontSize: number;
   terminalScrollback: number;
-  showPodMetricsInListViews: boolean;
+  enablePodMetrics: boolean;
   queryRefetchInterval: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   queryConfig: QueryConfig<any, Error>;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SETTINGS: IAppSettings = {
   timeout: 60,
   terminalFontSize: 12,
   terminalScrollback: 10000,
+  showPodMetricsInListViews: true,
   queryRefetchInterval: 5 * 60 * 1000,
   queryConfig: {
     retry: false,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SETTINGS: IAppSettings = {
   timeout: 60,
   terminalFontSize: 12,
   terminalScrollback: 10000,
-  showPodMetricsInListViews: true,
+  enablePodMetrics: true,
   queryRefetchInterval: 5 * 60 * 1000,
   queryConfig: {
     retry: false,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -148,9 +148,9 @@ export const readSettings = (): IAppSettings => {
       terminalScrollback: settings.terminalScrollback
         ? settings.terminalScrollback
         : DEFAULT_SETTINGS.terminalScrollback,
-      showPodMetricsInListViews: settings.hasOwnProperty('showPodMetricsInListViews')
-        ? settings.showPodMetricsInListViews
-        : DEFAULT_SETTINGS.showPodMetricsInListViews,
+      enablePodMetrics: settings.hasOwnProperty('enablePodMetrics')
+        ? settings.enablePodMetrics
+        : DEFAULT_SETTINGS.enablePodMetrics,
       queryRefetchInterval: settings.queryRefetchInterval
         ? settings.queryRefetchInterval
         : DEFAULT_SETTINGS.queryRefetchInterval,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -148,6 +148,9 @@ export const readSettings = (): IAppSettings => {
       terminalScrollback: settings.terminalScrollback
         ? settings.terminalScrollback
         : DEFAULT_SETTINGS.terminalScrollback,
+      showPodMetricsInListViews: settings.hasOwnProperty('showPodMetricsInListViews')
+        ? settings.showPodMetricsInListViews
+        : DEFAULT_SETTINGS.showPodMetricsInListViews,
       queryRefetchInterval: settings.queryRefetchInterval
         ? settings.queryRefetchInterval
         : DEFAULT_SETTINGS.queryRefetchInterval,


### PR DESCRIPTION
We are adding the possibility to disable Pod metrics in the list view. This should improve the usability of kubenav for large clusters, by not doing additional requests for each shown Pod in the list view.

The metrics can be disabled via *Settings* -> *General* -> *Enable Pod Metrics*.