### PR TITLE
Improve Plugins

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,6 +53,14 @@ var rootCmd = &cobra.Command{
 			log.WithError(err).Fatalf("Could not create Kubernetes client")
 		}
 
+		if pluginElasticsearchUsernameFlag == "" {
+			pluginElasticsearchUsernameFlag = os.Getenv("KUBENAV_ELASTICSEARCH_USERNAME")
+		}
+
+		if pluginElasticsearchPasswordFlag == "" {
+			pluginElasticsearchPasswordFlag = os.Getenv("KUBENAV_ELASTICSEARCH_PASSWORD")
+		}
+
 		router := http.NewServeMux()
 		apiClient := api.NewClient(false, &plugins.Config{
 			PrometheusEnabled:             pluginPrometheusEnabledFlag,

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -112,27 +112,31 @@ const Menu: React.FunctionComponent<IMenuProps> = ({ sections, history, location
           <IonMenuToggle autoHide={false}>
             <IonItem routerLink="/plugins/helm" routerDirection="root">
               <IonAvatar slot="start">
-                <img alt="Helm Releases" src="/assets/icons/kubernetes/helm.png" />
+                <img alt="Helm" src="/assets/icons/kubernetes/helm.png" />
               </IonAvatar>
-              <IonLabel>Helm Releases</IonLabel>
+              <IonLabel>Helm</IonLabel>
             </IonItem>
           </IonMenuToggle>
-          <IonMenuToggle autoHide={false}>
-            <IonItem routerLink="/plugins/prometheus" routerDirection="root">
-              <IonAvatar slot="start">
-                <img alt="Prometheus Dashboards" src="/assets/icons/kubernetes/prometheus.png" />
-              </IonAvatar>
-              <IonLabel>Prometheus Dashboards</IonLabel>
-            </IonItem>
-          </IonMenuToggle>
-          <IonMenuToggle autoHide={false}>
-            <IonItem routerLink="/plugins/elasticsearch" routerDirection="root">
-              <IonAvatar slot="start">
-                <img alt="Elasticsearch" src="/assets/icons/kubernetes/elasticsearch.png" />
-              </IonAvatar>
-              <IonLabel>Elasticsearch</IonLabel>
-            </IonItem>
-          </IonMenuToggle>
+          {context.settings.prometheusEnabled ? (
+            <IonMenuToggle autoHide={false}>
+              <IonItem routerLink="/plugins/prometheus" routerDirection="root">
+                <IonAvatar slot="start">
+                  <img alt="Prometheus" src="/assets/icons/kubernetes/prometheus.png" />
+                </IonAvatar>
+                <IonLabel>Prometheus</IonLabel>
+              </IonItem>
+            </IonMenuToggle>
+          ) : null}
+          {context.settings.elasticsearchEnabled ? (
+            <IonMenuToggle autoHide={false}>
+              <IonItem routerLink="/plugins/elasticsearch" routerDirection="root">
+                <IonAvatar slot="start">
+                  <img alt="Elasticsearch" src="/assets/icons/kubernetes/elasticsearch.png" />
+                </IonAvatar>
+                <IonLabel>Elasticsearch</IonLabel>
+              </IonItem>
+            </IonMenuToggle>
+          ) : null}
 
           <IonListHeader mode="md">
             <IonLabel>Settings</IonLabel>

--- a/src/components/plugins/elasticsearch/Details.tsx
+++ b/src/components/plugins/elasticsearch/Details.tsx
@@ -1,0 +1,43 @@
+import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover } from '@ionic/react';
+import { ellipsisHorizontal, ellipsisVertical, help } from 'ionicons/icons';
+import React, { useState } from 'react';
+
+import { openURL } from '../../../utils/helpers';
+
+const Details: React.FunctionComponent = () => {
+  const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [popoverEvent, setPopoverEvent] = useState();
+
+  return (
+    <React.Fragment>
+      <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
+        <IonList>
+          <IonItem
+            button={true}
+            detail={false}
+            onClick={() => {
+              openURL('https://docs.kubenav.io/plugins/elasticsearch/');
+              setShowPopover(false);
+            }}
+          >
+            <IonIcon slot="end" color="primary" icon={help} />
+            <IonLabel>Help</IonLabel>
+          </IonItem>
+        </IonList>
+      </IonPopover>
+
+      <IonButton
+        onClick={(e) => {
+          e.persist();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          setPopoverEvent(e as any);
+          setShowPopover(true);
+        }}
+      >
+        <IonIcon slot="icon-only" ios={ellipsisHorizontal} md={ellipsisVertical} />
+      </IonButton>
+    </React.Fragment>
+  );
+};
+
+export default Details;

--- a/src/components/plugins/elasticsearch/Document.tsx
+++ b/src/components/plugins/elasticsearch/Document.tsx
@@ -16,10 +16,19 @@ import React, { useState } from 'react';
 import { getProperty } from '../../../utils/helpers';
 import Editor from '../../misc/Editor';
 
+export interface IElasticsearchDocumentSource {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface IElasticsearchDocument {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  _source: IElasticsearchDocumentSource;
+}
+
 interface IResultProps {
   layout: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  document: any;
+  document: IElasticsearchDocument;
   fields: string[];
 }
 
@@ -85,7 +94,7 @@ const Document: React.FunctionComponent<IResultProps> = ({ layout, document, fie
           </IonToolbar>
         </IonHeader>
         <IonContent>
-          <Editor readOnly={true} mode="json" value={JSON.stringify(document, null, 2)} fullHeight={true} />
+          <Editor readOnly={true} mode="json" value={JSON.stringify(document['_source'], null, 2)} fullHeight={true} />
         </IonContent>
       </IonModal>
     </React.Fragment>

--- a/src/components/plugins/elasticsearch/QueryList.tsx
+++ b/src/components/plugins/elasticsearch/QueryList.tsx
@@ -32,7 +32,6 @@ interface IQuery {
   query: string;
   from: string;
   to: string;
-  size: string;
   selectedFields: string;
 }
 
@@ -62,7 +61,6 @@ const QueryList: React.FunctionComponent<IQueryListProps> = ({ item }: IQueryLis
           query: q,
           from: query.from ? query.from : 'now-15m',
           to: query.to ? query.to : 'now',
-          size: query.size ? query.size : '100',
           selectedFields: query.selectedFields ? query.selectedFields : '',
         });
       }
@@ -83,7 +81,7 @@ const QueryList: React.FunctionComponent<IQueryListProps> = ({ item }: IQueryLis
                   return (
                     <IonItem
                       key={index}
-                      routerLink={`/plugins/elasticsearch?query=${query.query}&from=${query.from}&to=${query.to}&size=${query.size}&selectedFields=${query.selectedFields}`}
+                      routerLink={`/plugins/elasticsearch?query=${query.query}&from=${query.from}&to=${query.to}&selectedFields=${query.selectedFields}`}
                       routerDirection="forward"
                     >
                       <IonLabel>

--- a/src/components/plugins/elasticsearch/QueryPage.tsx
+++ b/src/components/plugins/elasticsearch/QueryPage.tsx
@@ -34,6 +34,7 @@ import { IS_INCLUSTER } from '../../../utils/constants';
 import { AppContext } from '../../../utils/context';
 import useWindowWidth from '../../../utils/useWindowWidth';
 import Document, { IElasticsearchDocument, IElasticsearchDocumentSource } from './Document';
+import Details from './Details';
 
 const getFieldsRecursively = (prefix: string, document: IElasticsearchDocumentSource): string[] => {
   const fields: string[] = [];
@@ -205,6 +206,9 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
             <IonMenuButton />
           </IonButtons>
           <IonTitle>Elasticsearch</IonTitle>
+          <IonButtons slot="primary">
+            <Details />
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>

--- a/src/components/plugins/elasticsearch/QueryPage.tsx
+++ b/src/components/plugins/elasticsearch/QueryPage.tsx
@@ -7,6 +7,8 @@ import {
   IonContent,
   IonGrid,
   IonHeader,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
   IonInput,
   IonItem,
   IonLabel,
@@ -31,10 +33,9 @@ import { kubernetesRequest, pluginRequest } from '../../../utils/api';
 import { IS_INCLUSTER } from '../../../utils/constants';
 import { AppContext } from '../../../utils/context';
 import useWindowWidth from '../../../utils/useWindowWidth';
-import Document from './Document';
+import Document, { IElasticsearchDocument, IElasticsearchDocumentSource } from './Document';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getFieldsRecursively = (prefix: string, document: any): string[] => {
+const getFieldsRecursively = (prefix: string, document: IElasticsearchDocumentSource): string[] => {
   const fields: string[] = [];
   for (const field in document) {
     if (typeof document[field] === 'object') {
@@ -47,8 +48,7 @@ const getFieldsRecursively = (prefix: string, document: any): string[] => {
   return fields;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getFields = (documents: any[]): string[] => {
+const getFields = (documents: IElasticsearchDocument[]): string[] => {
   const fields: string[] = [];
   for (const document of documents) {
     fields.push(...getFieldsRecursively('', document['_source']));
@@ -64,6 +64,16 @@ const getFields = (documents: any[]): string[] => {
   return uniqueFields;
 };
 
+interface IElasticsearchHits {
+  hits: IElasticsearchDocument[];
+}
+
+interface IElasticsearchResult {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  _scroll_id: string;
+  hits: IElasticsearchHits;
+}
+
 type IQueryPageProps = RouteComponentProps;
 
 const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQueryPageProps) => {
@@ -76,9 +86,8 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
   const [query, setQuery] = useState<string>(url.get('query') ? (url.get('query') as string) : '');
   const [from, setFrom] = useState<string>(url.get('from') ? (url.get('from') as string) : 'now-15m');
   const [to, setTo] = useState<string>(url.get('to') ? (url.get('to') as string) : 'now');
-  const [size, setSize] = useState<string>(url.get('size') ? (url.get('size') as string) : '100');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [documents, setDocuments] = useState<any>(undefined);
+  const [scrollID, setScrollID] = useState<string>('');
+  const [documents, setDocuments] = useState<IElasticsearchDocument[]>([]);
   const [fields, setFields] = useState<string[]>([]);
   const [selectedFields, setSelectedFields] = useState<string[]>(
     url.get('selectedFields') ? (url.get('selectedFields') as string).split(',') : [],
@@ -98,10 +107,6 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
     setTo(event.target.value);
   };
 
-  const handleSize = (event) => {
-    setSize(event.target.value);
-  };
-
   const addField = (field: string) => {
     setSelectedFields((fields) => [...fields, field]);
   };
@@ -110,7 +115,10 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
     setSelectedFields(selectedFields.filter((item) => item !== field));
   };
 
-  const runQuery = async () => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  let result: IElasticsearchResult = { _scroll_id: '', hits: { hits: [] } };
+
+  const runQuery = async (useScrollID: boolean) => {
     try {
       setError('');
       setIsFetching(true);
@@ -134,12 +142,14 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
         }
       }
 
-      const docs = await pluginRequest(
+      result = await pluginRequest(
         'elasticsearch',
         context.settings.elasticsearchPort,
         context.settings.elasticsearchAddress,
         {
           query: {
+            size: 100,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             sort: [{ '@timestamp': { order: 'desc' } }],
             query: {
               bool: {
@@ -162,7 +172,7 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
               },
             },
           },
-          size: '100',
+          scrollID: useScrollID ? scrollID : '',
           username: context.settings.elasticsearchUsername,
           password: context.settings.elasticsearchPassword,
         },
@@ -171,13 +181,18 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
         await context.kubernetesAuthWrapper(''),
       );
 
-      setFields(getFields(docs.slice(docs.lenght > 10 ? 10 : docs.lenght)));
+      if (scrollID === '') {
+        setScrollID(result._scroll_id);
+        setFields(getFields(result.hits.hits.slice(result.hits.hits.length > 10 ? 10 : result.hits.hits.length)));
+        setDocuments(result.hits.hits);
+      } else {
+        setDocuments((docs) => [...docs, ...result.hits.hits]);
+      }
 
       setIsFetching(false);
-      setDocuments(docs);
     } catch (err) {
       setIsFetching(false);
-      setDocuments(undefined);
+      setDocuments([]);
       setError(err.message);
     }
   };
@@ -228,7 +243,7 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
                           </IonItem>
                         </IonCol>
                         <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="2" sizeXl="2">
-                          <IonButton expand="block" onClick={() => runQuery()}>
+                          <IonButton expand="block" onClick={() => runQuery(false)}>
                             Search
                           </IonButton>
                         </IonCol>
@@ -239,7 +254,7 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
                   {activeSegment === 'options' ? (
                     <IonGrid>
                       <IonRow>
-                        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+                        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="6" sizeXl="6">
                           <IonItem>
                             <IonLabel position="stacked">From</IonLabel>
                             <IonInput
@@ -251,22 +266,10 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
                             />
                           </IonItem>
                         </IonCol>
-                        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
+                        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="6" sizeXl="6">
                           <IonItem>
                             <IonLabel position="stacked">To</IonLabel>
                             <IonInput type="text" required={true} placeholder="To" value={to} onInput={handleTo} />
-                          </IonItem>
-                        </IonCol>
-                        <IonCol sizeXs="12" sizeSm="12" sizeMd="12" sizeLg="4" sizeXl="4">
-                          <IonItem>
-                            <IonLabel position="stacked">Size</IonLabel>
-                            <IonInput
-                              type="text"
-                              required={true}
-                              placeholder="Size"
-                              value={size}
-                              onInput={handleSize}
-                            />
                           </IonItem>
                         </IonCol>
                       </IonRow>
@@ -299,7 +302,7 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
             </IonCol>
           </IonRow>
 
-          {error || documents ? (
+          {error || documents.length > 0 ? (
             <IonRow>
               <IonCol>
                 <IonCard>
@@ -335,6 +338,13 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ location }: IQuer
                             </table>
                           </div>
                         )}
+                        <IonInfiniteScroll
+                          threshold="25%"
+                          disabled={isFetching || documents.length > 5000}
+                          onIonInfinite={() => runQuery(true)}
+                        >
+                          <IonInfiniteScrollContent loadingText="Loading more Documents..."></IonInfiniteScrollContent>
+                        </IonInfiniteScroll>
                       </React.Fragment>
                     )}
                   </IonCardContent>

--- a/src/components/plugins/helm/ReleasesPage.tsx
+++ b/src/components/plugins/helm/ReleasesPage.tsx
@@ -134,7 +134,7 @@ const ReleasesPage: React.FunctionComponent = () => {
           <IonButtons slot="start">
             <IonMenuButton />
           </IonButtons>
-          <IonTitle>Helm Releases</IonTitle>
+          <IonTitle>Helm</IonTitle>
           <IonButtons slot="primary">
             <Namespaces />
             <Details

--- a/src/components/plugins/prometheus/DashboardPage.tsx
+++ b/src/components/plugins/prometheus/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { kubernetesRequest } from '../../../utils/api';
 import { AppContext } from '../../../utils/context';
 import LoadingErrorCard from '../../misc/LoadingErrorCard';
 import Dashboard, { IDashboardProps, IVariable } from './Dashboard';
+import Details from './Details';
 
 interface IMatchParams {
   namespace: string;
@@ -83,6 +84,9 @@ const DashboardPage: React.FunctionComponent<IDashboardPageProps> = ({ match, lo
             <IonBackButton defaultHref="/plugins/prometheus" />
           </IonButtons>
           <IonTitle>{data ? data.title : ''}</IonTitle>
+          <IonButtons slot="primary">
+            <Details refresh={refetch} />
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>

--- a/src/components/plugins/prometheus/DashboardsPage.tsx
+++ b/src/components/plugins/prometheus/DashboardsPage.tsx
@@ -2,8 +2,6 @@ import { RefresherEventDetail } from '@ionic/core';
 import {
   IonButton,
   IonButtons,
-  IonCard,
-  IonCardContent,
   IonContent,
   IonHeader,
   IonInfiniteScroll,
@@ -27,6 +25,7 @@ import { IContext } from '../../../declarations';
 import { kubernetesRequest } from '../../../utils/api';
 import { AppContext } from '../../../utils/context';
 import LoadingErrorCard from '../../misc/LoadingErrorCard';
+import Details from './Details';
 
 const DashboardsPage: React.FunctionComponent = () => {
   const context = useContext<IContext>(AppContext);
@@ -41,7 +40,7 @@ const DashboardsPage: React.FunctionComponent = () => {
         context.settings.prometheusDashboardsNamespace
           ? `/api/v1/namespaces/${context.settings.prometheusDashboardsNamespace}/configmaps`
           : `/api/v1/configmaps`
-      }?labelSelector=kubenav.io/dashboard=false&limit=50${cursor ? `&continue=${cursor}` : ''}`,
+      }?labelSelector=kubenav.io/dashboard=true&limit=50${cursor ? `&continue=${cursor}` : ''}`,
       '',
       context.settings,
       await context.kubernetesAuthWrapper(''),
@@ -75,7 +74,10 @@ const DashboardsPage: React.FunctionComponent = () => {
           <IonButtons slot="start">
             <IonMenuButton />
           </IonButtons>
-          <IonTitle>Prometheus Dashboards</IonTitle>
+          <IonTitle>Prometheus</IonTitle>
+          <IonButtons slot="primary">
+            <Details refresh={refetch} />
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>
@@ -89,7 +91,7 @@ const DashboardsPage: React.FunctionComponent = () => {
               value={searchText}
               onIonChange={(e) => setSearchText(e.detail.value ? e.detail.value : '')}
             />
-            {data && data.length > 0 && data[0].items > 0 ? (
+            {data && data.length > 0 && data[0].items.length > 0 ? (
               <IonList>
                 {data.map((group, i) => (
                   <React.Fragment key={i}>
@@ -133,21 +135,7 @@ const DashboardsPage: React.FunctionComponent = () => {
                   ></IonInfiniteScrollContent>
                 </IonInfiniteScroll>
               </IonList>
-            ) : (
-              <IonCard>
-                <IonCardContent>
-                  <p>
-                    The Prometheus plugin allows you to create dashboards for Prometheus within kubenav. To use the
-                    Prometheus plugin you have to enable it in the <b>Settings</b>. The documentation for the Prometheus
-                    plugin can be found at{' '}
-                    <a href="https://docs.kubenav.io/plugins/prometheus/" target="_blank" rel="noopener noreferrer">
-                      https://docs.kubenav.io/plugins/prometheus/
-                    </a>
-                    .
-                  </p>
-                </IonCardContent>
-              </IonCard>
-            )}
+            ) : null}
           </React.Fragment>
         ) : isFetching ? null : (
           <LoadingErrorCard

--- a/src/components/plugins/prometheus/Details.tsx
+++ b/src/components/plugins/prometheus/Details.tsx
@@ -1,27 +1,14 @@
 import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover } from '@ionic/react';
-import {
-  ellipsisHorizontal,
-  ellipsisVertical,
-  help,
-  layers,
-  layersOutline,
-  refresh as refreshIcon,
-} from 'ionicons/icons';
+import { ellipsisHorizontal, ellipsisVertical, help, refresh as refreshIcon } from 'ionicons/icons';
 import React, { useState } from 'react';
 
 import { openURL } from '../../../utils/helpers';
 
 interface IDetailsProps {
   refresh: () => void;
-  showAllVersions?: boolean;
-  setShowAllVersions?: (value: boolean) => void;
 }
 
-const Details: React.FunctionComponent<IDetailsProps> = ({
-  refresh,
-  showAllVersions,
-  setShowAllVersions,
-}: IDetailsProps) => {
+const Details: React.FunctionComponent<IDetailsProps> = ({ refresh }: IDetailsProps) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
 
@@ -40,24 +27,11 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
             <IonIcon slot="end" color="primary" icon={refreshIcon} />
             <IonLabel>Refresh</IonLabel>
           </IonItem>
-          {showAllVersions !== undefined && setShowAllVersions ? (
-            <IonItem
-              button={true}
-              detail={false}
-              onClick={() => {
-                setShowAllVersions(!showAllVersions);
-                setShowPopover(false);
-              }}
-            >
-              <IonIcon slot="end" color="primary" icon={showAllVersions ? layers : layersOutline} />
-              <IonLabel>All Versions</IonLabel>
-            </IonItem>
-          ) : null}
           <IonItem
             button={true}
             detail={false}
             onClick={() => {
-              openURL('https://docs.kubenav.io/plugins/helm/');
+              openURL('https://docs.kubenav.io/plugins/prometheus/');
               setShowPopover(false);
             }}
           >

--- a/src/components/settings/InfoPage.tsx
+++ b/src/components/settings/InfoPage.tsx
@@ -16,12 +16,12 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
 import { useGetInfo } from '@ionic/react-hooks/device';
 import React, { memo, useEffect, useState } from 'react';
 
 import { VERSION } from '../../utils/constants';
+import { openURL } from '../../utils/helpers';
 import License from './info/License';
 
 const InfoPage: React.FunctionComponent = () => {
@@ -33,15 +33,6 @@ const InfoPage: React.FunctionComponent = () => {
       setVersion(info.appVersion);
     }
   }, [info]);
-
-  const openLink = (url: string) => {
-    if (isPlatform('electron')) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      window.require('electron').shell.openExternal(url);
-    } else {
-      window.open(url, '_system', 'location=yes');
-    }
-  };
 
   return (
     <IonPage>
@@ -89,25 +80,25 @@ const InfoPage: React.FunctionComponent = () => {
               <IonListHeader mode="md">
                 <IonLabel>Links</IonLabel>
               </IonListHeader>
-              <IonItem onClick={() => openLink('https://kubenav.io')} button={true}>
+              <IonItem onClick={() => openURL('https://kubenav.io')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="Website" src="/assets/icons/misc/browser.png" />
                 </IonAvatar>
                 <IonLabel>Website</IonLabel>
               </IonItem>
-              <IonItem onClick={() => openLink('https://docs.kubenav.io')} button={true}>
+              <IonItem onClick={() => openURL('https://docs.kubenav.io')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="Documentation" src="/assets/icons/misc/documentation.png" />
                 </IonAvatar>
                 <IonLabel>Documentation</IonLabel>
               </IonItem>
-              <IonItem onClick={() => openLink('https://github.com/kubenav/kubenav')} button={true}>
+              <IonItem onClick={() => openURL('https://github.com/kubenav/kubenav')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="GitHub" src="/assets/icons/misc/github.png" />
                 </IonAvatar>
                 <IonLabel>GitHub</IonLabel>
               </IonItem>
-              <IonItem onClick={() => openLink('https://twitter.com/kubenav')} button={true}>
+              <IonItem onClick={() => openURL('https://twitter.com/kubenav')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="Twitter" src="/assets/icons/misc/twitter.png" />
                 </IonAvatar>
@@ -117,13 +108,13 @@ const InfoPage: React.FunctionComponent = () => {
               <IonListHeader mode="md">
                 <IonLabel>Donation</IonLabel>
               </IonListHeader>
-              <IonItem onClick={() => openLink('https://github.com/sponsors/ricoberger')} button={true}>
+              <IonItem onClick={() => openURL('https://github.com/sponsors/ricoberger')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="GitHub Sponsors" src="/assets/icons/misc/github.png" />
                 </IonAvatar>
                 <IonLabel>GitHub Sponsors</IonLabel>
               </IonItem>
-              <IonItem onClick={() => openLink('https://www.paypal.me/ricoberger')} button={true}>
+              <IonItem onClick={() => openURL('https://www.paypal.me/ricoberger')} button={true}>
                 <IonAvatar slot="start">
                   <img alt="PayPal" src="/assets/icons/misc/paypal.png" />
                 </IonAvatar>

--- a/src/components/settings/clusters/aws/AWSSSOPage.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOPage.tsx
@@ -1,4 +1,3 @@
-import { Plugins } from '@capacitor/core';
 import {
   IonButton,
   IonButtons,
@@ -17,7 +16,6 @@ import {
   IonSelectOption,
   IonTitle,
   IonToolbar,
-  isPlatform,
 } from '@ionic/react';
 import React, { memo, useContext, useState } from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -25,8 +23,7 @@ import { RouteComponentProps } from 'react-router';
 import { IAWSSSO, ICluster, IContext } from '../../../../declarations';
 import { getAWSClusters, getAWSSSOConfig, getAWSSSOCredentailsWithConfig } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
-
-const { App } = Plugins;
+import { openURL } from '../../../../utils/helpers';
 
 const isChecked = (id: string, clusters: ICluster[]): boolean => {
   for (const cluster of clusters) {
@@ -79,14 +76,6 @@ const AWSSSOPage: React.FunctionComponent<IAWSSSOPageProps> = ({ history }: IAWS
       setConfig(ssoConfig);
     } catch (err) {
       setError(err.message);
-    }
-  };
-
-  const openURL = async (url: string) => {
-    if (isPlatform('hybrid')) {
-      await App.openUrl({ url: url });
-    } else {
-      window.open(url, '_system', 'location=yes');
     }
   };
 

--- a/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
@@ -1,13 +1,11 @@
-import { Plugins } from '@capacitor/core';
-import { IonButton, IonCardContent, isPlatform } from '@ionic/react';
+import { IonButton, IonCardContent } from '@ionic/react';
 import React, { useContext, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { IAWSSSO, IContext } from '../../../../declarations';
 import { getAWSSSOConfig, getAWSSSOCredentailsWithConfig } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
-
-const { App } = Plugins;
+import { openURL } from '../../../../utils/helpers';
 
 type IAWSSSOReAuthenticateProps = RouteComponentProps;
 
@@ -28,14 +26,6 @@ const AWSSSOReAuthenticate: React.FunctionComponent<IAWSSSOReAuthenticateProps> 
       }
     } catch (err) {
       setError(err.message);
-    }
-  };
-
-  const openURL = async (url: string) => {
-    if (isPlatform('hybrid')) {
-      await App.openUrl({ url: url });
-    } else {
-      window.open(url, '_system', 'location=yes');
     }
   };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,10 @@
+import { Plugins } from '@capacitor/core';
+import { isPlatform } from '@ionic/react';
 import { V1LabelSelector, V1Subject } from '@kubernetes/client-node';
 
 import { TTheme } from '../declarations';
+
+const { App } = Plugins;
 
 // capitalize uppercase the first letter of a string
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -148,6 +152,19 @@ export const matchLabels = (labels: { [key: string]: string }): string => {
   }
 
   return selectors.join(',');
+};
+
+// openURL opens the given URL in the users default browser.
+export const openURL = async (url: string): Promise<void> => {
+  if (isPlatform('hybrid')) {
+    await App.openUrl({ url: url });
+  } else if (isPlatform('electron')) {
+    window.require('electron').shell.openExternal(url);
+  } else {
+    window.open(url, '_system', 'location=yes');
+  }
+
+  return;
 };
 
 // randomString generates a random string of the given length.

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -11,8 +11,9 @@ import {
 } from './api';
 import { IS_INCLUSTER } from './constants';
 import { AppContext } from './context';
+import { openURL } from './helpers';
 
-const { App, Clipboard } = Plugins;
+const { Clipboard } = Plugins;
 
 // Creates a Context object. When React renders a component that subscribes to this Context object it will read the
 // current context value from the closest matching Provider above it in the tree.
@@ -125,10 +126,6 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
     }
   };
 
-  const openURL = async (url: string) => {
-    await App.openUrl({ url: url });
-  };
-
   const generateButtons = (): ActionSheetButton[] => {
     const buttons: ActionSheetButton[] = [];
 
@@ -186,16 +183,7 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
           {
             side: 'end',
             text: 'Open',
-            handler: () => {
-              if (isPlatform('electron')) {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                window.require('electron').shell.openExternal(`http://localhost:${messagePort}`);
-              } else if (isPlatform('hybrid')) {
-                openURL(`http://localhost:${messagePort}`);
-              } else {
-                window.open(`http://localhost:${messagePort}`, '_system', 'location=yes');
-              }
-            },
+            handler: () => openURL(`http://localhost:${messagePort}`),
           },
         ]}
       />


### PR DESCRIPTION
- The number of documents, which could be retrieved from the Elasticsearch API was limited to 100 documents. To support more documents (5000), we now support infinite scrolling for the plugin via the Elasticsearch scroll API.
- Change page title for plugins.
- Allow environment variables for Elasticsearch username and password.
- Add openURL helpers function and replace the existing functions to  open links in the users default browser.
- Add details menu for plugins, to refresh the page and to open the  documentation for a plugin.
- Fix dashboard selection for Prometheus plugin.
- Do not show plugins in menu, when they are disabled.