### PR TITLE
Improve authentication

### DIFF
--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -30,14 +30,6 @@ import Sections from './Sections';
 
 const { App } = Plugins;
 
-App.addListener('appUrlOpen', (data) => {
-  if (data.url.startsWith(GOOGLE_REDIRECT_URI)) {
-    window.location.replace(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
-  } else if (data.url.startsWith(OIDC_REDIRECT_URL)) {
-    window.location.replace(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
-  }
-});
-
 interface IMenuProps extends RouteComponentProps {
   sections: IAppSections;
 }
@@ -45,6 +37,14 @@ interface IMenuProps extends RouteComponentProps {
 const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location }: IMenuProps) => {
   const context = useContext<IContext>(AppContext);
   const [eventSourceInitialized, setEventSourceInitialized] = useState<boolean>(false);
+
+  App.addListener('appUrlOpen', (data) => {
+    if (data.url.startsWith(GOOGLE_REDIRECT_URI)) {
+      history.push(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
+    } else if (data.url.startsWith(OIDC_REDIRECT_URL)) {
+      history.push(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
+    }
+  });
 
   if (isPlatform('electron') && !eventSourceInitialized) {
     setEventSourceInitialized(true);

--- a/src/components/settings/clusters/AddCluster.tsx
+++ b/src/components/settings/clusters/AddCluster.tsx
@@ -32,11 +32,11 @@ const AddCluster: React.FunctionComponent<IAddCluster> = ({ activator }: IAddClu
           </IonToolbar>
         </IonHeader>
         <IonContent>
-          <Google />
-          <AWS />
-          <Azure />
-          <DigitalOcean />
-          <OIDC />
+          <Google close={() => setShowModal(false)} />
+          <AWS close={() => setShowModal(false)} />
+          <Azure close={() => setShowModal(false)} />
+          <DigitalOcean close={() => setShowModal(false)} />
+          <OIDC close={() => setShowModal(false)} />
           <Kubeconfig />
           <Manual />
         </IonContent>

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -246,6 +246,8 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
         authProviderOIDC.clientSecret,
         authProviderOIDC.certificateAuthority,
       );
+
+      setShowModal(false);
       window.location.replace(url);
     }
   };
@@ -262,6 +264,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
         clusterID: cluster.id,
       });
 
+      setShowModal(false);
       window.location.replace(
         `${GOOGLE_OAUTH2_ENDPOINT}?client_id=${authProviderGoogle.clientID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=${GOOGLE_RESPONSE_TYPE}&scope=${GOOGLE_SCOPE}`,
       );

--- a/src/components/settings/clusters/aws/AWS.tsx
+++ b/src/components/settings/clusters/aws/AWS.tsx
@@ -13,10 +13,15 @@ import {
   IonToast,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { saveTemporaryCredentials } from '../../../../utils/storage';
 
-const AWS: React.FunctionComponent = () => {
+export interface IAWSProps extends RouteComponentProps {
+  close: () => void;
+}
+
+const AWS: React.FunctionComponent<IAWSProps> = ({ close, history }: IAWSProps) => {
   const [accessKeyID, setAccessKeyID] = useState<string>('');
   const [region, setRegion] = useState<string>('');
   const [secretKey, setSecretKey] = useState<string>('');
@@ -51,7 +56,8 @@ const AWS: React.FunctionComponent = () => {
         sessionToken: sessionToken,
       });
 
-      window.location.replace(`/settings/clusters/aws`);
+      close();
+      history.push('/settings/clusters/aws');
     }
   };
 
@@ -130,4 +136,4 @@ const AWS: React.FunctionComponent = () => {
   );
 };
 
-export default AWS;
+export default withRouter(AWS);

--- a/src/components/settings/clusters/azure/Azure.tsx
+++ b/src/components/settings/clusters/azure/Azure.tsx
@@ -12,10 +12,15 @@ import {
   IonToggle,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { saveTemporaryCredentials } from '../../../../utils/storage';
 
-const Azure: React.FunctionComponent = () => {
+export interface IAzureProps extends RouteComponentProps {
+  close: () => void;
+}
+
+const Azure: React.FunctionComponent<IAzureProps> = ({ close, history }: IAzureProps) => {
   const [subscriptionID, setSubscriptionID] = useState<string>('');
   const [clientID, setClientID] = useState<string>('');
   const [clientSecret, setClientSecret] = useState<string>('');
@@ -67,7 +72,8 @@ const Azure: React.FunctionComponent = () => {
         admin: admin,
       });
 
-      window.location.replace(`/settings/clusters/azure`);
+      close();
+      history.push('/settings/clusters/azure');
     }
   };
 
@@ -129,4 +135,4 @@ const Azure: React.FunctionComponent = () => {
   );
 };
 
-export default Azure;
+export default withRouter(Azure);

--- a/src/components/settings/clusters/digitalocean/DigitalOcean.tsx
+++ b/src/components/settings/clusters/digitalocean/DigitalOcean.tsx
@@ -11,10 +11,15 @@ import {
   IonToast,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { saveTemporaryCredentials } from '../../../../utils/storage';
 
-const DigitalOcean: React.FunctionComponent = () => {
+export interface IDigitalOceanProps extends RouteComponentProps {
+  close: () => void;
+}
+
+const DigitalOcean: React.FunctionComponent<IDigitalOceanProps> = ({ close, history }: IDigitalOceanProps) => {
   const [token, setToken] = useState<string>('');
   const [error, setError] = useState<string>('');
 
@@ -31,7 +36,8 @@ const DigitalOcean: React.FunctionComponent = () => {
         clusterID: '',
       });
 
-      window.location.replace(`/settings/clusters/digitalocean`);
+      close();
+      history.push('/settings/clusters/digitalocean');
     }
   };
 
