### PR TITLE
Fix scrolling for info page

### DIFF
--- a/src/components/plugins/elasticsearch/Chart.tsx
+++ b/src/components/plugins/elasticsearch/Chart.tsx
@@ -38,7 +38,9 @@ const Chart: React.FunctionComponent<IChartProps> = ({ aggregations }: IChartPro
 
   const formatTime = (time: number): string => {
     const d = new Date(time);
-    return `${('0' + d.getHours()).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}`;
+    return `${('0' + (d.getMonth() + 1)).slice(-2)}/${('0' + d.getDate()).slice(-2)} ${('0' + d.getHours()).slice(
+      -2,
+    )}:${('0' + d.getMinutes()).slice(-2)}`;
   };
 
   return (

--- a/src/components/plugins/prometheus/Chart.tsx
+++ b/src/components/plugins/prometheus/Chart.tsx
@@ -41,11 +41,11 @@ interface IChartProps {
 const Chart: React.FunctionComponent<IChartProps> = ({ timeDiff, chart }: IChartProps) => {
   return (
     <IonCol
-      sizeXs={chart.size.xs}
-      sizeSm={chart.size.xs}
-      sizeMd={chart.size.md}
-      sizeLg={chart.size.lg}
-      sizeXl={chart.size.xl}
+      sizeXs={chart.size.xs ? chart.size.xs : '12'}
+      sizeSm={chart.size.xs ? chart.size.xs : '12'}
+      sizeMd={chart.size.md ? chart.size.md : '12'}
+      sizeLg={chart.size.lg ? chart.size.lg : '12'}
+      sizeXl={chart.size.xl ? chart.size.xl : '12'}
     >
       <IonCardEqualHeight>
         <IonCardHeader>

--- a/src/components/settings/InfoPage.tsx
+++ b/src/components/settings/InfoPage.tsx
@@ -3,8 +3,6 @@ import {
   IonButtons,
   IonCard,
   IonCardContent,
-  IonCardHeader,
-  IonCardTitle,
   IonContent,
   IonHeader,
   IonItem,
@@ -16,17 +14,21 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
+  isPlatform,
 } from '@ionic/react';
 import { useGetInfo } from '@ionic/react-hooks/device';
 import React, { memo, useEffect, useState } from 'react';
 
 import { VERSION } from '../../utils/constants';
 import { openURL } from '../../utils/helpers';
+import useWindowWidth from '../../utils/useWindowWidth';
 import License from './info/License';
 
 const InfoPage: React.FunctionComponent = () => {
-  const { info } = useGetInfo();
+  const width = useWindowWidth();
   const [version, setVersion] = useState<string>(VERSION ? VERSION : '');
+
+  const { info } = useGetInfo();
 
   useEffect(() => {
     if (info && info.appVersion) {
@@ -46,23 +48,10 @@ const InfoPage: React.FunctionComponent = () => {
       </IonHeader>
       <IonContent>
         <IonCard>
-          <img alt="kubenav" src="/assets/card-header.png" />
-          <IonCardHeader>
-            <IonCardTitle>kubenav</IonCardTitle>
-          </IonCardHeader>
+          {isPlatform('hybrid') || isPlatform('mobile') || width < 992 ? (
+            <img alt="kubenav" src="/assets/card-header.png" />
+          ) : null}
           <IonCardContent>
-            <p>
-              kubenav is a mobile and desktop app to manage Kubernetes clusters. The app provides an overview of all
-              resources in a Kubernetes clusters, including current status information for workloads. The details view
-              for resources provides additional information. It is possible to view logs and events or to get a shell
-              into a container. You can also edit and delete resources or scale your workloads within the app.
-            </p>
-            <p className="paragraph-margin-bottom">
-              The app is developed using Ionic Framework and Capacitor. The frontend part of the app is implemented
-              using TypeScript and React functional components. The backend part uses Go mobile for communication with
-              the Kubernetes API server and Cloud Providers. So it is possible to achieve nearly 100% code sharing
-              between the mobile and desktop implementation of kubenav.
-            </p>
             <IonList>
               <IonListHeader mode="md">
                 <IonLabel>General</IonLabel>


### PR DESCRIPTION
**Info page scrolling bug (closes #293):**

- On iOS it could happen that a user can not scroll in the info page and so the links are not reachable. Our current assumption is, that the problem was caused be the displayed paragraphs, so the paragraphs are removed for now.
- We are also removing the displayed image for larger screens, because on large screens only the image was visible and nothing else.

**Other improvements:**

- We are adding a default value (12) for the Prometheus chart size.
- We are not showing an empty card in the Elasticsearch plugin, when there are no results.
- We are showing the total number of hits for an Elasticsearch query and chaning the time formate for the Elasticsearch chart.