### PR TITLE
Add support for Macs with M1 chip

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.go]
+[*.{go,mod,sum}]
 indent_style = tab
 indent_size = 4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          stable: false
+          go-version: 1.16.0-beta1
 
       - name: Install Ionic
         run: |
@@ -73,6 +74,7 @@ jobs:
       - name: Compress Electron App
         run: |
           cd cmd/electron/output/darwin-amd64 && zip -r -X kubenav-darwin-amd64.zip kubenav.app
+          cd ../darwin-arm64 && zip -r -X kubenav-darwin-arm64.zip kubenav
           cd ../linux-amd64 && zip -r -X kubenav-linux-amd64.zip kubenav
           cd ../linux-arm && zip -r -X kubenav-linux-arm.zip kubenav
           cd ../linux-arm64 && zip -r -X kubenav-linux-arm64.zip kubenav
@@ -102,6 +104,13 @@ jobs:
         with:
           name: kubenav-darwin-amd64.zip
           path: cmd/electron/output/darwin-amd64/kubenav-darwin-amd64.zip
+
+      - name: Upload Artifact (darwin-arm64)
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kubenav-darwin-arm64.zip
+          path: cmd/electron/output/darwin-arm64/kubenav-darwin-arm64.zip
 
       - name: Upload Artifact (linux-amd64)
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
@@ -135,9 +144,10 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
         run: |
           utils/scripts/upload.sh cmd/electron/output/darwin-amd64/kubenav-darwin-amd64.zip application/zip
+          utils/scripts/upload.sh cmd/electron/output/darwin-amd64/kubenav-darwin-arm64.zip application/zip
           utils/scripts/upload.sh cmd/electron/output/linux-amd64/kubenav-linux-amd64.zip application/zip
-          utils/scripts/upload.sh cmd/electron/output/windows-amd64/kubenav-windows-amd64.zip application/zip
           utils/scripts/upload.sh cmd/electron/output/linux-arm64/kubenav-linux-arm64.zip application/zip
           utils/scripts/upload.sh cmd/electron/output/linux-arm/kubenav-linux-arm.zip application/zip
+          utils/scripts/upload.sh cmd/electron/output/windows-amd64/kubenav-windows-amd64.zip application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Compress Electron App
         run: |
           cd cmd/electron/output/darwin-amd64 && zip -r -X kubenav-darwin-amd64.zip kubenav.app
-          cd ../darwin-arm64 && zip -r -X kubenav-darwin-arm64.zip kubenav
+          cd ../darwin-arm64 && zip -r -X kubenav-darwin-arm64.zip kubenav.app
           cd ../linux-amd64 && zip -r -X kubenav-linux-amd64.zip kubenav
           cd ../linux-arm && zip -r -X kubenav-linux-arm.zip kubenav
           cd ../linux-arm64 && zip -r -X kubenav-linux-arm64.zip kubenav

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ build-server:
 
 build-electron:
 	rm -rf cmd/electron/bind_darwin_amd64.go
+	rm -rf cmd/electron/bind_darwin_arm64.go
 	rm -rf cmd/electron/bind_linux_amd64.go
 	rm -rf cmd/electron/bind_linux_arm.go
 	rm -rf cmd/electron/bind_linux_arm64.go

