### PR TITLE
fix-mac-10.15-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '13.x'
+          node-version: '14.x'
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Ionic
         run: |
-          npm install -g @ionic/cli@6.9.1
+          npm install -g @ionic/cli
 
       - name: Install Dependencies
         run: |

--- a/cmd/electron/bundler.json
+++ b/cmd/electron/bundler.json
@@ -3,7 +3,7 @@
   "icon_path_darwin": "resources/icon.icns",
   "icon_path_linux": "resources/icon.png",
   "icon_path_windows": "resources/icon.ico",
-  "version_electron": "11.1.0",
+  "version_electron": "11.1.1",
   "environments": [
     {
       "arch": "amd64",

--- a/cmd/electron/bundler.json
+++ b/cmd/electron/bundler.json
@@ -5,9 +5,17 @@
   "icon_path_windows": "resources/icon.ico",
   "version_electron": "11.1.0",
   "environments": [
-    {"arch": "amd64", "os": "darwin"},
-    {"arch": "amd64", "os": "linux"},
-    {"arch": "amd64", "os": "windows"}
+    {
+      "arch": "amd64",
+      "os": "darwin",
+      "env": {
+        "CGO_ENABLED": "1",
+        "CGO_CFLAGS": "-mmacosx-version-min=10.11",
+        "CGO_LDFLAGS": "-mmacosx-version-min=10.11"
+      }
+    },
+    { "arch": "amd64", "os": "linux" },
+    { "arch": "amd64", "os": "windows" }
   ],
   "info_plist": {
     "CFBundleIconFile": "kubenav.icns",


### PR DESCRIPTION
fix incompatibility with MAC OS versions older than 11
also update node, ionic cli and electron