### PR TITLE
Disable cluster and node metrics

### DIFF
--- a/src/components/overview/ClusterMetrics.tsx
+++ b/src/components/overview/ClusterMetrics.tsx
@@ -162,8 +162,6 @@ const ClusterMetrics: React.FunctionComponent = () => {
     { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
   );
 
-  console.log(data);
-
   if (isError || data === undefined) {
     return null;
   } else {

--- a/src/components/overview/ClusterMetrics.tsx
+++ b/src/components/overview/ClusterMetrics.tsx
@@ -47,7 +47,7 @@ const ClusterMetrics: React.FunctionComponent = () => {
   const cluster = context.currentCluster();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data } = useQuery<IMetrics, Error>(
+  const { isError, data } = useQuery<IMetrics, Error>(
     ['ClusterMetrics', cluster ? cluster.id : ''],
     async () => {
       try {
@@ -162,19 +162,25 @@ const ClusterMetrics: React.FunctionComponent = () => {
     { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
   );
 
-  return (
-    <IonRow>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="CPU" data={data && data.cpu ? data.cpu : undefined} unit="m" />
-      </IonCol>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="Memory" data={data && data.memory ? data.memory : undefined} unit="Mi" />
-      </IonCol>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="Pods" data={data && data.pods ? data.pods : undefined} unit="" />
-      </IonCol>
-    </IonRow>
-  );
+  console.log(data);
+
+  if (isError || data === undefined) {
+    return null;
+  } else {
+    return (
+      <IonRow>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="CPU" data={data && data.cpu ? data.cpu : undefined} unit="m" />
+        </IonCol>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="Memory" data={data && data.memory ? data.memory : undefined} unit="Mi" />
+        </IonCol>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="Pods" data={data && data.pods ? data.pods : undefined} unit="" />
+        </IonCol>
+      </IonRow>
+    );
+  }
 };
 
 export default memo(ClusterMetrics, (): boolean => {

--- a/src/components/overview/OverviewPage.tsx
+++ b/src/components/overview/OverviewPage.tsx
@@ -38,7 +38,7 @@ const OverviewPage: React.FunctionComponent = () => {
       <IonContent>
         {context.clusters && context.cluster ? (
           <IonGrid>
-            <ClusterMetrics />
+            {context.settings.enablePodMetrics ? <ClusterMetrics /> : null}
             <Warnings />
 
             {context.settings.prometheusEnabled ? (

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -96,7 +96,7 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
 
       {item.metadata ? <Metadata metadata={item.metadata} type={type} /> : null}
 
-      {data ? <NodeMetrics item={item} metrics={data} /> : null}
+      {data && context.settings.enablePodMetrics ? <NodeMetrics item={item} metrics={data} /> : null}
 
       <IonRow>
         {item.status && item.status.capacity && item.status.allocatable ? (

--- a/src/components/resources/cluster/nodes/NodeMetrics.tsx
+++ b/src/components/resources/cluster/nodes/NodeMetrics.tsx
@@ -53,7 +53,7 @@ const NodeMetrics: React.FunctionComponent<INodeMetricsProps> = ({ item, metrics
   const cluster = context.currentCluster();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data } = useQuery<IMetrics, Error>(
+  const { isError, data } = useQuery<IMetrics, Error>(
     ['NodeMetrics', cluster ? cluster.id : ''],
     async () => {
       try {
@@ -134,19 +134,23 @@ const NodeMetrics: React.FunctionComponent<INodeMetricsProps> = ({ item, metrics
     { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
   );
 
-  return (
-    <IonRow>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="CPU" data={data && data.cpu ? data.cpu : undefined} unit="m" />
-      </IonCol>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="Memory" data={data && data.memory ? data.memory : undefined} unit="Mi" />
-      </IonCol>
-      <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-        <ChartDetailsRadialBar title="Pods" data={data && data.pods ? data.pods : undefined} unit="" />
-      </IonCol>
-    </IonRow>
-  );
+  if (isError || data === undefined) {
+    return null;
+  } else {
+    return (
+      <IonRow>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="CPU" data={data && data.cpu ? data.cpu : undefined} unit="m" />
+        </IonCol>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="Memory" data={data && data.memory ? data.memory : undefined} unit="Mi" />
+        </IonCol>
+        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+          <ChartDetailsRadialBar title="Pods" data={data && data.pods ? data.pods : undefined} unit="" />
+        </IonCol>
+      </IonRow>
+    );
+  }
 };
 
 export default memo(NodeMetrics, (): boolean => {


### PR DESCRIPTION
The cluster and node metrics are now disabled, when the pod metrics are disabled in the settings, because we also need to load all pods for these metrics. The panels are also not shown when one of the requests fails.

Closes #228.