--- a/cmd/electron/bundler.json
+++ b/cmd/electron/bundler.json
@@ -5,15 +5,8 @@
   "icon_path_windows": "resources/icon.ico",
   "version_electron": "11.1.1",
   "environments": [
-    {
-      "arch": "amd64",
-      "os": "darwin",
-      "env": {
-        "CGO_ENABLED": "1",
-        "CGO_CFLAGS": "-mmacosx-version-min=10.11",
-        "CGO_LDFLAGS": "-mmacosx-version-min=10.11"
-      }
-    },
+    {"arch": "amd64", "os": "darwin", "env": {"CGO_ENABLED": "1", "CGO_CFLAGS": "-mmacosx-version-min=10.11", "CGO_LDFLAGS": "-mmacosx-version-min=10.11"}},
+    {"arch": "arm64", "os": "darwin"},
     {"arch": "amd64", "os": "linux"},
     {"arch": "arm64", "os": "linux"},
     {"arch": "arm", "os": "linux", "env": {"GOARM": "7"}},

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/akavel/rsrc v0.9.0 // indirect
 	github.com/asticode/go-astikit v0.13.0
-	github.com/asticode/go-astilectron v0.20.0
-	github.com/asticode/go-astilectron-bootstrap v0.4.4
-	github.com/asticode/go-astilectron-bundler v0.7.3
+	github.com/asticode/go-astilectron v0.22.0
+	github.com/asticode/go-astilectron-bootstrap v0.4.6
+	github.com/asticode/go-astilectron-bundler v0.7.5
 	github.com/aws/aws-sdk-go v1.30.20
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/elazarl/go-bindata-assetfs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,14 @@ github.com/asticode/go-astilectron v0.18.0 h1:4Hc069d3/8La+nWt5o/WWYmNiYfzfGGzC1
 github.com/asticode/go-astilectron v0.18.0/go.mod h1:bF7zkk11IwP8lBPhEl3cCtkKIwsRRR6264OFM1v3Yso=
 github.com/asticode/go-astilectron v0.20.0 h1:HUPl8BPxuRDiOnK4JSpTzJweSNpR85HZUQFopf7MVcM=
 github.com/asticode/go-astilectron v0.20.0/go.mod h1:bF7zkk11IwP8lBPhEl3cCtkKIwsRRR6264OFM1v3Yso=
+github.com/asticode/go-astilectron v0.22.0 h1:YT9LzDroGf2YlIAc8JBgWsvggOfeL4yj/0WXL9Qf918=
+github.com/asticode/go-astilectron v0.22.0/go.mod h1:bF7zkk11IwP8lBPhEl3cCtkKIwsRRR6264OFM1v3Yso=
 github.com/asticode/go-astilectron-bootstrap v0.4.0 h1:iHUJSIWtwq2wELHd5hbKMzsE1dMzIlHlfyakOIZcUFI=
 github.com/asticode/go-astilectron-bootstrap v0.4.0/go.mod h1:zySr3PUhZTjs+WTzyuHJMNAeEeUvgOr2yH7WTIqdY1o=
 github.com/asticode/go-astilectron-bootstrap v0.4.4 h1:AebHl8ooixuqOgvRz01++l2ki1mSlKeId7OWYjS5Z5M=
 github.com/asticode/go-astilectron-bootstrap v0.4.4/go.mod h1:+BSfTf4V8vW27vo4xEwUr4lXTryWL3awdALRSZfy1mM=
+github.com/asticode/go-astilectron-bootstrap v0.4.6 h1:4P6By2wb5bXBB6slARBbQwEjTEd2zz/NtZ7FWPtsE6s=
+github.com/asticode/go-astilectron-bootstrap v0.4.6/go.mod h1:ok9CtLkAr7i16/wBCV4tUt9bV+cgxgsxa/Mfr9gq4uk=
 github.com/asticode/go-astilectron-bundler v0.5.2 h1:JC4UBDr28vVY8gk4A/wag8BW0gvAd6z4MGUM/D7NXw4=
 github.com/asticode/go-astilectron-bundler v0.5.2/go.mod h1:V1VInmdndq/Kd+45cOh4fa9fARNZSCpXqxDznbh+lO0=
 github.com/asticode/go-astilectron-bundler v0.7.0 h1:P5Ot4loRUMSgHMEkH+DIQ0adKvEuJQaVDEcUuxnGFRs=
@@ -85,6 +89,8 @@ github.com/asticode/go-astilectron-bundler v0.7.2 h1:0/h8rbZyTlywjnG3XGeENe4Pv0/
 github.com/asticode/go-astilectron-bundler v0.7.2/go.mod h1:pOhXErxB5yqWhIxWXrXi5GWblxLVUIhZI+wo0xa64CY=
 github.com/asticode/go-astilectron-bundler v0.7.3 h1:CXQVmSNZ4uE7gkURKqyTtnzKn6nfGGwQrwWeexqeDnw=
 github.com/asticode/go-astilectron-bundler v0.7.3/go.mod h1:ZCUI3iEtXQg47aEGKMsVXVQddKF5hOM86GAm3DjiDho=
+github.com/asticode/go-astilectron-bundler v0.7.5 h1:IVpqnHSIqnTOpLxYSBdKrdC4OtPFFtU7QwKvS5nn/+c=
+github.com/asticode/go-astilectron-bundler v0.7.5/go.mod h1:aRBf+nju88VYVcnQdWzNDF71jf8KA46spqNG0nvftzE=
 github.com/asticode/go-bindata v1.0.0 h1:5whO0unjdx2kbAbzoBMS3307jKAEf3oQ1lJcx5RdgA8=
 github.com/asticode/go-bindata v1.0.0/go.mod h1:t/Y+/iCLrvaYkv8Y6PscRnyUeYzy9y9+8JC9CMcKdHY=
 github.com/aws/aws-sdk-go v1.30.20 h1:ktsy2vodSZxz/arYqo7DlpkIeNohHL+4Rmjdo7YGtrE=


### PR DESCRIPTION
Add support for Macs with M1 chip. The build is named `kubenav-darwin-arm64.zip` and can be found at https://github.com/kubenav/kubenav/actions/runs/482082630.