### PR TITLE
Remove job label from Prometheus metrics

### DIFF
--- a/src/components/overview/OverviewPage.tsx
+++ b/src/components/overview/OverviewPage.tsx
@@ -102,19 +102,19 @@ const OverviewPage: React.FunctionComponent = () => {
                     queries: [
                       {
                         label: 'Current',
-                        query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="", container!="POD"}[4m]))`,
+                        query: `sum(irate(container_cpu_usage_seconds_total{image!="", container!="", container!="POD"}[4m]))`,
                       },
                       {
                         label: 'Requested',
-                        query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", container!=""})`,
+                        query: `sum(kube_pod_container_resource_requests{resource="cpu", container!=""})`,
                       },
                       {
                         label: 'Limit',
-                        query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", resource="cpu", container!=""})`,
+                        query: `sum(kube_pod_container_resource_limits{resource="cpu", container!=""})`,
                       },
                       {
                         label: 'Allocatable',
-                        query: `sum(kube_node_status_allocatable_cpu_cores{job="kube-state-metrics"})`,
+                        query: `sum(kube_node_status_allocatable_cpu_cores)`,
                       },
                     ],
                   },
@@ -132,23 +132,23 @@ const OverviewPage: React.FunctionComponent = () => {
                     queries: [
                       {
                         label: 'Current',
-                        query: `sum(container_memory_usage_bytes{job="kubelet", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
+                        query: `sum(container_memory_usage_bytes{container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Requested',
-                        query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", container!=""}) / 1024 / 1024 / 1024`,
+                        query: `sum(kube_pod_container_resource_requests{resource="memory", container!=""}) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Limit',
-                        query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", resource="memory", container!=""}) / 1024 / 1024 / 1024`,
+                        query: `sum(kube_pod_container_resource_limits{resource="memory", container!=""}) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Cache',
-                        query: `sum(container_memory_cache{job="kubelet", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
+                        query: `sum(container_memory_cache{container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Allocatable',
-                        query: `sum(kube_node_status_allocatable_memory_bytes{job="kube-state-metrics"}) / 1024 / 1024 / 1024`,
+                        query: `sum(kube_node_status_allocatable_memory_bytes) / 1024 / 1024 / 1024`,
                       },
                     ],
                   },
@@ -166,11 +166,11 @@ const OverviewPage: React.FunctionComponent = () => {
                     queries: [
                       {
                         label: 'Current',
-                        query: `count(kube_pod_info{job="kube-state-metrics"})`,
+                        query: `count(kube_pod_info)`,
                       },
                       {
                         label: 'Allocatable',
-                        query: `sum(kube_node_status_allocatable_pods{job="kube-state-metrics"})`,
+                        query: `sum(kube_node_status_allocatable_pods)`,
                       },
                     ],
                   },

--- a/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
+++ b/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
@@ -60,19 +60,19 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
+                  query: `sum(irate(container_cpu_usage_seconds_total{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", image!="", container!="", container!="POD"}[4m]))`,
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_requests{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="cpu", container!=""})`,
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_limits{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="cpu", container!=""})`,
                 },
@@ -92,25 +92,25 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{job="kubelet", namespace="${
+                  query: `sum(container_memory_usage_bytes{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", container!="", container!="POD"}) / 1024 / 1024`,
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_requests{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024`,
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_limits{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024`,
                 },
                 {
                   label: 'Cache',
-                  query: `sum(container_memory_cache{job="kubelet", namespace="${
+                  query: `sum(container_memory_cache{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", container!="", container!="POD"}) / 1024 / 1024`,
                 },

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -196,25 +196,25 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", node="${
+                  query: `sum(irate(container_cpu_usage_seconds_total{node="${
                     item.metadata ? item.metadata.name : ''
                   }", image!="", container!="", container!="POD"}[4m]))`,
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", node="${
+                  query: `sum(kube_pod_container_resource_requests{node="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="cpu", container!=""})`,
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", node="${
+                  query: `sum(kube_pod_container_resource_limits{node="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="cpu", container!=""})`,
                 },
                 {
                   label: 'Allocatable',
-                  query: `sum(kube_node_status_allocatable_cpu_cores{job="kube-state-metrics", node="${
+                  query: `sum(kube_node_status_allocatable_cpu_cores{node="${
                     item.metadata ? item.metadata.name : ''
                   }"})`,
                 },
@@ -234,31 +234,31 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{job="kubelet", node="${
+                  query: `sum(container_memory_usage_bytes{node="${
                     item.metadata ? item.metadata.name : ''
                   }", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", node="${
+                  query: `sum(kube_pod_container_resource_requests{node="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", node="${
+                  query: `sum(kube_pod_container_resource_limits{node="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Cache',
-                  query: `sum(container_memory_cache{job="kubelet", node="${
+                  query: `sum(container_memory_cache{node="${
                     item.metadata ? item.metadata.name : ''
                   }", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Allocatable',
-                  query: `sum(kube_node_status_allocatable_memory_bytes{job="kube-state-metrics", node="${
+                  query: `sum(kube_node_status_allocatable_memory_bytes{node="${
                     item.metadata ? item.metadata.name : ''
                   }"}) / 1024 / 1024 / 1024`,
                 },
@@ -278,15 +278,11 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
               queries: [
                 {
                   label: 'Current',
-                  query: `count(kube_pod_info{job="kube-state-metrics", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }"})`,
+                  query: `count(kube_pod_info{node="${item.metadata ? item.metadata.name : ''}"})`,
                 },
                 {
                   label: 'Allocatable',
-                  query: `sum(kube_node_status_allocatable_pods{job="kube-state-metrics", node="${
-                    item.metadata ? item.metadata.name : ''
-                  }"})`,
+                  query: `sum(kube_node_status_allocatable_pods{node="${item.metadata ? item.metadata.name : ''}"})`,
                 },
               ],
             },

--- a/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimDetails.tsx
+++ b/src/components/resources/configAndStorage/persistentVolumeClaims/PersistentVolumeClaimDetails.tsx
@@ -104,18 +104,18 @@ const PersistentVolumeClaimDetails: React.FunctionComponent<IPersistentVolumeCla
                 {
                   label: 'Used Space',
                   query: `(
-                    sum without(instance, node) (kubelet_volume_stats_capacity_bytes{job="kubelet", namespace="${
+                    sum without(instance, node) (kubelet_volume_stats_capacity_bytes{namespace="${
                       item.metadata ? item.metadata.namespace : ''
                     }", persistentvolumeclaim="${item.metadata ? item.metadata.name : ''}"})
                     -
-                    sum without(instance, node) (kubelet_volume_stats_available_bytes{job="kubelet", namespace="${
+                    sum without(instance, node) (kubelet_volume_stats_available_bytes{namespace="${
                       item.metadata ? item.metadata.namespace : ''
                     }", persistentvolumeclaim="${item.metadata ? item.metadata.name : ''}"})
                   ) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Total Space',
-                  query: `sum without(instance, node) (kubelet_volume_stats_capacity_bytes{job="kubelet", namespace="${
+                  query: `sum without(instance, node) (kubelet_volume_stats_capacity_bytes{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", persistentvolumeclaim="${item.metadata ? item.metadata.name : ''}"}) / 1024 / 1024 / 1024`,
                 },
@@ -135,13 +135,13 @@ const PersistentVolumeClaimDetails: React.FunctionComponent<IPersistentVolumeCla
               queries: [
                 {
                   label: 'Used inodes',
-                  query: `sum without(instance, node) (kubelet_volume_stats_inodes_used{job="kubelet", namespace="${
+                  query: `sum without(instance, node) (kubelet_volume_stats_inodes_used{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", persistentvolumeclaim="${item.metadata ? item.metadata.name : ''}"})`,
                 },
                 {
                   label: 'Total inodes',
-                  query: `sum without(instance, node) (kubelet_volume_stats_inodes{job="kubelet", namespace="${
+                  query: `sum without(instance, node) (kubelet_volume_stats_inodes{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", persistentvolumeclaim="${item.metadata ? item.metadata.name : ''}"})`,
                 },

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -215,7 +215,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{job="kubelet", namespace="${
+                  query: `sum(irate(container_cpu_usage_seconds_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", image!="", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -223,7 +223,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_requests{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", resource="cpu", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -231,7 +231,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_limits{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", resource="cpu", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -253,7 +253,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{job="kubelet", namespace="${
+                  query: `sum(container_memory_usage_bytes{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -261,7 +261,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                 },
                 {
                   label: 'Requested',
-                  query: `sum(kube_pod_container_resource_requests{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_requests{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", resource="memory", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -269,7 +269,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                 },
                 {
                   label: 'Limit',
-                  query: `sum(kube_pod_container_resource_limits{job="kube-state-metrics", namespace="${
+                  query: `sum(kube_pod_container_resource_limits{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", resource="memory", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -277,7 +277,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                 },
                 {
                   label: 'Cache',
-                  query: `sum(container_memory_cache{job="kubelet", namespace="${
+                  query: `sum(container_memory_cache{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${
                     item.metadata ? item.metadata.name : ''
@@ -299,13 +299,13 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'RX',
-                  query: `sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job="kubelet", namespace="${
+                  query: `sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${item.metadata ? item.metadata.name : ''}"}[4m]))) / 1024 / 1024`,
                 },
                 {
                   label: 'TX',
-                  query: `sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job="kubelet", namespace="${
+                  query: `sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${item.metadata ? item.metadata.name : ''}"}[4m]))) / 1024 / 1024`,
                 },
@@ -325,7 +325,7 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'Restarts',
-                  query: `max(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="${
+                  query: `max(kube_pod_container_status_restarts_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${item.metadata ? item.metadata.name : ''}", container=~"{{ .Container }}"})`,
                 },


### PR DESCRIPTION
Remove the job label from all Prometheus metrics, because the job label is not always the same.

Fixes #278.