### PR TITLE
Improve default metrics

### DIFF
--- a/src/components/overview/OverviewPage.tsx
+++ b/src/components/overview/OverviewPage.tsx
@@ -102,7 +102,7 @@ const OverviewPage: React.FunctionComponent = () => {
                     queries: [
                       {
                         label: 'Current',
-                        query: `sum(irate(container_cpu_usage_seconds_total{image!="", container!="", container!="POD"}[4m]))`,
+                        query: `sum(max(rate(container_cpu_usage_seconds_total{id="/"}[2m])) by (node))`,
                       },
                       {
                         label: 'Requested',
@@ -132,7 +132,7 @@ const OverviewPage: React.FunctionComponent = () => {
                     queries: [
                       {
                         label: 'Current',
-                        query: `sum(container_memory_usage_bytes{container!="", container!="POD"}) / 1024 / 1024 / 1024`,
+                        query: `sum(max(container_memory_working_set_bytes{id="/"}) by (node)) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Requested',
@@ -141,10 +141,6 @@ const OverviewPage: React.FunctionComponent = () => {
                       {
                         label: 'Limit',
                         query: `sum(kube_pod_container_resource_limits{resource="memory", container!=""}) / 1024 / 1024 / 1024`,
-                      },
-                      {
-                        label: 'Cache',
-                        query: `sum(container_memory_cache{container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                       },
                       {
                         label: 'Allocatable',

--- a/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
+++ b/src/components/resources/cluster/namespaces/NamespaceDetails.tsx
@@ -61,9 +61,9 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{namespace="${
+                  query: `sum(max(rate(container_cpu_usage_seconds_total{namespace="${
                     item.metadata ? item.metadata.name : ''
-                  }", image!="", container!="", container!="POD"}[4m]))`,
+                  }", image!="", container!="POD", container!=""}[2m])) by (pod, container))`,
                 },
                 {
                   label: 'Requested',
@@ -93,9 +93,9 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{namespace="${
+                  query: `sum(max(container_memory_working_set_bytes{namespace="${
                     item.metadata ? item.metadata.name : ''
-                  }", container!="", container!="POD"}) / 1024 / 1024`,
+                  }", container!="POD", container!=""}) by (pod, container)) / 1024 / 1024`,
                 },
                 {
                   label: 'Requested',
@@ -108,12 +108,6 @@ const NamespaceDetails: React.FunctionComponent<INamespaceDetailsProps> = ({ ite
                   query: `sum(kube_pod_container_resource_limits{namespace="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024`,
-                },
-                {
-                  label: 'Cache',
-                  query: `sum(container_memory_cache{namespace="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container!="", container!="POD"}) / 1024 / 1024`,
                 },
               ],
             },

--- a/src/components/resources/cluster/nodes/NodeDetails.tsx
+++ b/src/components/resources/cluster/nodes/NodeDetails.tsx
@@ -197,9 +197,9 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{node="${
+                  query: `sum(max(rate(container_cpu_usage_seconds_total{id="/", node="${
                     item.metadata ? item.metadata.name : ''
-                  }", image!="", container!="", container!="POD"}[4m]))`,
+                  }"}[2m])))`,
                 },
                 {
                   label: 'Requested',
@@ -235,9 +235,9 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{node="${
+                  query: `sum(max(container_memory_working_set_bytes{id="/", node="${
                     item.metadata ? item.metadata.name : ''
-                  }", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
+                  }"})) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Requested',
@@ -250,12 +250,6 @@ const NodeDetails: React.FunctionComponent<INodeDetailsProps> = ({ item, type }:
                   query: `sum(kube_pod_container_resource_limits{node="${
                     item.metadata ? item.metadata.name : ''
                   }", resource="memory", container!=""}) / 1024 / 1024 / 1024`,
-                },
-                {
-                  label: 'Cache',
-                  query: `sum(container_memory_cache{node="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container!="", container!="POD"}) / 1024 / 1024 / 1024`,
                 },
                 {
                   label: 'Allocatable',

--- a/src/components/resources/workloads/pods/PodDetails.tsx
+++ b/src/components/resources/workloads/pods/PodDetails.tsx
@@ -216,11 +216,11 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(irate(container_cpu_usage_seconds_total{namespace="${
+                  query: `sum(max(rate(container_cpu_usage_seconds_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", image!="", pod="${
                     item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}", container!="POD"}[4m]))`,
+                  }", container=~"{{ .Container }}", container!="POD", container!=""}[2m])) by (container))`,
                 },
                 {
                   label: 'Requested',
@@ -254,11 +254,11 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               queries: [
                 {
                   label: 'Current',
-                  query: `sum(container_memory_usage_bytes{namespace="${
+                  query: `sum(max(container_memory_working_set_bytes{namespace="${
                     item.metadata ? item.metadata.namespace : ''
                   }", pod="${
                     item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}", container!="POD"}) / 1024 / 1024`,
+                  }", container=~"{{ .Container }}", container!="POD", container!=""}) by (container)) / 1024 / 1024`,
                 },
                 {
                   label: 'Requested',
@@ -276,14 +276,6 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
                     item.metadata ? item.metadata.name : ''
                   }", container=~"{{ .Container }}"}) / 1024 / 1024`,
                 },
-                {
-                  label: 'Cache',
-                  query: `sum(container_memory_cache{namespace="${
-                    item.metadata ? item.metadata.namespace : ''
-                  }", pod="${
-                    item.metadata ? item.metadata.name : ''
-                  }", container=~"{{ .Container }}", container!="POD"}) / 1024 / 1024`,
-                },
               ],
             },
             {
@@ -299,16 +291,16 @@ const PodDetails: React.FunctionComponent<IPodDetailsProps> = ({ item, type }: I
               type: 'area',
               queries: [
                 {
-                  label: 'RX',
-                  query: `sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{namespace="${
+                  label: 'Receive',
+                  query: `sum(rate(container_network_receive_bytes_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
-                  }", pod="${item.metadata ? item.metadata.name : ''}"}[4m]))) / 1024 / 1024`,
+                  }", pod="${item.metadata ? item.metadata.name : ''}"}[2m])) by (pod) / 1024 / 1024`,
                 },
                 {
-                  label: 'TX',
-                  query: `sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{namespace="${
+                  label: 'Transmit',
+                  query: `-sum(rate(container_network_transmit_bytes_total{namespace="${
                     item.metadata ? item.metadata.namespace : ''
-                  }", pod="${item.metadata ? item.metadata.name : ''}"}[4m]))) / 1024 / 1024`,
+                  }", pod="${item.metadata ? item.metadata.name : ''}"}[2m])) by (pod) / 1024 / 1024`,
                 },
               ],
             },


### PR DESCRIPTION
Instead of `container_memory_usage_bytes` we are now using `container_memory_usage_bytes` for the memory metrics now. The advantage of this that the graphs will be consistent with the metrics retrieved by the metrics API.

For the node and cluster metrics we are also switching to this metric. So that the results for the graphs are the same as reported by `kubectl top nodes`.

We also have adjusted the metrics for CPU usage and the Network I/O.