### PR TITLE
Add support for AWS SSO

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,6 +26,8 @@ func (c *Client) Register(router *http.ServeMux) {
 	// The AWS handlers are used to handle the authentication against AWS for the mobile implementation of kubenav.
 	router.HandleFunc("/api/aws/clusters", middleware.Cors(c.awsGetClustersHandler))
 	router.HandleFunc("/api/aws/token", middleware.Cors(c.awsGetTokenHandler))
+	router.HandleFunc("/api/aws/ssoconfig", middleware.Cors(c.awsGetSSOConfigHandler))
+	router.HandleFunc("/api/aws/ssotoken", middleware.Cors(c.awsGetSSOTokenHandler))
 
 	// The Azure handler is used to retrieve all AKS clusters from Azure for the mobile implementation of kubenav.
 	router.HandleFunc("/api/azure/clusters", middleware.Cors(c.azureGetClustersHandler))

--- a/pkg/api/aws.go
+++ b/pkg/api/aws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/kubenav/kubenav/pkg/api/middleware"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/sso"
+	"github.com/aws/aws-sdk-go/service/ssooidc"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
@@ -21,12 +24,35 @@ type AWSRequest struct {
 	SecretAccessKey string `json:"secretAccessKey"`
 	SessionToken    string `json:"sessionToken"`
 	Region          string `json:"region"`
+	StartURL        string `json:"startURL"`
 	ClusterID       string `json:"clusterID"`
 }
 
 // AWSTokenResponse is the structure to return an Token for AWS.
 type AWSTokenResponse struct {
 	Token string `json:"token"`
+}
+
+// AWSSSOConfig is the structure to return the configuration for AWS SSO.
+type AWSSSOConfig struct {
+	AWSSSOCredentials
+	Client ssooidc.RegisterClientOutput           `json:"client"`
+	Device ssooidc.StartDeviceAuthorizationOutput `json:"device"`
+}
+
+// AWSSSOCredentials returns AWS credentials generated via AWS SSO.
+type AWSSSOCredentials struct {
+	AccessKeyID       string `json:"accessKeyId"`
+	SecretAccessKey   string `json:"secretAccessKey"`
+	SessionToken      string `json:"sessionToken"`
+	Expire            int64  `json:"expire"`
+	Region            string `json:"region"`
+	StartURL          string `json:"startURL"`
+	AccountID         string `json:"accountID"`
+	RoleName          string `json:"roleName"`
+	AccessToken       string `json:"accessToken"`
+	AccessTokenExpire int64  `json:"accessTokenExpire"`
+	ClusterID         string `json:"clusterID"`
 }
 
 // awsGetClustersHandler returns all EKS clusters from AWS. The user have to provide an access key id, a secret
@@ -138,4 +164,141 @@ func (c *Client) awsGetTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	middleware.Write(w, r, awsTokenResponse)
 	return
+}
+
+// awsGetSSOConfigHandler registers a new client and starts the device authentication. The client and device
+// authentication is returned, so that we can use the information in the following steps of the SSO flow.
+func (c *Client) awsGetSSOConfigHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var awsRequest AWSRequest
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&awsRequest)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+		return
+	}
+
+	mySession, err := session.NewSession()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create new AWS session: %s", err.Error()))
+		return
+	}
+
+	svc := ssooidc.New(mySession, aws.NewConfig().WithRegion(awsRequest.Region))
+
+	registeredClient, err := svc.RegisterClient(&ssooidc.RegisterClientInput{
+		ClientName: stringPointer("kubenav"),
+		ClientType: stringPointer("public"),
+	})
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not register new client: %s", err.Error()))
+		return
+	}
+
+	startDeviceAuth, err := svc.StartDeviceAuthorization(&ssooidc.StartDeviceAuthorizationInput{
+		ClientId:     registeredClient.ClientId,
+		ClientSecret: registeredClient.ClientSecret,
+		StartUrl:     &awsRequest.StartURL,
+	})
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not start device authorization: %s", err.Error()))
+		return
+	}
+
+	middleware.Write(w, r, AWSSSOConfig{
+		Client: *registeredClient,
+		Device: *startDeviceAuth,
+	})
+	return
+}
+
+// awsGetSSOTokenHandler requests a new token with the client and device information from the former step. The retrieved
+// access token is then used to get the credentials for AWS.
+func (c *Client) awsGetSSOTokenHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		middleware.Write(w, r, nil)
+		return
+	}
+
+	var ssoConfig AWSSSOConfig
+	if r.Body == nil {
+		middleware.Errorf(w, r, nil, http.StatusBadRequest, "Request body is empty")
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&ssoConfig)
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not decode request body: %s", err.Error()))
+		return
+	}
+
+	mySession, err := session.NewSession()
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create new AWS session: %s", err.Error()))
+		return
+	}
+
+	var accessToken string
+	var accessTokenExpire int64
+	if ssoConfig.AccessToken != "" {
+		if ssoConfig.Expire < (time.Now().Unix()-60)*1000 {
+			middleware.Errorf(w, r, nil, http.StatusBadRequest, "Your AWS access token is expired, you have to reauthenticate.")
+			return
+		}
+
+		accessToken = ssoConfig.AccessToken
+		accessTokenExpire = ssoConfig.AccessTokenExpire
+	} else {
+		svcssooidc := ssooidc.New(mySession, aws.NewConfig().WithRegion(ssoConfig.Region))
+
+		token, err := svcssooidc.CreateToken(&ssooidc.CreateTokenInput{
+			ClientId:     ssoConfig.Client.ClientId,
+			ClientSecret: ssoConfig.Client.ClientSecret,
+			DeviceCode:   ssoConfig.Device.DeviceCode,
+			GrantType:    stringPointer("urn:ietf:params:oauth:grant-type:device_code"),
+		})
+		if err != nil {
+			middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not create new AWS token: %s", err.Error()))
+			return
+		}
+
+		accessToken = *token.AccessToken
+		accessTokenExpire = (time.Now().Unix() + *token.ExpiresIn) * 1000
+	}
+
+	svcsso := sso.New(mySession, aws.NewConfig().WithRegion(ssoConfig.Region))
+
+	creds, err := svcsso.GetRoleCredentials(&sso.GetRoleCredentialsInput{
+		AccessToken: &accessToken,
+		AccountId:   &ssoConfig.AccountID,
+		RoleName:    &ssoConfig.RoleName,
+	})
+	if err != nil {
+		middleware.Errorf(w, r, err, http.StatusBadRequest, fmt.Sprintf("Could not get AWS credentials: %s", err.Error()))
+		return
+	}
+
+	middleware.Write(w, r, &AWSSSOCredentials{
+		AccessKeyID:       *creds.RoleCredentials.AccessKeyId,
+		SecretAccessKey:   *creds.RoleCredentials.SecretAccessKey,
+		SessionToken:      *creds.RoleCredentials.SessionToken,
+		Expire:            *creds.RoleCredentials.Expiration,
+		Region:            ssoConfig.Region,
+		StartURL:          ssoConfig.StartURL,
+		AccountID:         ssoConfig.AccountID,
+		RoleName:          ssoConfig.RoleName,
+		AccessToken:       accessToken,
+		AccessTokenExpire: accessTokenExpire,
+	})
+	return
+}
+
+func stringPointer(s string) *string {
+	return &s
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import CustomResourcesListPage from './components/resources/cluster/customResour
 import DetailsPage from './components/resources/DetailsPage';
 import ListPage from './components/resources/ListPage';
 import ClustersAWSPage from './components/settings/clusters/aws/AWSPage';
+import ClustersAWSSSOPage from './components/settings/clusters/aws/AWSSSOPage';
 import ClustersAzurePage from './components/settings/clusters/azure/AzurePage';
 import ClustersGooglePage from './components/settings/clusters/google/GooglePage';
 import ClustersKubeconfigPage from './components/settings/clusters/kubeconfig/KubeconfigPage';
@@ -65,6 +66,7 @@ const App: React.FunctionComponent = () => (
                 <Route path="/plugins/helm/:namespace/:name" component={HelmReleasePage} exact={true} />
                 <Route path="/settings/clusters" component={ClustersPage} exact={true} />
                 <Route path="/settings/clusters/aws" component={ClustersAWSPage} exact={true} />
+                <Route path="/settings/clusters/awssso" component={ClustersAWSSSOPage} exact={true} />
                 <Route path="/settings/clusters/azure" component={ClustersAzurePage} exact={true} />
                 <Route path="/settings/clusters/google" component={ClustersGooglePage} exact={true} />
                 <Route path="/settings/clusters/kubeconfig" component={ClustersKubeconfigPage} exact={true} />

--- a/src/components/misc/LoadingErrorCard.tsx
+++ b/src/components/misc/LoadingErrorCard.tsx
@@ -2,6 +2,7 @@ import { IonButton, IonCard, IonCardContent, IonCardHeader, IonCardTitle } from 
 import React from 'react';
 
 import { IClusters } from '../../declarations';
+import AWSSSOReAuthenticate from '../settings/clusters/aws/AWSSSOReAuthenticate';
 
 interface ILoadingErrorCard {
   cluster?: string;
@@ -46,11 +47,13 @@ const LoadingErrorCard: React.FunctionComponent<ILoadingErrorCard> = ({
         </IonCardContent>
       ) : null}
 
-      {clusters && cluster ? (
+      {clusters && cluster && error && error.message === 'aws_sso_access_token_is_expired' ? (
+        <AWSSSOReAuthenticate />
+      ) : (
         <IonCardContent>
           <p className="paragraph-margin-bottom">{error ? error.message : 'An unknown error occured.'}</p>
         </IonCardContent>
-      ) : null}
+      )}
     </IonCard>
   );
 };

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -22,6 +22,7 @@ import { close, create } from 'ionicons/icons';
 import React, { useContext, useState } from 'react';
 
 import {
+  IAWSSSOCredentials,
   ICluster,
   IClusterAuthProviderAWS,
   IClusterAuthProviderAzure,
@@ -62,6 +63,9 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
   const [namespace, setNamespace] = useState<string>(cluster.namespace);
   const [authProvider] = useState<TAuthProvider>(cluster.authProvider);
   const [authProviderAWS, setAuthProviderAWS] = useState<IClusterAuthProviderAWS | undefined>(cluster.authProviderAWS);
+  const [authProviderAWSSSO, setAuthProviderAWSSSO] = useState<IAWSSSOCredentials | undefined>(
+    cluster.authProviderAWSSSO,
+  );
   const [authProviderAzure, setAuthProviderAzure] = useState<IClusterAuthProviderAzure | undefined>(
     cluster.authProviderAzure,
   );
@@ -114,6 +118,17 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
 
   const handleAuthProviderAWS = (event) => {
     setAuthProviderAWS((prevState) =>
+      prevState
+        ? {
+            ...prevState,
+            [event.target.name]: event.target.value,
+          }
+        : undefined,
+    );
+  };
+
+  const handleAuthProviderAWSSSO = (event) => {
+    setAuthProviderAWSSSO((prevState) =>
       prevState
         ? {
             ...prevState,
@@ -219,6 +234,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
         insecureSkipTLSVerify: insecureSkipTLSVerify,
         authProvider: cluster.authProvider,
         authProviderAWS: authProviderAWS,
+        authProviderAWSSSO: authProviderAWSSSO,
         authProviderAzure: authProviderAzure,
         authProviderGoogle: authProviderGoogle,
         authProviderOIDC: authProviderOIDC,
@@ -348,6 +364,40 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
                     value={authProviderAWS.sessionToken}
                     name="sessionToken"
                     onInput={handleAuthProviderAWS}
+                  />
+                </IonItem>
+              </IonItemGroup>
+            ) : null}
+            {authProvider === 'awssso' && authProviderAWSSSO ? (
+              <IonItemGroup>
+                <IonItemDivider>
+                  <IonLabel>AWS SSO</IonLabel>
+                </IonItemDivider>
+                <IonItem>
+                  <IonLabel position="stacked">Start URL</IonLabel>
+                  <IonInput
+                    type="text"
+                    value={authProviderAWSSSO.startURL}
+                    name="startURL"
+                    onInput={handleAuthProviderAWSSSO}
+                  />
+                </IonItem>
+                <IonItem>
+                  <IonLabel position="stacked">Account ID</IonLabel>
+                  <IonInput
+                    type="text"
+                    value={authProviderAWSSSO.accountID}
+                    name="accountID"
+                    onInput={handleAuthProviderAWSSSO}
+                  />
+                </IonItem>
+                <IonItem>
+                  <IonLabel position="stacked">Role Name</IonLabel>
+                  <IonInput
+                    type="text"
+                    value={authProviderAWSSSO.roleName}
+                    name="roleName"
+                    onInput={handleAuthProviderAWSSSO}
                   />
                 </IonItem>
               </IonItemGroup>

--- a/src/components/settings/clusters/aws/AWS.tsx
+++ b/src/components/settings/clusters/aws/AWS.tsx
@@ -117,6 +117,9 @@ const AWS: React.FunctionComponent = () => {
         <IonButton expand="block" onClick={() => importClusters()}>
           Import from AWS
         </IonButton>
+        <IonButton expand="block" routerLink="/settings/clusters/awssso" routerDirection="root">
+          Import using AWS SSO
+        </IonButton>
       </IonCardContent>
 
       <IonToast isOpen={error !== ''} onDidDismiss={() => setError('')} message={error} duration={3000} />

--- a/src/components/settings/clusters/aws/AWS.tsx
+++ b/src/components/settings/clusters/aws/AWS.tsx
@@ -70,6 +70,9 @@ const AWS: React.FunctionComponent = () => {
           id, a secret key and a region. The credentials are used to retrieve your EKS clusters from AWS and to generate
           a token for the Kubernetes API requests.
         </p>
+        <p className="paragraph-margin-bottom">
+          If you want to use AWS SSO just click the <b>Import using AWS SSO</b> button.
+        </p>
 
         <IonList className="paragraph-margin-bottom" lines="full">
           <IonItem>

--- a/src/components/settings/clusters/aws/AWSSSOPage.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOPage.tsx
@@ -1,0 +1,252 @@
+import { Plugins } from '@capacitor/core';
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonMenuButton,
+  IonPage,
+  IonSelect,
+  IonSelectOption,
+  IonTitle,
+  IonToolbar,
+  isPlatform,
+} from '@ionic/react';
+import React, { memo, useContext, useState } from 'react';
+import { RouteComponentProps } from 'react-router';
+
+import { IAWSSSO, ICluster, IContext } from '../../../../declarations';
+import { getAWSClusters, getAWSSSOConfig, getAWSSSOCredentailsWithConfig } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+
+const { App } = Plugins;
+
+const isChecked = (id: string, clusters: ICluster[]): boolean => {
+  for (const cluster of clusters) {
+    if (cluster.id === id) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+type IAWSSSOPageProps = RouteComponentProps;
+
+const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWSSSOPageProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const [startURL, setStartURL] = useState<string>('');
+  const [region, setRegion] = useState<string>('');
+  const [accountID, setAccountID] = useState<string>('');
+  const [roleName, setRoleName] = useState<string>('');
+  const [config, setConfig] = useState<IAWSSSO | undefined>(undefined);
+  const [error, setError] = useState<string>('');
+  const [clusters, setClusters] = useState<ICluster[]>([]);
+  const [selectedClusters, setSelectedClusters] = useState<ICluster[]>([]);
+
+  const handleStartURL = (event) => {
+    setStartURL(event.target.value);
+  };
+
+  const handleRegion = (event) => {
+    setRegion(event.target.value);
+  };
+
+  const handleAccountID = (event) => {
+    setAccountID(event.target.value);
+  };
+
+  const handleRoleName = (event) => {
+    setRoleName(event.target.value);
+  };
+
+  const startSSOFlow = async () => {
+    try {
+      const ssoConfig = await getAWSSSOConfig(startURL, region);
+      setConfig(ssoConfig);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const openURL = async (url: string) => {
+    if (isPlatform('hybrid')) {
+      await App.openUrl({ url: url });
+    } else {
+      window.open(url, '_system', 'location=yes');
+    }
+  };
+
+  const createToken = async (ssoConfig: IAWSSSO) => {
+    try {
+      const credentials = await getAWSSSOCredentailsWithConfig(ssoConfig, startURL, region, accountID, roleName);
+
+      const awsClusters = await getAWSClusters({
+        accessKeyID: credentials.accessKeyId,
+        clusterID: '',
+        region: credentials.region,
+        secretKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken,
+      });
+      const tmpClusters: ICluster[] = [];
+
+      // eslint-disable-next-line
+      awsClusters.map((cluster) => {
+        tmpClusters.push({
+          id: `aws_${credentials.region}_${cluster.Name}`,
+          name: `aws_${credentials.region}_${cluster.Name}`,
+          url: `${cluster.Endpoint}`,
+          certificateAuthorityData: cluster.CertificateAuthority.Data,
+          clientCertificateData: '',
+          clientKeyData: '',
+          token: '',
+          username: '',
+          password: '',
+          insecureSkipTLSVerify: false,
+          authProvider: 'awssso',
+          authProviderAWSSSO: { ...credentials, clusterID: cluster.Name },
+          namespace: 'default',
+        });
+      });
+
+      setClusters(tmpClusters);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const toggleSelectedCluster = (checked: boolean, cluster: ICluster) => {
+    if (checked) {
+      setSelectedClusters([...selectedClusters, cluster]);
+    } else {
+      setSelectedClusters(selectedClusters.filter((c) => c.id !== cluster.id));
+    }
+  };
+
+  const addClusters = () => {
+    context.addCluster(selectedClusters);
+    history.push('/settings/clusters');
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonMenuButton />
+          </IonButtons>
+          <IonTitle>AWS SSO</IonTitle>
+          {clusters && clusters.length > 0 ? (
+            <IonButtons slot="primary">
+              <IonButton onClick={() => addClusters()}>Add</IonButton>
+            </IonButtons>
+          ) : null}
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        {clusters && clusters.length > 0 ? (
+          <IonList>
+            {clusters.map((cluster, index) => {
+              return (
+                <IonItem key={index}>
+                  <IonCheckbox
+                    slot="start"
+                    checked={isChecked(cluster.id, selectedClusters)}
+                    onIonChange={(e) => toggleSelectedCluster(e.detail.checked, cluster)}
+                  />
+                  <IonLabel>{cluster.name}</IonLabel>
+                </IonItem>
+              );
+            })}
+          </IonList>
+        ) : config ? (
+          <IonCard>
+            <IonCardContent>
+              <p className="paragraph-margin-bottom">
+                You have to finialize the device authentication by clicking the <b>Verify</b> button.
+              </p>
+              <p className="paragraph-margin-bottom">
+                When you have finished the device authentication you have to click the <b>Create Token</b> button to
+                retrieve a new token to interact with the AWS API.
+              </p>
+
+              {error ? <p className="paragraph-margin-bottom">{error}</p> : null}
+
+              <IonButton expand="block" onClick={() => openURL(config.device.VerificationUriComplete)}>
+                Verify
+              </IonButton>
+              <IonButton expand="block" onClick={() => createToken(config)}>
+                Get Clusters
+              </IonButton>
+            </IonCardContent>
+          </IonCard>
+        ) : (
+          <IonCard>
+            <IonCardContent>
+              <IonList className="paragraph-margin-bottom" lines="full">
+                <IonItem>
+                  <IonLabel position="stacked">Start URL</IonLabel>
+                  <IonInput type="text" required={true} value={startURL} onInput={handleStartURL} />
+                </IonItem>
+                <IonItem>
+                  <IonLabel position="stacked">Account ID</IonLabel>
+                  <IonInput type="text" required={true} value={accountID} onInput={handleAccountID} />
+                </IonItem>
+                <IonItem>
+                  <IonLabel position="stacked">Role Name</IonLabel>
+                  <IonInput type="text" required={true} value={roleName} onInput={handleRoleName} />
+                </IonItem>
+                <IonItem>
+                  <IonLabel>Region</IonLabel>
+                  <IonSelect value={region} onIonChange={handleRegion}>
+                    <IonSelectOption value="us-east-2">USA Ost (Ohio)</IonSelectOption>
+                    <IonSelectOption value="us-east-1">USA Ost (Nord-Virginia)</IonSelectOption>
+                    <IonSelectOption value="us-west-1">USA West (Nordkalifornien)</IonSelectOption>
+                    <IonSelectOption value="us-west-2">USA West (Oregon)</IonSelectOption>
+                    <IonSelectOption value="ap-east-1">Asien-Pazifik (Hongkong)</IonSelectOption>
+                    <IonSelectOption value="ap-south-1">Asien-Pazifik (Mumbai)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-3">Asien-Pazifik (Osaka-Lokal)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-2">Asien-Pazifik (Seoul)</IonSelectOption>
+                    <IonSelectOption value="ap-southeast-1">Asien-Pazifik (Singapur)</IonSelectOption>
+                    <IonSelectOption value="ap-southeast-2">Asien-Pazifik (Sydney)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-1">Asien-Pazifik (Tokio)</IonSelectOption>
+                    <IonSelectOption value="ca-central-1">Kanada (Zentral)</IonSelectOption>
+                    <IonSelectOption value="cn-north-1">China (Peking)</IonSelectOption>
+                    <IonSelectOption value="cn-northwest-1">China (Ningxia)</IonSelectOption>
+                    <IonSelectOption value="eu-central-1">EU (Frankfurt)</IonSelectOption>
+                    <IonSelectOption value="eu-west-1">EU (Irland)</IonSelectOption>
+                    <IonSelectOption value="eu-west-2">EU (London)</IonSelectOption>
+                    <IonSelectOption value="eu-west-3">EU (Paris)</IonSelectOption>
+                    <IonSelectOption value="eu-north-1">EU (Stockholm)</IonSelectOption>
+                    <IonSelectOption value="me-south-1">Naher Osten (Bahrain)</IonSelectOption>
+                    <IonSelectOption value="sa-east-1">Südamerika (São Paulo)</IonSelectOption>
+                    <IonSelectOption value="us-gov-east-1">AWS GovCloud (USA Ost)</IonSelectOption>
+                    <IonSelectOption value="us-gov-west-1">AWS GovCloud (USA)</IonSelectOption>
+                  </IonSelect>
+                </IonItem>
+              </IonList>
+
+              {error ? <p className="paragraph-margin-bottom">{error}</p> : null}
+
+              <IonButton expand="block" onClick={() => startSSOFlow()}>
+                Sign In
+              </IonButton>
+            </IonCardContent>
+          </IonCard>
+        )}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default memo(AWSSSOPage, (): boolean => {
+  return true;
+});

--- a/src/components/settings/clusters/aws/AWSSSOPage.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOPage.tsx
@@ -45,6 +45,7 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
 
   const [startURL, setStartURL] = useState<string>('');
   const [region, setRegion] = useState<string>('');
+  const [ssoRegion, setSSORegion] = useState<string>('');
   const [accountID, setAccountID] = useState<string>('');
   const [roleName, setRoleName] = useState<string>('');
   const [config, setConfig] = useState<IAWSSSO | undefined>(undefined);
@@ -56,10 +57,6 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
     setStartURL(event.target.value);
   };
 
-  const handleRegion = (event) => {
-    setRegion(event.target.value);
-  };
-
   const handleAccountID = (event) => {
     setAccountID(event.target.value);
   };
@@ -68,9 +65,17 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
     setRoleName(event.target.value);
   };
 
+  const handleSSORegion = (event) => {
+    setSSORegion(event.target.value);
+  };
+
+  const handleRegion = (event) => {
+    setRegion(event.target.value);
+  };
+
   const startSSOFlow = async () => {
     try {
-      const ssoConfig = await getAWSSSOConfig(startURL, region);
+      const ssoConfig = await getAWSSSOConfig(startURL, ssoRegion);
       setConfig(ssoConfig);
     } catch (err) {
       setError(err.message);
@@ -87,7 +92,14 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
 
   const createToken = async (ssoConfig: IAWSSSO) => {
     try {
-      const credentials = await getAWSSSOCredentailsWithConfig(ssoConfig, startURL, region, accountID, roleName);
+      const credentials = await getAWSSSOCredentailsWithConfig(
+        ssoConfig,
+        startURL,
+        ssoRegion,
+        accountID,
+        roleName,
+        region,
+      );
 
       const awsClusters = await getAWSClusters({
         accessKeyID: credentials.accessKeyId,
@@ -203,6 +215,34 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
                 <IonItem>
                   <IonLabel position="stacked">Role Name</IonLabel>
                   <IonInput type="text" required={true} value={roleName} onInput={handleRoleName} />
+                </IonItem>
+                <IonItem>
+                  <IonLabel>SSO Region</IonLabel>
+                  <IonSelect value={ssoRegion} onIonChange={handleSSORegion}>
+                    <IonSelectOption value="us-east-2">USA Ost (Ohio)</IonSelectOption>
+                    <IonSelectOption value="us-east-1">USA Ost (Nord-Virginia)</IonSelectOption>
+                    <IonSelectOption value="us-west-1">USA West (Nordkalifornien)</IonSelectOption>
+                    <IonSelectOption value="us-west-2">USA West (Oregon)</IonSelectOption>
+                    <IonSelectOption value="ap-east-1">Asien-Pazifik (Hongkong)</IonSelectOption>
+                    <IonSelectOption value="ap-south-1">Asien-Pazifik (Mumbai)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-3">Asien-Pazifik (Osaka-Lokal)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-2">Asien-Pazifik (Seoul)</IonSelectOption>
+                    <IonSelectOption value="ap-southeast-1">Asien-Pazifik (Singapur)</IonSelectOption>
+                    <IonSelectOption value="ap-southeast-2">Asien-Pazifik (Sydney)</IonSelectOption>
+                    <IonSelectOption value="ap-northeast-1">Asien-Pazifik (Tokio)</IonSelectOption>
+                    <IonSelectOption value="ca-central-1">Kanada (Zentral)</IonSelectOption>
+                    <IonSelectOption value="cn-north-1">China (Peking)</IonSelectOption>
+                    <IonSelectOption value="cn-northwest-1">China (Ningxia)</IonSelectOption>
+                    <IonSelectOption value="eu-central-1">EU (Frankfurt)</IonSelectOption>
+                    <IonSelectOption value="eu-west-1">EU (Irland)</IonSelectOption>
+                    <IonSelectOption value="eu-west-2">EU (London)</IonSelectOption>
+                    <IonSelectOption value="eu-west-3">EU (Paris)</IonSelectOption>
+                    <IonSelectOption value="eu-north-1">EU (Stockholm)</IonSelectOption>
+                    <IonSelectOption value="me-south-1">Naher Osten (Bahrain)</IonSelectOption>
+                    <IonSelectOption value="sa-east-1">Südamerika (São Paulo)</IonSelectOption>
+                    <IonSelectOption value="us-gov-east-1">AWS GovCloud (USA Ost)</IonSelectOption>
+                    <IonSelectOption value="us-gov-west-1">AWS GovCloud (USA)</IonSelectOption>
+                  </IonSelect>
                 </IonItem>
                 <IonItem>
                   <IonLabel>Region</IonLabel>

--- a/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
@@ -1,0 +1,91 @@
+import { Plugins } from '@capacitor/core';
+import { IonButton, IonCardContent, isPlatform } from '@ionic/react';
+import React, { useContext, useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+import { IAWSSSO, IContext } from '../../../../declarations';
+import { getAWSSSOConfig, getAWSSSOCredentailsWithConfig } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+
+const { App } = Plugins;
+
+type IAWSSSOReAuthenticateProps = RouteComponentProps;
+
+const AWSSSOReAuthenticate: React.FunctionComponent<IAWSSSOReAuthenticateProps> = ({
+  history,
+}: IAWSSSOReAuthenticateProps) => {
+  const context = useContext<IContext>(AppContext);
+  const cluster = context.currentCluster();
+
+  const [config, setConfig] = useState<IAWSSSO | undefined>(undefined);
+  const [error, setError] = useState<string>('Your access token is expired.');
+
+  const startSSOFlow = async () => {
+    try {
+      if (cluster && cluster.authProviderAWSSSO) {
+        const ssoConfig = await getAWSSSOConfig(cluster.authProviderAWSSSO.startURL, cluster.authProviderAWSSSO.region);
+        setConfig(ssoConfig);
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const openURL = async (url: string) => {
+    if (isPlatform('hybrid')) {
+      await App.openUrl({ url: url });
+    } else {
+      window.open(url, '_system', 'location=yes');
+    }
+  };
+
+  const finish = async (ssoConfig: IAWSSSO) => {
+    try {
+      if (cluster && cluster.authProviderAWSSSO) {
+        const credentials = await getAWSSSOCredentailsWithConfig(
+          ssoConfig,
+          cluster.authProviderAWSSSO.startURL,
+          cluster.authProviderAWSSSO.ssoRegion,
+          cluster.authProviderAWSSSO.accountID,
+          cluster.authProviderAWSSSO.roleName,
+          cluster.authProviderAWSSSO.region,
+        );
+
+        const tmpCluster = cluster;
+        tmpCluster.authProviderAWSSSO = credentials;
+
+        context.editCluster(tmpCluster);
+        history.go(0);
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <IonCardContent>
+      {error ? <p className="paragraph-margin-bottom">{error}</p> : null}
+
+      {config ? (
+        <React.Fragment>
+          <p className="paragraph-margin-bottom">
+            To finish the sign in process you have to click the <b>Verify</b> button and after you finished the
+            verification process the <b>Finish Sign In Process</b> button.
+          </p>
+          <IonButton expand="block" onClick={() => openURL(config.device.VerificationUriComplete)}>
+            Verify
+          </IonButton>
+          <IonButton expand="block" onClick={() => finish(config)}>
+            Finish Sign In Process
+          </IonButton>
+        </React.Fragment>
+      ) : (
+        <IonButton expand="block" onClick={() => startSSOFlow()}>
+          Sign In
+        </IonButton>
+      )}
+    </IonCardContent>
+  );
+};
+
+export default withRouter(AWSSSOReAuthenticate);

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -80,6 +80,7 @@ export interface IAWSSSOCredentials {
   sessionToken: string;
   expire: number;
   region: string;
+  ssoRegion: string;
   startURL: string;
   accountID: string;
   roleName: string;

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -62,6 +62,41 @@ export interface IAWSClusterCertificateAuthority {
   Data: string;
 }
 
+export interface IAWSSSO {
+  client: IAWSSSOClient;
+  device: IAWSSSODevice;
+}
+
+export interface IAWSSSOClient {
+  ClientId: string;
+  ClientIdIssuedAt: number;
+  ClientSecret: string;
+  ClientSecretExpiresAt: number;
+}
+
+export interface IAWSSSOCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  expire: number;
+  region: string;
+  startURL: string;
+  accountID: string;
+  roleName: string;
+  accessToken: string;
+  accessTokenExpire: number;
+  clusterID: string;
+}
+
+export interface IAWSSSODevice {
+  DeviceCode: string;
+  ExpiresIn: number;
+  Interval: number;
+  UserCode: string;
+  VerificationUri: string;
+  VerificationUriComplete: string;
+}
+
 export interface IAWSToken {
   accessKeyID: string;
   secretKey: string;
@@ -95,6 +130,7 @@ export interface ICluster {
   insecureSkipTLSVerify: boolean;
   authProvider: TAuthProvider;
   authProviderAWS?: IClusterAuthProviderAWS;
+  authProviderAWSSSO?: IAWSSSOCredentials;
   authProviderAzure?: IClusterAuthProviderAzure;
   authProviderGoogle?: IClusterAuthProviderGoogle;
   authProviderOIDC?: IClusterAuthProviderOIDC;
@@ -377,7 +413,7 @@ export interface ITerminalResponse {
 export type TActivator = 'block-button' | 'button' | 'item' | 'item-option';
 
 // DEPRECATED: The value '' can be removed when the migration is done.
-export type TAuthProvider = '' | 'aws' | 'azure' | 'google' | 'kubeconfig' | 'oidc';
+export type TAuthProvider = '' | 'aws' | 'awssso' | 'azure' | 'google' | 'kubeconfig' | 'oidc';
 
 export type TSyncType = 'context' | 'namespace';
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -86,7 +86,7 @@ export const getAWSClusters = async (credentials: IClusterAuthProviderAWS): Prom
 };
 
 // getAWSSSOConfig initialize the SSO flow, by registering a new client and starting the device authentication.
-export const getAWSSSOConfig = async (startURL: string, region: string): Promise<IAWSSSO> => {
+export const getAWSSSOConfig = async (startURL: string, ssoRegion: string): Promise<IAWSSSO> => {
   try {
     await checkServer();
 
@@ -94,7 +94,7 @@ export const getAWSSSOConfig = async (startURL: string, region: string): Promise
       method: 'post',
       body: JSON.stringify({
         startURL: startURL,
-        region: region,
+        ssoRegion: ssoRegion,
       }),
     });
 
@@ -117,7 +117,7 @@ export const getAWSSSOConfig = async (startURL: string, region: string): Promise
 // getAWSSSOCredentails is used to retrieve creadentials for AWS with the SSO config.
 export const getAWSSSOCredentails = async (credentials: IAWSSSOCredentials): Promise<IAWSSSOCredentials> => {
   try {
-    if (credentials.expire - 60 > new Date().getTime()) {
+    if (credentials.expire - 60000 > new Date().getTime()) {
       return credentials;
     }
 
@@ -132,6 +132,7 @@ export const getAWSSSOCredentails = async (credentials: IAWSSSOCredentials): Pro
         roleName: credentials.roleName,
         accessToken: credentials.accessToken,
         accessTokenExpire: credentials.accessTokenExpire,
+        clusterID: credentials.clusterID,
       }),
     });
 
@@ -155,9 +156,10 @@ export const getAWSSSOCredentails = async (credentials: IAWSSSOCredentials): Pro
 export const getAWSSSOCredentailsWithConfig = async (
   config: IAWSSSO,
   startURL: string,
-  region: string,
+  ssoRegion: string,
   accountID: string,
   roleName: string,
+  region: string,
 ): Promise<IAWSSSOCredentials> => {
   try {
     await checkServer();
@@ -168,9 +170,10 @@ export const getAWSSSOCredentailsWithConfig = async (
         client: config.client,
         device: config.device,
         startURL: startURL,
-        region: region,
+        ssoRegion: ssoRegion,
         accountID: accountID,
         roleName: roleName,
+        region: region,
       }),
     });
 

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -10,6 +10,7 @@ import {
   getOIDCAccessToken,
   getInclusterSettings,
   syncKubeconfig,
+  getAWSSSOCredentails,
   getAWSToken,
   getGoogleAccessToken,
 } from './api';
@@ -314,6 +315,24 @@ export const AppContextProvider: React.FunctionComponent<IAppContextProvider> = 
         const credentials = clusters[clusterID].authProviderAWS;
         if (credentials) {
           const token = await getAWSToken(credentials);
+          clusters[clusterID].token = token;
+        } else {
+          throw new Error('AWS credentials are missing');
+        }
+      } else if (clusters[clusterID].authProvider === 'awssso') {
+        let credentials = clusters[clusterID].authProviderAWSSSO;
+        if (credentials) {
+          credentials = await getAWSSSOCredentails(credentials);
+          clusters[clusterID].authProviderAWSSSO = credentials;
+
+          const token = await getAWSToken({
+            accessKeyID: credentials.accessKeyId,
+            clusterID: credentials.clusterID,
+            region: credentials.region,
+            secretKey: credentials.secretAccessKey,
+            sessionToken: credentials.sessionToken,
+          });
+
           clusters[clusterID].token = token;
         } else {
           throw new Error('AWS credentials are missing');


### PR DESCRIPTION
This commit adds support for AWS SSO, were the user can add EKS clusters by using the AWS SSO flow. For that the user have to provide a start URL for the SSO flow, his account id, a role name and the AWS region. When the user has provided all of these details a new client will be created which the user has to verify. As last step he can use the new client to import all of his EKS clusters.

Closes #239.