### PR TITLE
Add support for creating manifests

### DIFF
--- a/src/components/misc/Editor.tsx
+++ b/src/components/misc/Editor.tsx
@@ -1,4 +1,5 @@
 import { Plugins } from '@capacitor/core';
+import { isPlatform } from '@ionic/react';
 import React, { useContext, useRef } from 'react';
 import AceEditor from 'react-ace';
 
@@ -37,13 +38,15 @@ const Editor: React.FunctionComponent<IEditorProps> = ({
     }
   };
 
-  Keyboard.addListener('keyboardDidShow', () => {
-    editor.current?.editor.resize();
-  });
+  if (isPlatform('hybrid')) {
+    Keyboard.addListener('keyboardDidShow', () => {
+      editor.current?.editor.resize();
+    });
 
-  Keyboard.addListener('keyboardDidHide', () => {
-    editor.current?.editor.resize();
-  });
+    Keyboard.addListener('keyboardDidHide', () => {
+      editor.current?.editor.resize();
+    });
+  }
 
   return (
     <AceEditor

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -114,6 +114,8 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
                 url: match.url,
                 namespace: isNamespaced(match.params.type) ? (cluster ? cluster.namespace : '') : '',
               }}
+              type={match.params.type}
+              page={page}
             />
           </IonButtons>
         </IonToolbar>

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -123,6 +123,7 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
                 url: match.url,
                 namespace: cluster ? cluster.namespace : '',
               }}
+              type="customresourcedefinitions"
             />
           </IonButtons>
         </IonToolbar>

--- a/src/components/resources/misc/list/CreateItem.tsx
+++ b/src/components/resources/misc/list/CreateItem.tsx
@@ -160,11 +160,18 @@ export const CreateItemActivator: React.FunctionComponent<ICreateItemActivatorPr
 interface ICreateItemProps {
   page: IAppPage;
   type: string;
+  refresh: () => void;
   show: boolean;
   hide: () => void;
 }
 
