### PR TITLE
Add version for macOS implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
 
       - name: Install Ionic
         run: |

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -13,18 +13,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
 
       - name: Generate Bindings (Android)
         # We must build the Android bindings on Ubuntu,
         # because the macOS used for GitHub Actions contains an outdated NDK version.
         if: matrix.os == 'ubuntu-latest'
         run: |
-          go get golang.org/x/mobile/cmd/gomobile
-          go install golang.org/x/mobile/cmd/gomobile
+          go mod download
           gomobile init
           make bindings-android
 
@@ -35,7 +34,6 @@ jobs:
         run: |
           unset ANDROID_HOME
           unset ANDROID_NDK_HOME
-          go get golang.org/x/mobile/cmd/gomobile
-          go install golang.org/x/mobile/cmd/gomobile
+          go mod download
           gomobile init
           make bindings-ios

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -23,7 +23,8 @@ jobs:
         # because the macOS used for GitHub Actions contains an outdated NDK version.
         if: matrix.os == 'ubuntu-latest'
         run: |
-          go mod download
+          go get golang.org/x/mobile/cmd/gomobile
+          go install golang.org/x/mobile/cmd/gomobile
           gomobile init
           make bindings-android
 
@@ -34,6 +35,7 @@ jobs:
         run: |
           unset ANDROID_HOME
           unset ANDROID_NDK_HOME
-          go mod download
+          go get golang.org/x/mobile/cmd/gomobile
+          go install golang.org/x/mobile/cmd/gomobile
           gomobile init
           make bindings-ios

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ release-major:
 	sed -i.bak 's/MARKETING_VERSION = .*/MARKETING_VERSION = ${MAJORVERSION};/g' ios/App/App.xcodeproj/project.pbxproj
 	rm -f ios/App/App.xcodeproj/project.pbxproj.bak
 
+	sed -i.bak 's/\"CFBundleVersion\":.*/\"CFBundleVersion\": \"${MAJORVERSION}\",/g' cmd/electron/bundler.json
+	sed -i.bak 's/\"CFBundleShortVersionString\":.*/\"CFBundleShortVersionString\": \"${MAJORVERSION}\",/g' cmd/electron/bundler.json
+	rm -f cmd/electron/bundler.json.bak
+
 	git add .
 	git commit -m 'Prepare release $(MAJORVERSION)'
 	git push
@@ -91,6 +95,10 @@ release-minor:
 	/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${IOS_CF_BUNDLE_VERSION}" ios/App/App/Info.plist
 	sed -i.bak 's/MARKETING_VERSION = .*/MARKETING_VERSION = ${MINORVERSION};/g' ios/App/App.xcodeproj/project.pbxproj
 	rm -f ios/App/App.xcodeproj/project.pbxproj.bak
+
+	sed -i.bak 's/\"CFBundleVersion\":.*/\"CFBundleVersion\": \"${MINORVERSION}\",/g' cmd/electron/bundler.json
+	sed -i.bak 's/\"CFBundleShortVersionString\":.*/\"CFBundleShortVersionString\": \"${MINORVERSION}\",/g' cmd/electron/bundler.json
+	rm -f cmd/electron/bundler.json.bak
 
 	git add .
 	git commit -m 'Prepare release $(MINORVERSION)'
@@ -118,6 +126,10 @@ release-patch:
 	/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${IOS_CF_BUNDLE_VERSION}" ios/App/App/Info.plist
 	sed -i.bak 's/MARKETING_VERSION = .*/MARKETING_VERSION = ${PATCHVERSION};/g' ios/App/App.xcodeproj/project.pbxproj
 	rm -f ios/App/App.xcodeproj/project.pbxproj.bak
+
+	sed -i.bak 's/\"CFBundleVersion\":.*/\"CFBundleVersion\": \"${PATCHVERSION}\",/g' cmd/electron/bundler.json
+	sed -i.bak 's/\"CFBundleShortVersionString\":.*/\"CFBundleShortVersionString\": \"${PATCHVERSION}\",/g' cmd/electron/bundler.json
+	rm -f cmd/electron/bundler.json.bak
 
 	git add .
 	git commit -m 'Prepare release $(PATCHVERSION)'

--- a/cmd/electron/bundler.json
+++ b/cmd/electron/bundler.json
@@ -14,6 +14,8 @@
     "CFBundleExecutable": "kubenav",
     "CFBundleName": "kubenav",
     "CFBundleIdentifier": "io.kubenav.kubenav",
+    "CFBundleVersion": "3.1.0",
+    "CFBundleShortVersionString": "3.1.0",
     "LSUIElement": "NO",
     "CFBundlePackageType": "APPL",
     "LSEnvironment": {

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install
 ENV REACT_APP_INCLUSTER true
 RUN ionic build
 
-FROM golang:1.14.4-alpine3.12 as server
+FROM golang:1.15.5-alpine3.12 as server
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "Building on $BUILDPLATFORM, for $TARGETPLATFORM" > /log


### PR DESCRIPTION
- This commit add the CFBundleVersion and CFBundleShortVersionString to the Info.plist file for macOS, to show the version information of kubenav in the Finder. The version is automatically updated via the Makefile (like it is done for the iOS and Android version) during a new release.
- Update the used Go version in the GitHub Actions to 1.15.

Fixes #260.