### PR TITLE
Create Job from CronJob

### DIFF
--- a/pkg/kube/request.go
+++ b/pkg/kube/request.go
@@ -52,6 +52,8 @@ func KubernetesRequest(ctx context.Context, method, url, body string, clientset 
 		return clientset.RESTClient().Delete().RequestURI(url).DoRaw(ctx)
 	} else if method == "PATCH" {
 		return clientset.RESTClient().Patch(types.JSONPatchType).RequestURI(url).Body([]byte(body)).DoRaw(ctx)
+	} else if method == "POST" {
+		return clientset.RESTClient().Post().RequestURI(url).Body([]byte(body)).DoRaw(ctx)
 	}
 
 	return []byte(``), fmt.Errorf("Request method is not implemented")

--- a/src/components/resources/misc/details/CreateJobItem.tsx
+++ b/src/components/resources/misc/details/CreateJobItem.tsx
@@ -1,0 +1,122 @@
+import { IonAlert, IonIcon, IonItem, IonLabel } from '@ionic/react';
+import { V1beta1CronJob, V1Job } from '@kubernetes/client-node';
+import { caretForwardCircle } from 'ionicons/icons';
+import React, { useContext, useState } from 'react';
+
+import { IContext, TActivator } from '../../../../declarations';
+import { kubernetesRequest } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+import { randomString } from '../../../../utils/helpers';
+import { resources } from '../../../../utils/resources';
+
+interface ICreateJobItemActivatorProps {
+  activator: TActivator;
+  onClick: () => void;
+}
+
+export const CreateJobItemActivator: React.FunctionComponent<ICreateJobItemActivatorProps> = ({
+  activator,
+  onClick,
+}: ICreateJobItemActivatorProps) => {
+  if (activator === 'item') {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={caretForwardCircle} />
+        <IonLabel>Create Job</IonLabel>
+      </IonItem>
+    );
+  } else {
+    return null;
+  }
+};
+
+interface ICreateJobItemProps {
+  show: boolean;
+  hide: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: V1beta1CronJob;
+  closeAction?: () => void;
+}
+
+const CreateJobItem: React.FunctionComponent<ICreateJobItemProps> = ({ show, hide, item }: ICreateJobItemProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [error, setError] = useState<string>('');
+
+  const handleCreateJob = async () => {
+    try {
+      if (item.metadata && item.metadata.namespace && item.metadata.name && item.spec && item.spec.jobTemplate.spec) {
+        const jobURL = resources.workloads.pages.jobs.listURL(
+          item.metadata && item.metadata.namespace ? item.metadata.namespace : '',
+        );
+        const jobName = `${item.metadata.name}-manual-${randomString(6)}`.toLowerCase();
+        const job: V1Job = {
+          kind: 'Job',
+          apiVersion: 'batch/v1',
+          metadata: {
+            name: jobName,
+            namespace: item.metadata.namespace,
+            labels: {
+              'job-name': jobName,
+            },
+            annotations: {
+              'cronjob.kubernetes.io/instantiate': 'manual',
+            },
+          },
+          spec: {
+            parallelism: item.spec.jobTemplate.spec.parallelism,
+            completions: item.spec.jobTemplate.spec.completions,
+            backoffLimit: item.spec.jobTemplate.spec.backoffLimit,
+            template: {
+              metadata: {
+                labels: {
+                  'job-name': jobName,
+                },
+              },
+              spec: item.spec.jobTemplate.spec.template.spec,
+            },
+          },
+        };
+
+        await kubernetesRequest(
+          'POST',
+          jobURL,
+          JSON.stringify(job),
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+      }
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {error !== '' ? (
+        <IonAlert
+          isOpen={error !== ''}
+          onDidDismiss={() => setError('')}
+          header={`Could not create Job ${item.metadata ? item.metadata.name : ''}`}
+          message={error}
+          buttons={['OK']}
+        />
+      ) : null}
+
+      <IonAlert
+        isOpen={show}
+        onDidDismiss={hide}
+        header={item.metadata ? item.metadata.name : ''}
+        message={`Do you really want to create the Job ${
+          item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
+        }${item.metadata ? item.metadata.name : ''}?`}
+        buttons={[
+          { text: 'Cancel', role: 'cancel', handler: hide },
+          { text: 'Create', handler: () => handleCreateJob() },
+        ]}
+      />
+    </React.Fragment>
+  );
+};
+
+export default CreateJobItem;

--- a/src/components/resources/misc/details/Details.tsx
+++ b/src/components/resources/misc/details/Details.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { IBookmark } from '../../../../declarations';
 import useWindowWidth from '../../../../utils/useWindowWidth';
 import Bookmark from '../shared/Bookmark';
+import CreateJobItem, { CreateJobItemActivator } from './CreateJobItem';
 import DeleteItem, { DeleteItemActivator } from './DeleteItem';
 import EditItem, { EditItemActivator } from './EditItem';
 import LogsItem, { LogsItemActivator } from './LogsItem';
@@ -14,7 +15,7 @@ import ShellItem, { ShellItemActivator } from './ShellItem';
 import SSHItem, { SSHItemActivator } from './SSHItem';
 import ViewItem, { ViewItemActivator } from './ViewItem';
 
-type TShow = '' | 'delete' | 'edit' | 'logs' | 'restart' | 'scale' | 'shell' | 'ssh' | 'view';
+type TShow = '' | 'createjob' | 'delete' | 'edit' | 'logs' | 'restart' | 'scale' | 'shell' | 'ssh' | 'view';
 
 interface IDetailsProps {
   refresh: () => void;
@@ -52,6 +53,9 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, type, item, 
             <IonLabel>Refresh</IonLabel>
           </IonItem>
           <Bookmark bookmark={bookmark} hide={() => showType('')} />
+          {type === 'cronjobs' ? (
+            <CreateJobItemActivator activator="item" onClick={() => showType('createjob')} />
+          ) : null}
           {type === 'deployments' ||
           type === 'statefulsets' ||
           type === 'replicationcontrollers' ||
@@ -76,6 +80,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, type, item, 
         </IonList>
       </IonPopover>
 
+      <CreateJobItem show={show === 'createjob'} hide={() => setShow('')} item={item} />
       <ScaleItem show={show === 'scale'} hide={() => setShow('')} item={item} url={url} />
       <RestartItem show={show === 'restart'} hide={() => setShow('')} item={item} url={url} />
       <LogsItem show={show === 'logs'} hide={() => setShow('')} item={item} url={url} />


### PR DESCRIPTION
It is now possible to create a Job from a CronJob, for that a new menu item **Create Job** was added to the details menu of a CronJob. This feature is an implementation of the `kubectl create job --from=cronjob/<name of cronjob> <name of job>` command. The created Job follows the following naming: `<cronjob name>-manual-<random string>`.