### PR TITLE
Visualize log count in Elasticsearch plugin

### DIFF
--- a/pkg/handlers/plugins/elasticsearch/elasticsearch.go
+++ b/pkg/handlers/plugins/elasticsearch/elasticsearch.go
@@ -29,6 +29,15 @@ type Response struct {
 		} `json:"total"`
 		Hits []map[string]interface{} `json:"hits"`
 	} `json:"hits"`
+	Aggregations struct {
+		LogCount struct {
+			Buckets []struct {
+				KeyAsString string `json:"key_as_string"`
+				Key         int64  `json:"key"`
+				DocCount    int64  `json:"doc_count"`
+			} `json:"buckets"`
+		} `json:"logcount"`
+	} `json:"aggregations"`
 }
 
 // ResponseError ...

--- a/src/components/plugins/elasticsearch/Chart.tsx
+++ b/src/components/plugins/elasticsearch/Chart.tsx
@@ -1,0 +1,80 @@
+import { IonCol, IonRow, isPlatform } from '@ionic/react';
+import React, { useContext } from 'react';
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+import { IContext } from '../../../declarations';
+import { AppContext } from '../../../utils/context';
+import { isDarkMode } from '../../../utils/helpers';
+
+export interface IBucket {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  key_as_string: string;
+  key: number;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  doc_count: number;
+}
+
+export interface ILogCount {
+  buckets: IBucket[];
+  interval: string;
+}
+
+export interface IAggregations {
+  logcount: ILogCount;
+}
+
+export interface IPrometheusResult {
+  label: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  values: any[][];
+}
+
+interface IChartProps {
+  aggregations: IAggregations;
+}
+
+const Chart: React.FunctionComponent<IChartProps> = ({ aggregations }: IChartProps) => {
+  const context = useContext<IContext>(AppContext);
+
+  const formatTime = (time: number): string => {
+    const d = new Date(time);
+    return `${('0' + d.getHours()).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}`;
+  };
+
+  return (
+    <IonRow style={{ height: '200px', width: '100%' }}>
+      <IonCol style={{ padding: '0px' }}>
+        <ResponsiveContainer>
+          <BarChart data={aggregations.logcount.buckets}>
+            <XAxis
+              dataKey="key"
+              scale="time"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={formatTime}
+            />
+            {!isPlatform('hybrid') ? (
+              <Tooltip
+                cursor={{ stroke: '#949494', strokeWidth: 2 }}
+                contentStyle={
+                  isDarkMode(context.settings.theme)
+                    ? isPlatform('ios')
+                      ? { backgroundColor: '1c1c1c', borderColor: '#949494' }
+                      : { backgroundColor: '#1A1B1E', borderColor: '#949494' }
+                    : { backgroundColor: '#ffffff', borderColor: '#949494' }
+                }
+                formatter={(value) => {
+                  return [value, 'Count'];
+                }}
+                labelFormatter={formatTime}
+              />
+            ) : null}
+            <Bar dataKey="doc_count" stroke="#326ce5" fill="#326ce5" />
+          </BarChart>
+        </ResponsiveContainer>
+      </IonCol>
+    </IonRow>
+  );
+};
+
+export default Chart;

--- a/src/components/plugins/elasticsearch/Chart.tsx
+++ b/src/components/plugins/elasticsearch/Chart.tsx
@@ -1,6 +1,6 @@
 import { IonCol, IonRow, isPlatform } from '@ionic/react';
 import React, { useContext } from 'react';
-import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 
 import { IContext } from '../../../declarations';
 import { AppContext } from '../../../utils/context';

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -1,5 +1,5 @@
 import { Plugins } from '@capacitor/core';
-import { ActionSheetButton, IonActionSheet, IonFab, IonFabButton, IonIcon, IonToast, isPlatform } from '@ionic/react';
+import { ActionSheetButton, IonActionSheet, IonFab, IonFabButton, IonIcon, IonToast } from '@ionic/react';
 import { repeatOutline } from 'ionicons/icons';
 import React, { useContext, useEffect, useState, ReactElement } from 'react';
 

--- a/src/utils/portforwarding.tsx
+++ b/src/utils/portforwarding.tsx
@@ -213,22 +213,7 @@ export const PortForwardingContextProvider: React.FunctionComponent<IPortForward
           },
           {
             text: 'Open',
-            handler: () => {
-              if (isPlatform('electron')) {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                window
-                  .require('electron')
-                  .shell.openExternal(`http://localhost:${portForwardings[selectedPortForwarding].localPort}`);
-              } else if (isPlatform('hybrid')) {
-                openURL(`http://localhost:${portForwardings[selectedPortForwarding].localPort}`);
-              } else {
-                window.open(
-                  `http://localhost:${portForwardings[selectedPortForwarding].localPort}`,
-                  '_system',
-                  'location=yes',
-                );
-              }
-            },
+            handler: () => openURL(`http://localhost:${portForwardings[selectedPortForwarding].localPort}`),
           },
         ]}
       />


### PR DESCRIPTION
Similar to Kibana, we are visualizing the log count for the selected time range, by passing an additional aggregation to the search request and passing the buckets to a new Chart component. The chart component uses a BarChart from recharts to visualize the log count.

![Bildschirmfoto 2020-12-19 um 18 49 15](https://user-images.githubusercontent.com/18552168/102696931-464a3b00-4232-11eb-9474-a133416a5082.png)