### PR TITLE
Improve event handling

### DIFF
--- a/src/components/overview/Warnings.tsx
+++ b/src/components/overview/Warnings.tsx
@@ -19,9 +19,11 @@ import { IContext } from '../../declarations';
 import { kubernetesRequest } from '../../utils/api';
 import { AppContext } from '../../utils/context';
 import useWindowWidth from '../../utils/useWindowWidth';
+import { involvedObjectLink } from '../resources/cluster/events/eventHelper';
 
 interface IEvent {
   name: string;
+  namespace: string;
   routerLink: string;
   reason: string;
   message: string;
@@ -53,32 +55,10 @@ const Warnings: React.FunctionComponent = () => {
             : '';
 
           if (events.map((e) => e.name).indexOf(name) === -1) {
-            let routerLink = '';
-            if (event.involvedObject.kind === 'CronJob') {
-              routerLink = `/resources/workloads/cronjobs/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'DaemonSet') {
-              routerLink = `/resources/workloads/daemonsets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'Deployment') {
-              routerLink = `/resources/workloads/deployments/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'Job') {
-              routerLink = `/resources/workloads/jobs/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'Pod') {
-              routerLink = `/resources/workloads/pods/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'ReplicaSet') {
-              routerLink = `/resources/workloads/replicasets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'ReplicationController') {
-              routerLink = `/resources/workloads/replicationcontrollers/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'StatefulSet') {
-              routerLink = `/resources/workloads/statefulsets/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'Endpoints') {
-              routerLink = `/resources/discovery-and-loadbalancing/endpoints/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            } else if (event.involvedObject.kind === 'HorizontalPodAutoscaler') {
-              routerLink = `/resources/discovery-and-loadbalancing/horizontalpodautoscalers/${event.involvedObject.namespace}/${event.involvedObject.name}`;
-            }
-
             events.push({
               name: name,
-              routerLink: routerLink,
+              namespace: event.metadata.namespace ? event.metadata.namespace : '',
+              routerLink: involvedObjectLink(event.involvedObject),
               reason: event.reason ? event.reason : '',
               message: event.message ? event.message : '',
             });
@@ -115,7 +95,9 @@ const Warnings: React.FunctionComponent = () => {
                             routerDirection="forward"
                           >
                             <IonLabel class="ion-text-wrap">
-                              <h2>{event.name}</h2>
+                              <h2>
+                                {event.name} ({event.namespace})
+                              </h2>
                               <p>
                                 {event.reason ? `${event.reason}: ` : ''}
                                 {event.message}
@@ -132,6 +114,7 @@ const Warnings: React.FunctionComponent = () => {
                     <thead>
                       <tr>
                         <th>Name</th>
+                        <th>Namespace</th>
                         <th>Reason</th>
                         <th>Message</th>
                       </tr>
@@ -150,6 +133,7 @@ const Warnings: React.FunctionComponent = () => {
                                     </IonRouterLink>
                                   )}
                                 </td>
+                                <td>{event.namespace}</td>
                                 <td>{event.reason}</td>
                                 <td>{event.message}</td>
                               </tr>

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -1,5 +1,6 @@
 import { RefresherEventDetail } from '@ionic/core';
 import {
+  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
@@ -140,7 +141,18 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
                         ? group.items
                             .filter((item) => {
                               const regex = new RegExp(searchText, 'gi');
-                              return item.metadata && item.metadata.name && item.metadata.name.match(regex);
+                              if (match.params.type === 'events') {
+                                return (
+                                  item.metadata &&
+                                  item.metadata.name &&
+                                  (item.metadata.name.match(regex) ||
+                                    item.message.match(regex) ||
+                                    item.reason.match(regex) ||
+                                    item.type.match(regex))
+                                );
+                              } else {
+                                return item.metadata && item.metadata.name && item.metadata.name.match(regex);
+                              }
                             })
                             .map((item, j) => {
                               if (
@@ -183,6 +195,11 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
                 disabled={!canFetchMore || (isFetchingMore as boolean)}
                 onIonInfinite={loadMore}
               >
+                {(!isFetchingMore as boolean) ? (
+                  <IonButton size="small" expand="block" fill="clear" onClick={() => fetchMore()}>
+                    Load more
+                  </IonButton>
+                ) : null}
                 <IonInfiniteScrollContent loadingText={`Loading more ${page.pluralText}...`}></IonInfiniteScrollContent>
               </IonInfiniteScroll>
             </IonList>

--- a/src/components/resources/cluster/events/EventDetails.tsx
+++ b/src/components/resources/cluster/events/EventDetails.tsx
@@ -1,4 +1,13 @@
-import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonGrid, IonRow } from '@ionic/react';
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonCol,
+  IonGrid,
+  IonRouterLink,
+  IonRow,
+} from '@ionic/react';
 import { V1Event } from '@kubernetes/client-node';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -6,7 +15,7 @@ import { RouteComponentProps } from 'react-router';
 import { timeDifference } from '../../../../utils/helpers';
 import Metadata from '../../misc/template/Metadata';
 import Row from '../../misc/template/Row';
-import { eventSource } from './eventHelper';
+import { eventSource, involvedObjectLink } from './eventHelper';
 
 interface IEventDetailsProps extends RouteComponentProps {
   item: V1Event;
@@ -54,7 +63,20 @@ const EventDetails: React.FunctionComponent<IEventDetailsProps> = ({ item, type 
             <IonCardContent>
               <Row obj={item.involvedObject} objKey="apiVersion" title="API Version" />
               <Row obj={item.involvedObject} objKey="kind" title="Kind" />
-              <Row obj={item.involvedObject} objKey="name" title="Name" />
+              <Row
+                obj={item.involvedObject}
+                objKey="name"
+                title="Name"
+                value={(name: string) =>
+                  involvedObjectLink(item.involvedObject) ? (
+                    <IonRouterLink routerLink={involvedObjectLink(item.involvedObject)} routerDirection="forward">
+                      {name}
+                    </IonRouterLink>
+                  ) : (
+                    name
+                  )
+                }
+              />
               <Row obj={item.involvedObject} objKey="namespace" title="Namespace" />
             </IonCardContent>
           </IonCard>

--- a/src/components/resources/cluster/events/EventItem.tsx
+++ b/src/components/resources/cluster/events/EventItem.tsx
@@ -27,8 +27,14 @@ const EventItem: React.FunctionComponent<IEventItemProps> = ({ item, section, ty
       }`}
       routerDirection="forward"
     >
-      <IonLabel>
-        <h2>{item.metadata ? item.metadata.name : ''}</h2>
+      <IonLabel class="ion-text-wrap">
+        <h2>
+          {item.metadata.name
+            ? item.metadata.name.split('.').length > 0
+              ? item.metadata.name.split('.')[0]
+              : item.metadata.name
+            : ''}
+        </h2>
         <p>
           {item.type ? `Type: ${item.type}` : ''}
           {item.reason ? ` | Reason: ${item.reason}` : ''}

--- a/src/components/resources/cluster/events/eventHelper.ts
+++ b/src/components/resources/cluster/events/eventHelper.ts
@@ -1,4 +1,4 @@
-import { V1EventSource } from '@kubernetes/client-node';
+import { V1EventSource, V1ObjectReference } from '@kubernetes/client-node';
 
 // eventSource is a helper function to generate a string which contains information for an event.
 export const eventSource = (value: V1EventSource): string => {
@@ -15,4 +15,31 @@ export const eventSource = (value: V1EventSource): string => {
   }
 
   return '';
+};
+
+// involvedObjectLink returns the link to the involved object for an event.
+export const involvedObjectLink = (involvedObject: V1ObjectReference): string => {
+  if (involvedObject.kind === 'CronJob') {
+    return `/resources/workloads/cronjobs/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'DaemonSet') {
+    return `/resources/workloads/daemonsets/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'Deployment') {
+    return `/resources/workloads/deployments/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'Job') {
+    return `/resources/workloads/jobs/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'Pod') {
+    return `/resources/workloads/pods/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'ReplicaSet') {
+    return `/resources/workloads/replicasets/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'ReplicationController') {
+    return `/resources/workloads/replicationcontrollers/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'StatefulSet') {
+    return `/resources/workloads/statefulsets/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'Endpoints') {
+    return `/resources/discovery-and-loadbalancing/endpoints/${involvedObject.namespace}/${involvedObject.name}`;
+  } else if (involvedObject.kind === 'HorizontalPodAutoscaler') {
+    return `/resources/discovery-and-loadbalancing/horizontalpodautoscalers/${involvedObject.namespace}/${involvedObject.name}`;
+  } else {
+    return '';
+  }
 };


### PR DESCRIPTION
To improve the handling of events we are adding the namespace of the event in the overview page, showing the full event message in the events list, adding the link to the involved object in the event details and allow filtering for the event type, reason and message in the events list via the search input.

We are also adding a button to load more items, which is needed, when the user type sth. in the search box. Since it can happen that the filter reduce the number of items to not fill the screen, the load more function isn't triggered via infinite scrolling. The button can be now used to load more items in a filtered view.

Closes #248.