### PR TITLE
Fix rederict for Google and OIDC

### DIFF
--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -30,6 +30,14 @@ import Sections from './Sections';
 
 const { App } = Plugins;
 
+App.addListener('appUrlOpen', (data) => {
+  if (data.url.startsWith(GOOGLE_REDIRECT_URI)) {
+    window.location.replace(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
+  } else if (data.url.startsWith(OIDC_REDIRECT_URL)) {
+    window.location.replace(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
+  }
+});
+
 interface IMenuProps extends RouteComponentProps {
   sections: IAppSections;
 }
@@ -37,14 +45,6 @@ interface IMenuProps extends RouteComponentProps {
 const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location }: IMenuProps) => {
   const context = useContext<IContext>(AppContext);
   const [eventSourceInitialized, setEventSourceInitialized] = useState<boolean>(false);
-
-  App.addListener('appUrlOpen', (data) => {
-    if (data.url.startsWith(GOOGLE_REDIRECT_URI)) {
-      history.push(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
-    } else if (data.url.startsWith(OIDC_REDIRECT_URL)) {
-      history.push(data.url.replace(`${CUSTOM_URI_SCHEME}:`, ''));
-    }
-  });
 
   if (isPlatform('electron') && !eventSourceInitialized) {
     setEventSourceInitialized(true);


### PR DESCRIPTION
Currently the redirect within the app for Google and OIDC is broken, because `history.push` doesn't pass the query parameters to the correct page.

This is fixed by using the old way via `window.location.replace`. This also means that a user must reauthenticate when he enables authentication and is redirected to the app.

Fixes #267.