### PR TITLE
Parse Kubeconfig containing OIDC Provider

### DIFF
--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -98,27 +98,67 @@ const KubeconfigPage: React.FunctionComponent<IKubeconfigPageProps> = ({ history
             !user['client-key-data'] &&
             !user.token &&
             !user.username &&
-            !user.password
+            !user.password &&
+            !user['auth-provider']
           ) {
             throw new Error('Invalid kubeconfig');
           }
 
-          clusters.push({
-            id: '',
-            name: ctx.name,
-            url: cluster.server,
-            certificateAuthorityData: cluster['certificate-authority-data']
-              ? cluster['certificate-authority-data']
-              : '',
-            clientCertificateData: user['client-certificate-data'] ? user['client-certificate-data'] : '',
-            clientKeyData: user['client-key-data'] ? user['client-key-data'] : '',
-            token: user.token ? user.token : '',
-            username: user.username ? user.username : '',
-            password: user.password ? user.password : '',
-            insecureSkipTLSVerify: cluster['insecure-skip-tls-verify'] ? cluster['insecure-skip-tls-verify'] : false,
-            authProvider: 'kubeconfig',
-            namespace: 'default',
-          });
+          if (user['auth-provider'] && user['auth-provider'].name !== 'oidc') {
+            throw new Error('Invalid kubeconfig');
+          } else if (user['auth-provider'] && user['auth-provider'].name === 'oidc') {
+            clusters.push({
+              id: '',
+              name: ctx.name,
+              url: cluster.server,
+              certificateAuthorityData: cluster['certificate-authority-data']
+                ? cluster['certificate-authority-data']
+                : '',
+              clientCertificateData: '',
+              clientKeyData: '',
+              token: '',
+              username: '',
+              password: '',
+              insecureSkipTLSVerify: cluster['insecure-skip-tls-verify'] ? cluster['insecure-skip-tls-verify'] : false,
+              authProvider: 'kubeconfig',
+              authProviderOIDC: {
+                clientID: user['auth-provider'].config['client-id'] ? user['auth-provider'].config['client-id'] : '',
+                clientSecret: user['auth-provider'].config['client-secret']
+                  ? user['auth-provider'].config['client-secret']
+                  : '',
+                idToken: user['auth-provider'].config['id-token'] ? user['auth-provider'].config['id-token'] : '',
+                idpIssuerURL: user['auth-provider'].config['idp-issuer-url']
+                  ? user['auth-provider'].config['idp-issuer-url']
+                  : '',
+                refreshToken: user['auth-provider'].config['refresh-token']
+                  ? user['auth-provider'].config['refresh-token']
+                  : '',
+                certificateAuthority: user['auth-provider'].config['idp-certificate-authority-data']
+                  ? user['auth-provider'].config['idp-certificate-authority-data']
+                  : '',
+                accessToken: '',
+                expiry: Math.floor(Date.now() / 1000),
+              },
+              namespace: 'default',
+            });
+          } else {
+            clusters.push({
+              id: '',
+              name: ctx.name,
+              url: cluster.server,
+              certificateAuthorityData: cluster['certificate-authority-data']
+                ? cluster['certificate-authority-data']
+                : '',
+              clientCertificateData: user['client-certificate-data'] ? user['client-certificate-data'] : '',
+              clientKeyData: user['client-key-data'] ? user['client-key-data'] : '',
+              token: user.token ? user.token : '',
+              username: user.username ? user.username : '',
+              password: user.password ? user.password : '',
+              insecureSkipTLSVerify: cluster['insecure-skip-tls-verify'] ? cluster['insecure-skip-tls-verify'] : false,
+              authProvider: 'kubeconfig',
+              namespace: 'default',
+            });
+          }
         }
 
         context.addCluster(clusters);

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -242,6 +242,21 @@ export interface IKubeconfigUser {
   token?: string;
   username?: string;
   password?: string;
+  'auth-provider'?: IKubeconfigUserAuthProvider;
+}
+
+export interface IKubeconfigUserAuthProvider {
+  name: string;
+  config: IKubeconfigUserAuthProviderOIDC;
+}
+
+export interface IKubeconfigUserAuthProviderOIDC {
+  'client-id'?: string;
+  'client-secret'?: string;
+  'id-token'?: string;
+  'idp-issuer-url'?: string;
+  'refresh-token'?: string;
+  'idp-certificate-authority-data'?: string;
 }
 
 export interface IKubeconfigUserRef {


### PR DESCRIPTION
Until now it wasn't possible to add a Kubeconfig which contains clusters using an OIDC provider. kubenav rejected these config with an error message "Invalid kubeconfig".

Now it is also possible to paste/select a Kubeconfig file containing an OIDC provider. The auth context is now used by kubenav and the cluster is added in the same way, like a cluster using token/certificate based authentication.