-const CreateItem: React.FunctionComponent<ICreateItemProps> = ({ type, page, show, hide }: ICreateItemProps) => {
+const CreateItem: React.FunctionComponent<ICreateItemProps> = ({
+  type,
+  page,
+  refresh,
+  show,
+  hide,
+}: ICreateItemProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
 
@@ -198,6 +205,7 @@ const CreateItem: React.FunctionComponent<ICreateItemProps> = ({ type, page, sho
         );
       }
       hide();
+      refresh();
     } catch (err) {
       setError(err);
     }

--- a/src/components/resources/misc/list/CreateItem.tsx
+++ b/src/components/resources/misc/list/CreateItem.tsx
@@ -1,0 +1,251 @@
+import {
+  IonAlert,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonItemOption,
+  IonLabel,
+  IonList,
+  IonModal,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { close, create } from 'ionicons/icons';
+import yaml from 'js-yaml';
+import React, { useContext, useState } from 'react';
+
+import { IAppPage, IContext, TActivator } from '../../../../declarations';
+import { kubernetesRequest } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+import { isNamespaced } from '../../../../utils/helpers';
+import Editor from '../../../misc/Editor';
+
+const createYAML = (
+  type: string,
+  apiVersion: string,
+  kind: string,
+  name: string,
+  namespace: string,
+  replicas: number,
+  image: string,
+): string => {
+  if (type === 'deployments' || type === 'statefulsets') {
+    return `apiVersion: ${apiVersion}
+    kind: ${kind}
+    metadata:
+      labels:
+        app: ${name}
+      name: ${name}
+      namespace: ${namespace}
+    spec:
+      replicas: ${replicas}
+      selector:
+        matchLabels:
+          app: ${name}
+      template:
+        metadata:
+          labels:
+            app: ${name}
+        spec:
+          containers:
+            - name: ${name}
+              image: ${image}`;
+  } else if (type === 'daemonsets' || type === 'jobs') {
+    return `apiVersion: ${apiVersion}
+    kind: ${kind}
+    metadata:
+      labels:
+        app: ${name}
+      name: ${name}
+      namespace: ${namespace}
+    spec:
+      selector:
+        matchLabels:
+          app: ${name}
+      template:
+        metadata:
+          labels:
+            app: ${name}
+        spec:
+          containers:
+            - name: ${name}
+              image: ${image}`;
+  } else if (isNamespaced(type)) {
+    return `apiVersion: ${apiVersion}
+    kind: ${kind}
+    metadata:
+      name: ${name}
+      namespace: ${namespace}`;
+  } else {
+    return `apiVersion: ${apiVersion}
+    kind: ${kind}
+    metadata:
+      name: ${name}`;
+  }
+};
+
+interface ICreateItemActivatorProps {
+  activator: TActivator;
+  onClick: () => void;
+}
+
+export const CreateItemActivator: React.FunctionComponent<ICreateItemActivatorProps> = ({
+  activator,
+  onClick,
+}: ICreateItemActivatorProps) => {
+  if (activator === 'item-option') {
+    return (
+      <IonItemOption color="primary" onClick={onClick}>
+        <IonIcon slot="start" icon={create} />
+        Create
+      </IonItemOption>
+    );
+  } else if (activator === 'button') {
+    return (
+      <IonButton onClick={onClick}>
+        <IonIcon slot="icon-only" icon={create} />
+      </IonButton>
+    );
+  } else {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={create} />
+        <IonLabel>Create</IonLabel>
+      </IonItem>
+    );
+  }
+};
+
+interface ICreateItemProps {
+  page: IAppPage;
+  type: string;
+  show: boolean;
+  hide: () => void;
+}
+
+const CreateItem: React.FunctionComponent<ICreateItemProps> = ({ type, page, show, hide }: ICreateItemProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [error, setError] = useState<string>('');
+  const [view, setView] = useState<number>(0);
+  const [valueName, setValueName] = useState<string>('');
+  const [valueNamespace, setValueNamespace] = useState<string>('');
+  const [valueReplicas, setValueReplicas] = useState<number>(1);
+  const [valueImage, setValueImage] = useState<string>('');
+  const [value, setValue] = useState<string>('');
+
+  const handleNextView = () => {
+    setValue(createYAML(type, page.apiVersion, page.kind, valueName, valueNamespace, valueReplicas, valueImage));
+    setView(1);
+  };
+
+  const handleName = (event) => {
+    setValueName(event.target.value);
+  };
+
+  const handleNamespace = (event) => {
+    setValueNamespace(event.target.value);
+  };
+
+  const handleReplicas = (event) => {
+    setValueReplicas(event.target.value);
+  };
+
+  const handleImage = (event) => {
+    setValueImage(event.target.value);
+  };
+
+  const handleHide = () => {
+    setView(0);
+    hide();
+  };
+
+  const handleCreate = async () => {
+    try {
+      const yamlObj = yaml.safeLoad(value);
+      if (yamlObj && typeof yamlObj === 'object') {
+        await kubernetesRequest(
+          'POST',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          page.listURL(isNamespaced(type) ? (yamlObj as any).metadata.namespace : ''),
+          JSON.stringify(yamlObj),
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+      }
+      handleHide();
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  return (
+    <React.Fragment>
+      {error !== '' ? (
+        <IonAlert
+          isOpen={error !== ''}
+          onDidDismiss={() => setError('')}
+          header={`Could not create ${page.singleText}`}
+          message={error}
+          buttons={['OK']}
+        />
+      ) : null}
+
+      <IonModal isOpen={show} onDidDismiss={handleHide}>
+        <IonHeader>
+          <IonToolbar>
+            <IonButtons slot="start">
+              <IonButton onClick={handleHide}>
+                <IonIcon slot="icon-only" icon={close} />
+              </IonButton>
+            </IonButtons>
+            <IonTitle>Create {page.singleText}</IonTitle>
+            <IonButtons slot="primary">
+              {view === 0 ? (
+                <IonButton onClick={() => handleNextView()}>Next</IonButton>
+              ) : (
+                <IonButton onClick={() => handleCreate()}>Create</IonButton>
+              )}
+            </IonButtons>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent>
+          {view === 0 ? (
+            <IonList lines="full">
+              <IonItem>
+                <IonLabel position="stacked">Name</IonLabel>
+                <IonInput type="text" required={true} value={valueName} onInput={handleName} />
+              </IonItem>
+              {isNamespaced(type) ? (
+                <IonItem>
+                  <IonLabel position="stacked">Namespace</IonLabel>
+                  <IonInput type="text" required={true} value={valueNamespace} onInput={handleNamespace} />
+                </IonItem>
+              ) : null}
+              {type === 'deployments' || type === 'statefulsets' ? (
+                <IonItem>
+                  <IonLabel position="stacked">Replicas</IonLabel>
+                  <IonInput type="number" required={true} value={valueReplicas} onInput={handleReplicas} />
+                </IonItem>
+              ) : null}
+              {type === 'daemonsets' || type === 'deployments' || type === 'statefulsets' || type === 'jobs' ? (
+                <IonItem>
+                  <IonLabel position="stacked">Image</IonLabel>
+                  <IonInput type="text" required={true} value={valueImage} onInput={handleImage} />
+                </IonItem>
+              ) : null}
+            </IonList>
+          ) : (
+            <Editor readOnly={false} value={value} onChange={(newValue) => setValue(newValue)} fullHeight={true} />
+          )}
+        </IonContent>
+      </IonModal>
+    </React.Fragment>
+  );
+};
+
+export default CreateItem;

--- a/src/components/resources/misc/list/Details.tsx
+++ b/src/components/resources/misc/list/Details.tsx
@@ -2,18 +2,21 @@ import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover } from '@ion
 import { ellipsisHorizontal, ellipsisVertical, refresh as refreshIcon } from 'ionicons/icons';
 import React, { useState } from 'react';
 
-import { IBookmark } from '../../../../declarations';
+import { IAppPage, IBookmark } from '../../../../declarations';
 import Bookmark from '../shared/Bookmark';
+import CreateItem, { CreateItemActivator } from './CreateItem';
 
-type TShow = '';
+type TShow = '' | 'create';
 
 interface IDetailsProps {
   refresh: () => void;
   bookmark: IBookmark;
+  type: string;
+  page?: IAppPage;
 }
 
-const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, bookmark }: IDetailsProps) => {
-  const [, setShow] = useState<TShow>('');
+const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, bookmark, type, page }: IDetailsProps) => {
+  const [show, setShow] = useState<TShow>('');
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
 
@@ -38,8 +41,19 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, bookmark }: 
             <IonLabel>Refresh</IonLabel>
           </IonItem>
           <Bookmark bookmark={bookmark} hide={() => showType('')} />
