### PR TITLE
Fix bugs regarding authentication

### DIFF
--- a/src/theme/custom.css
+++ b/src/theme/custom.css
@@ -222,9 +222,14 @@ ion-avatar {
 }
 
 .auth-img {
-  max-width: 50%;
+  max-width: 256px;
 }
 
 .auth-padding-top {
-  padding-top: 25vh;
+  padding-top: 100px;
+}
+
+.auth-unlock-button {
+  max-width: 512px;
+  margin: auto;
 }

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -405,6 +405,12 @@ export const AuthenticationWrapper: React.FunctionComponent<IAuthenticationWrapp
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
+  useEffect(() => {
+    if (settings.authenticationEnabled && isPlatform('hybrid') && !isAuthenticated) {
+      signIn();
+    }
+  }, [isAuthenticated, settings.authenticationEnabled]);
+
   const signIn = async () => {
     try {
       await FingerprintAIO.show({});

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -29,6 +29,7 @@ import {
   saveClusters,
   saveSettings,
 } from './storage';
+import useWindowHeight from './useWindowHeight';
 
 const { SplashScreen } = Plugins;
 
@@ -400,6 +401,7 @@ export const AuthenticationWrapper: React.FunctionComponent<IAuthenticationWrapp
   settings,
   children,
 }: IAuthenticationWrapperProps) => {
+  const height = useWindowHeight();
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -418,8 +420,8 @@ export const AuthenticationWrapper: React.FunctionComponent<IAuthenticationWrapp
         <IonContent color="primary">
           <IonGrid>
             <IonRow className="ion-justify-content-center">
-              <IonCol className="auth-col">
-                <img className="auth-padding-top auth-img" alt="kubenav" src="/assets/icons/icon.png" />
+              <IonCol className="auth-col auth-padding-top">
+                {height > 512 ? <img className="auth-img" alt="kubenav" src="/assets/icons/icon.png" /> : null}
               </IonCol>
             </IonRow>
             <IonRow className="ion-justify-content-center">
@@ -429,8 +431,8 @@ export const AuthenticationWrapper: React.FunctionComponent<IAuthenticationWrapp
             </IonRow>
             <IonRow className="ion-justify-content-center">
               <IonCol className="auth-col">
-                <IonButton onClick={signIn} fill="outline" expand="block" color="white">
-                  Sign In
+                <IonButton className="auth-unlock-button" onClick={signIn} fill="outline" expand="block" color="white">
+                  Unlock
                 </IonButton>
               </IonCol>
             </IonRow>

--- a/src/utils/useWindowHeight.tsx
+++ b/src/utils/useWindowHeight.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useWindowHeight = (): number => {
+  const [height, setHeight] = useState<number>(window.innerHeight);
+
+  useEffect(() => {
+    const handleResize = () => setHeight(window.innerHeight);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+
+  return height;
+};
+
+export default useWindowHeight;


### PR DESCRIPTION
- For larger screens (tablets), the Sign In button was hidden and the user had to scroll to click the button. Now the button should be visible for all display sizes.
- For that we add a new hook useWindowHeight, which returns the current height of the window. If the window height is to small to display the icon and the Sign In button we hide the icon.
- We also rename the Sign In button to Unlock.
- Instead of clicking the unlock button, the user is automatically ask to unlock the app via Face ID / Touch ID. This means the user only must click the unlock button, when the authentication fails.

Fixes #263 and #264.