@@ -67,4 +73,4 @@ const DigitalOcean: React.FunctionComponent = () => {
   );
 };
 
-export default DigitalOcean;
+export default withRouter(DigitalOcean);

--- a/src/components/settings/clusters/google/Google.tsx
+++ b/src/components/settings/clusters/google/Google.tsx
@@ -20,7 +20,11 @@ import {
 } from '../../../../utils/constants';
 import { saveTemporaryCredentials } from '../../../../utils/storage';
 
-const Google: React.FunctionComponent = () => {
+export interface IGoogleProps {
+  close: () => void;
+}
+
+const Google: React.FunctionComponent<IGoogleProps> = ({ close }: IGoogleProps) => {
   const [clientID, setClientID] = useState<string>('');
   const [error, setError] = useState<string>('');
 
@@ -41,6 +45,7 @@ const Google: React.FunctionComponent = () => {
         tokenType: '',
       });
 
+      close();
       window.location.replace(
         `${GOOGLE_OAUTH2_ENDPOINT}?client_id=${clientID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=${GOOGLE_RESPONSE_TYPE}&scope=${GOOGLE_SCOPE}`,
       );

--- a/src/components/settings/clusters/kubeconfig/Kubeconfig.tsx
+++ b/src/components/settings/clusters/kubeconfig/Kubeconfig.tsx
@@ -18,7 +18,7 @@ const Kubeconfig: React.FunctionComponent = () => {
           <code>certificate-authority-data</code> field. If you only have a field <code>certificate-authority</code>
           with the path to the certificate this does not work.
         </p>
-        <IonButton expand="block" href="/settings/clusters/kubeconfig">
+        <IonButton expand="block" routerLink="/settings/clusters/kubeconfig" routerDirection="root">
           Import Kubeconfig
         </IonButton>
       </IonCardContent>

--- a/src/components/settings/clusters/manual/Manual.tsx
+++ b/src/components/settings/clusters/manual/Manual.tsx
@@ -16,7 +16,7 @@ const Manual: React.FunctionComponent = () => {
           Choose this option to add a cluster manually. You have to provide a name, the server and a certificate. You
           can choose between username and password, token or a client certificate and key for the authentication.
         </p>
-        <IonButton expand="block" href="/settings/clusters/manual">
+        <IonButton expand="block" routerLink="/settings/clusters/manual" routerDirection="root">
           Add a Cluster
         </IonButton>
       </IonCardContent>

--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -12,12 +12,17 @@ import {
   IonToast,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { getOIDCLink } from '../../../../utils/api';
 import { isBase64 } from '../../../../utils/helpers';
 import { saveTemporaryCredentials } from '../../../../utils/storage';
 
-const OIDC: React.FunctionComponent = () => {
+export interface IOIDCProps extends RouteComponentProps {
+  close: () => void;
+}
+
+const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProps) => {
   const [discoveryURL, setDiscoveryURL] = useState<string>('');
   const [clientID, setClientID] = useState<string>('');
   const [clientSecret, setClientSecret] = useState<string>('');
@@ -63,10 +68,12 @@ const OIDC: React.FunctionComponent = () => {
       });
 
       if (refreshToken) {
-        window.location.replace('/settings/clusters/oidc');
+        close();
+        history.push('/settings/clusters/oidc');
       } else {
         try {
           const url = await getOIDCLink(discoveryURL, clientID, clientSecret, ca);
+          close();
           window.location.replace(url);
         } catch (err) {
           setError(err.message);
@@ -127,4 +134,4 @@ const OIDC: React.FunctionComponent = () => {
   );
 };
 
-export default OIDC;
+export default withRouter(OIDC);

--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -215,3 +215,16 @@ ion-avatar {
 .tooltip:hover .tooltiptext {
   visibility: visible;
 }
+
+/* Authentication Wrapper */
+.auth-col {
+  text-align: center;
+}
+
+.auth-img {
+  max-width: 50%;
+}
+
+.auth-padding-top {
+  padding-top: 25vh;
+}

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -90,7 +90,23 @@
   --ion-color-light-contrast-rgb: 0, 0, 0;
   --ion-color-light-shade: #d7d8da;
   --ion-color-light-tint: #f5f6f9;
+
+  --ion-color-white: #ffffff;
+  --ion-color-white-rgb: 255, 255, 255;
+  --ion-color-white-contrast: #000000;
+  --ion-color-white-contrast-rgb: 0, 0, 0;
+  --ion-color-white-shade: #ffffff;
+  --ion-color-white-tint: #ffffff;
 }
+
+.ion-color-white {
+  --ion-color-base: var(--ion-color-white) !important;
+  --ion-color-base-rgb: var(--ion-color-white-rgb) !important;
+  --ion-color-contrast: var(--ion-color-white-contrast) !important;
+  --ion-color-contrast-rgb: var(--ion-color-white-contrast-rgb) !important;
+  --ion-color-shade: var(--ion-color-white-shade) !important;
+  --ion-color-tint: var(--ion-color-white-tint) !important;
+  }
 
 /* Dark Mode
 // --------------------------------------------------


### PR DESCRIPTION
- Instead of showing the splash screen after a failed authentication, we are using the new AuthenticationWrapper component. This component contains a sign in button were the user can trigger a re-authentication.
- When a new cluster was added the user was forced to re-authenticate, when authentication was enabled, because we were using some ugly window.location function for redirecting. Now we are properly using the underlying React Router to handle the navigation, after the user selected an option to add a new cluster.

Closes #255.