### PR TITLE
Add shortcut to toggle full screen

### DIFF
--- a/cmd/electron/menu.go
+++ b/cmd/electron/menu.go
@@ -163,6 +163,7 @@ func getMenuOptions(updateAvailable bool, client kube.Client, log *logrus.Logger
 				{Label: astikit.StrPtr("Select All"), Role: astilectron.MenuItemRoleSelectAll},
 				{Type: astilectron.MenuItemTypeSeparator},
 				{Label: astikit.StrPtr("Reload"), Role: astilectron.MenuItemRoleReload},
+				{Label: astikit.StrPtr("Full Screen"), Role: astilectron.MenuItemRoleToggleFullScreen},
 			},
 		},
 		{


### PR DESCRIPTION
It is now possible to toggle the full screen modus of kubenav. Next to the shortcut the full screen modus can also be activated via the menu.

Closes #227.