### PR TITLE
Add setting for the query limit

### DIFF
--- a/src/components/overview/Warnings.tsx
+++ b/src/components/overview/Warnings.tsx
@@ -32,13 +32,13 @@ const Warnings: React.FunctionComponent = () => {
   const cluster = context.currentCluster();
   const width = useWindowWidth();
 
-  const { data } = useQuery<IEvent[], Error>(
+  const { isError, data } = useQuery<IEvent[], Error>(
     ['OverviewWarnings', cluster],
     async () => {
       try {
         const eventList: V1EventList = await kubernetesRequest(
           'GET',
-          '/api/v1/events?limit=100&fieldSelector=type=Warning',
+          `/api/v1/events?limit=${context.settings.queryLimit}&fieldSelector=type=Warning`,
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),
@@ -93,75 +93,79 @@ const Warnings: React.FunctionComponent = () => {
     { ...context.settings.queryConfig, refetchInterval: context.settings.queryRefetchInterval },
   );
 
-  return (
-    <IonRow>
-      <IonCol>
-        <IonCard>
-          <IonCardHeader>
-            <IonCardTitle>Warnings</IonCardTitle>
-          </IonCardHeader>
-          <IonCardContent>
-            {isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? (
-              <IonList>
-                {data && data.length > 0
-                  ? data.map((event, index) => {
-                      return (
-                        <IonItem
-                          key={index}
-                          routerLink={event.routerLink === '' ? undefined : event.routerLink}
-                          routerDirection="forward"
-                        >
-                          <IonLabel class="ion-text-wrap">
-                            <h2>{event.name}</h2>
-                            <p>
-                              {event.reason ? `${event.reason}: ` : ''}
-                              {event.message}
-                            </p>
-                          </IonLabel>
-                        </IonItem>
-                      );
-                    })
-                  : null}
-              </IonList>
-            ) : (
-              <div className="table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Reason</th>
-                      <th>Message</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data && data.length > 0
-                      ? data.map((event, index) => {
-                          return (
-                            <tr key={index}>
-                              <td>
-                                {event.routerLink === '' ? (
-                                  event.name
-                                ) : (
-                                  <IonRouterLink routerLink={event.routerLink} routerDirection="forward">
-                                    {event.name}
-                                  </IonRouterLink>
-                                )}
-                              </td>
-                              <td>{event.reason}</td>
-                              <td>{event.message}</td>
-                            </tr>
-                          );
-                        })
-                      : null}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </IonCardContent>
-        </IonCard>
-      </IonCol>
-    </IonRow>
-  );
+  if (isError || data === undefined) {
+    return null;
+  } else {
+    return (
+      <IonRow>
+        <IonCol>
+          <IonCard>
+            <IonCardHeader>
+              <IonCardTitle>Warnings</IonCardTitle>
+            </IonCardHeader>
+            <IonCardContent>
+              {isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? (
+                <IonList>
+                  {data && data.length > 0
+                    ? data.map((event, index) => {
+                        return (
+                          <IonItem
+                            key={index}
+                            routerLink={event.routerLink === '' ? undefined : event.routerLink}
+                            routerDirection="forward"
+                          >
+                            <IonLabel class="ion-text-wrap">
+                              <h2>{event.name}</h2>
+                              <p>
+                                {event.reason ? `${event.reason}: ` : ''}
+                                {event.message}
+                              </p>
+                            </IonLabel>
+                          </IonItem>
+                        );
+                      })
+                    : null}
+                </IonList>
+              ) : (
+                <div className="table">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Reason</th>
+                        <th>Message</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data && data.length > 0
+                        ? data.map((event, index) => {
+                            return (
+                              <tr key={index}>
+                                <td>
+                                  {event.routerLink === '' ? (
+                                    event.name
+                                  ) : (
+                                    <IonRouterLink routerLink={event.routerLink} routerDirection="forward">
+                                      {event.name}
+                                    </IonRouterLink>
+                                  )}
+                                </td>
+                                <td>{event.reason}</td>
+                                <td>{event.message}</td>
+                              </tr>
+                            );
+                          })
+                        : null}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </IonCardContent>
+          </IonCard>
+        </IonCol>
+      </IonRow>
+    );
+  }
 };
 
 export default Warnings;

--- a/src/components/plugins/helm/History.tsx
+++ b/src/components/plugins/helm/History.tsx
@@ -38,7 +38,7 @@ const History: React.FunctionComponent<IHistoryProps> = ({ name, namespace, helm
       try {
         const secrets: V1SecretList = await kubernetesRequest(
           'GET',
-          `/api/v1/namespaces/${namespace}/secrets?limit=100&labelSelector=owner=helm,name=${name}`,
+          `/api/v1/namespaces/${namespace}/secrets?limit=${context.settings.queryLimit}&labelSelector=owner=helm,name=${name}`,
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),

--- a/src/components/plugins/helm/ReleasesPage.tsx
+++ b/src/components/plugins/helm/ReleasesPage.tsx
@@ -29,18 +29,13 @@ import ItemStatus from '../../resources/misc/template/ItemStatus';
 import Details from './Details';
 import { IHelmRelease, IHelmReleases } from './helpers';
 
-// ReleasesPage shows a list of the selected resource. The list can be filtered by namespace and each item contains a status
-// indicator, to get an overview of problems in the cluster.
 const ReleasesPage: React.FunctionComponent = () => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
 
-  // namespace and showNamespace is used to group all items by namespace and to only show the namespace once via the
-  // IonItemDivider component.
   let namespace = '';
   let showNamespace = false;
 
-  // searchText is used to search and filter the list of items.
   const [searchText, setSearchText] = useState<string>('');
 
   const { isError, isFetching, data, error, refetch } = useQuery<IHelmReleases, Error>(
@@ -56,7 +51,7 @@ const ReleasesPage: React.FunctionComponent = () => {
           'GET',
           `${
             cluster && cluster.namespace ? `/api/v1/namespaces/${cluster.namespace}/secrets` : `/api/v1/secrets`
-          }?limit=100&labelSelector=owner=helm`,
+          }?limit=${context.settings.queryLimit}&labelSelector=owner=helm`,
           '',
           context.settings,
           await context.kubernetesAuthWrapper(''),
@@ -123,8 +118,6 @@ const ReleasesPage: React.FunctionComponent = () => {
     return 'warning';
   };
 
-  // The doRefresh method is used for a manual reload of the items for the corresponding resource. The
-  // event.detail.complete() call is required to finish the animation of the IonRefresher component.
   const doRefresh = async (event: CustomEvent<RefresherEventDetail>) => {
     event.detail.complete();
     refetch();

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -130,6 +130,21 @@ const GeneralPage: React.FunctionComponent = () => {
             </IonItem>
             <IonItem>
               <IonLabel className="label-for-range" position="stacked">
+                Limit
+              </IonLabel>
+              <IonRange
+                min={100}
+                max={1000}
+                step={100}
+                pin={true}
+                color="primary"
+                name="queryLimit"
+                value={context.settings.queryLimit}
+                onIonChange={handleRangeChange}
+              />
+            </IonItem>
+            <IonItem>
+              <IonLabel className="label-for-range" position="stacked">
                 Refresh Interval (in seconds)
               </IonLabel>
               <IonRange

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -36,6 +36,7 @@ export interface IAppSettings {
   terminalFontSize: number;
   terminalScrollback: number;
   enablePodMetrics: boolean;
+  queryLimit: number;
   queryRefetchInterval: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   queryConfig: QueryConfig<any, Error>;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SETTINGS: IAppSettings = {
   terminalFontSize: 12,
   terminalScrollback: 10000,
   enablePodMetrics: true,
+  queryLimit: 100,
   queryRefetchInterval: 5 * 60 * 1000,
   queryConfig: {
     retry: false,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -151,6 +151,7 @@ export const readSettings = (): IAppSettings => {
       enablePodMetrics: settings.hasOwnProperty('enablePodMetrics')
         ? settings.enablePodMetrics
         : DEFAULT_SETTINGS.enablePodMetrics,
+      queryLimit: settings.queryLimit ? settings.queryLimit : DEFAULT_SETTINGS.queryLimit,
       queryRefetchInterval: settings.queryRefetchInterval
         ? settings.queryRefetchInterval
         : DEFAULT_SETTINGS.queryRefetchInterval,


### PR DESCRIPTION
Until now the limit for some queries were restricted to 100 items, which could cause problems that some resources not shown. To allow the user to query more items, when needed, we are adding a new limit setting.

The upper limit is set to 1000 items, each user must ensure that a too high limit has a negative impact on the performance of the app.

Fixes #245.