+          {page !== undefined &&
+          type !== 'componentstatuses' &&
+          type !== 'customresourcedefinitions' &&
+          type !== 'events' &&
+          type !== 'nodes' ? (
+            <CreateItemActivator activator="item" onClick={() => showType('create')} />
+          ) : null}
         </IonList>
       </IonPopover>
+
+      {page !== undefined ? (
+        <CreateItem show={show === 'create'} hide={() => setShow('')} type={type} page={page} />
+      ) : null}
 
       <IonButton
         onClick={(e) => {

--- a/src/components/resources/misc/list/Details.tsx
+++ b/src/components/resources/misc/list/Details.tsx
@@ -52,7 +52,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, bookmark, ty
       </IonPopover>
 
       {page !== undefined ? (
-        <CreateItem show={show === 'create'} hide={() => setShow('')} type={type} page={page} />
+        <CreateItem show={show === 'create'} hide={() => setShow('')} type={type} page={page} refresh={refresh} />
       ) : null}
 
       <IonButton

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -7,6 +7,8 @@ export interface IAppPage {
   icon: string;
   singleText: string;
   pluralText: string;
+  apiVersion: string;
+  kind: string;
   listURL: (namespace: string) => string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   listItemComponent: React.FunctionComponent<any>;

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -77,6 +77,8 @@ export const resources: IAppSections = {
         singleText: 'Cron Job',
         pluralText: 'Cron Jobs',
         icon: '/assets/icons/kubernetes/cronjob.png',
+        kind: 'CronJob',
+        apiVersion: 'batch/v1beta1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/batch/v1beta1/namespaces/${namespace}/cronjobs` : `/apis/batch/v1beta1/cronjobs`;
         },
@@ -90,6 +92,8 @@ export const resources: IAppSections = {
         singleText: 'Daemon Set',
         pluralText: 'Daemon Sets',
         icon: '/assets/icons/kubernetes/ds.png',
+        kind: 'DaemonSet',
+        apiVersion: 'apps/v1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/apps/v1/namespaces/${namespace}/daemonsets` : `/apis/apps/v1/daemonsets`;
         },
@@ -103,6 +107,8 @@ export const resources: IAppSections = {
         singleText: 'Deployment',
         pluralText: 'Deployments',
         icon: '/assets/icons/kubernetes/deploy.png',
+        kind: 'Deployment',
+        apiVersion: 'apps/v1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/apps/v1/namespaces/${namespace}/deployments` : `/apis/apps/v1/deployments`;
         },
@@ -116,6 +122,8 @@ export const resources: IAppSections = {
         singleText: 'Job',
         pluralText: 'Jobs',
         icon: '/assets/icons/kubernetes/job.png',
+        kind: 'Job',
+        apiVersion: 'batch/v1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/batch/v1/namespaces/${namespace}/jobs` : `/apis/batch/v1/jobs`;
         },
@@ -129,6 +137,8 @@ export const resources: IAppSections = {
         singleText: 'Pod',
         pluralText: 'Pods',
         icon: '/assets/icons/kubernetes/pod.png',
+        kind: 'Pod',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/pods` : `/api/v1/pods`;
         },
@@ -142,6 +152,8 @@ export const resources: IAppSections = {
         singleText: 'Replica Set',
         pluralText: 'Replica Sets',
         icon: '/assets/icons/kubernetes/rs.png',
+        kind: 'ReplicaSet',
+        apiVersion: 'apps/v1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/apps/v1/namespaces/${namespace}/replicasets` : `/apis/apps/v1/replicasets`;
         },
@@ -155,6 +167,8 @@ export const resources: IAppSections = {
         singleText: 'Replication Controller',
         pluralText: 'Replication Controllers',
         icon: '/assets/icons/kubernetes/deploy.png',
+        kind: 'ReplicationController',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/api/v1/namespaces/${namespace}/replicationcontrollers`
@@ -170,6 +184,8 @@ export const resources: IAppSections = {
         singleText: 'Stateful Set',
         pluralText: 'Stateful Sets',
         icon: '/assets/icons/kubernetes/sts.png',
+        kind: 'StatefulSet',
+        apiVersion: 'apps/v1',
         listURL: (namespace: string): string => {
           return namespace ? `/apis/apps/v1/namespaces/${namespace}/statefulsets` : `/apis/apps/v1/statefulsets`;
         },
@@ -188,6 +204,8 @@ export const resources: IAppSections = {
         singleText: 'Endpoint',
         pluralText: 'Endpoints',
         icon: '/assets/icons/kubernetes/ep.png',
+        kind: 'Endpoints',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/endpoints` : `/api/v1/endpoints`;
         },
@@ -201,6 +219,8 @@ export const resources: IAppSections = {
         singleText: 'Horizontal Pod Autoscaler',
         pluralText: 'Horizontal Pod Autoscalers',
         icon: '/assets/icons/kubernetes/hpa.png',
+        kind: 'HorizontalPodAutoscaler',
+        apiVersion: 'autoscaling/v2beta1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/autoscaling/v2beta1/namespaces/${namespace}/horizontalpodautoscalers`
@@ -216,6 +236,8 @@ export const resources: IAppSections = {
         singleText: 'Ingresse',
         pluralText: 'Ingresses',
         icon: '/assets/icons/kubernetes/ing.png',
+        kind: 'Ingresse',
+        apiVersion: 'networking.k8s.io/v1beta1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/networking.k8s.io/v1beta1/namespaces/${namespace}/ingresses`
@@ -231,6 +253,8 @@ export const resources: IAppSections = {
         singleText: 'Network Policy',
         pluralText: 'Network Policies',
         icon: '/assets/icons/kubernetes/netpol.png',
+        kind: 'NetworkPolicy',
+        apiVersion: 'networking.k8s.io/v1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/networking.k8s.io/v1/namespaces/${namespace}/networkpolicies`
@@ -246,6 +270,8 @@ export const resources: IAppSections = {
         singleText: 'Service',
         pluralText: 'Services',
         icon: '/assets/icons/kubernetes/svc.png',
+        kind: 'Service',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/services` : `/api/v1/services`;
         },
@@ -264,6 +290,8 @@ export const resources: IAppSections = {
         singleText: 'Config Map',
         pluralText: 'Config Maps',
         icon: '/assets/icons/kubernetes/cm.png',
+        kind: 'ConfigMap',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/configmaps` : `/api/v1/configmaps`;
         },
@@ -278,6 +306,8 @@ export const resources: IAppSections = {
         pluralText: 'Persistent Volumes',
         icon: '/assets/icons/kubernetes/pv.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'PersistentVolume',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return `/api/v1/persistentvolumes`;
         },
@@ -291,6 +321,8 @@ export const resources: IAppSections = {
         singleText: 'Persistent Volume Claim',
         pluralText: 'Persistent Volume Claims',
         icon: '/assets/icons/kubernetes/pvc.png',
+        kind: 'PersistentVolumeClaim',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/api/v1/namespaces/${namespace}/persistentvolumeclaims`
@@ -306,6 +338,8 @@ export const resources: IAppSections = {
         singleText: 'Pod Disruption Budget',
         pluralText: 'Pod Disruption Budgets',
         icon: '/assets/icons/kubernetes/pdb.png',
+        kind: 'PodDisruptionBudget',
+        apiVersion: 'policy/v1beta1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/policy/v1beta1/namespaces/${namespace}/poddisruptionbudgets`
@@ -321,6 +355,8 @@ export const resources: IAppSections = {
         singleText: 'Secret',
         pluralText: 'Secrets',
         icon: '/assets/icons/kubernetes/secret.png',
+        kind: 'Secret',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/secrets` : `/api/v1/secrets`;
         },
@@ -334,6 +370,8 @@ export const resources: IAppSections = {
         singleText: 'Service Account',
         pluralText: 'Service Accounts',
         icon: '/assets/icons/kubernetes/sa.png',
+        kind: 'ServiceAccount',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/serviceaccounts` : `/api/v1/serviceaccounts`;
         },
@@ -348,6 +386,8 @@ export const resources: IAppSections = {
         pluralText: 'Storage Classes',
         icon: '/assets/icons/kubernetes/sc.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'StorageClass',
+        apiVersion: 'storage.k8s.io/v1',
         listURL: (namespace: string): string => {
           return `/apis/storage.k8s.io/v1/storageclasses`;
         },
@@ -367,6 +407,8 @@ export const resources: IAppSections = {
         pluralText: 'Cluster Roles',
         icon: '/assets/icons/kubernetes/c-role.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'ClusterRole',
+        apiVersion: 'rbac.authorization.k8s.io/v1',
         listURL: (namespace: string): string => {
           return `/apis/rbac.authorization.k8s.io/v1/clusterroles`;
         },
@@ -381,6 +423,8 @@ export const resources: IAppSections = {
         pluralText: 'Cluster Role Bindings',
         icon: '/assets/icons/kubernetes/c-rb.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'ClusterRoleBinding',
+        apiVersion: 'rbac.authorization.k8s.io/v1',
         listURL: (namespace: string): string => {
           return `/apis/rbac.authorization.k8s.io/v1/clusterrolebindings`;
         },
@@ -394,6 +438,8 @@ export const resources: IAppSections = {
         singleText: 'Role',
         pluralText: 'Roles',
         icon: '/assets/icons/kubernetes/role.png',
+        kind: 'Role',
+        apiVersion: 'rbac.authorization.k8s.io/v1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/roles`
@@ -409,6 +455,8 @@ export const resources: IAppSections = {
         singleText: 'Role Binding',
         pluralText: 'Role Bindings',
         icon: '/assets/icons/kubernetes/rb.png',
+        kind: 'RoleBinding',
+        apiVersion: 'rbac.authorization.k8s.io/v1',
         listURL: (namespace: string): string => {
           return namespace
             ? `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/rolebindings`
@@ -430,6 +478,8 @@ export const resources: IAppSections = {
         pluralText: 'Component Statuses',
         icon: '/assets/icons/kubernetes/master.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'ComponentStatus',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return `/api/v1/componentstatuses`;
         },
@@ -445,6 +495,8 @@ export const resources: IAppSections = {
         pluralText: 'Custom Resource Definitions',
         icon: '/assets/icons/kubernetes/crd.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: '',
+        apiVersion: '',
         listURL: (namespace: string): string => {
           return `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`;
         },
@@ -459,6 +511,8 @@ export const resources: IAppSections = {
         singleText: 'Event',
         pluralText: 'Events',
         icon: '/assets/icons/kubernetes/events.png',
+        kind: 'Event',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return namespace ? `/api/v1/namespaces/${namespace}/events` : `/api/v1/events`;
         },
@@ -473,6 +527,8 @@ export const resources: IAppSections = {
         pluralText: 'Namespaces',
         icon: '/assets/icons/kubernetes/ns.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'Namespace',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return `/api/v1/namespaces`;
         },
@@ -487,6 +543,8 @@ export const resources: IAppSections = {
         pluralText: 'Nodes',
         icon: '/assets/icons/kubernetes/node.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'Node',
+        apiVersion: 'v1',
         listURL: (namespace: string): string => {
           return `/api/v1/nodes`;
         },
@@ -501,6 +559,8 @@ export const resources: IAppSections = {
         pluralText: 'Pod Security Policies',
         icon: '/assets/icons/kubernetes/psp.png',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        kind: 'PodSecurityPolicy',
+        apiVersion: 'policy/v1beta1',
         listURL: (namespace: string): string => {
           return `/apis/policy/v1beta1/podsecuritypolicies`;
         },


### PR DESCRIPTION
It is now possible to create new manifest files, within the details menu in the list view of each component. This feature is available for each resource kind, except ComponentStatuses. CRDs, Events and Nodes.

To implement this feature we had to add the `apiVersion` and `kind` to each page, which we may also should use for the generation of the request URLs in the future.

The user have to enter the name for each resource. For namespaced resources we are also requesting the namespace. For some other resources like Deployments, StatefulSets, etc. we are also showing some additional fields in the form (e.g. replicas and image). When a user clicks on the **Next** button the complete yaml file is shown where the user can add additional properties. With a click on the **Create** button the yaml file is applied in the Kubernetes cluster.

Closes #212. 