### PR TITLE
Allow additional OIDC scopes

### DIFF
--- a/pkg/api/oidc.go
+++ b/pkg/api/oidc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/kubenav/kubenav/pkg/api/middleware"
 
@@ -23,6 +24,7 @@ type OIDCRequest struct {
 	RedirectURL          string `json:"redirectURL"`
 	RefreshToken         string `json:"refreshToken"`
 	Code                 string `json:"code"`
+	Scopes               string `json:"scopes"`
 }
 
 // OIDCResponse is the structure of a response for one of the OIDC methods.
@@ -64,12 +66,16 @@ func (c *Client) oidcGetLinkHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oidcRequest.Scopes = strings.ReplaceAll(oidcRequest.Scopes, " ", "")
+	scopes := strings.Split(oidcRequest.Scopes, ",")
+	scopes = append(scopes, oidc.ScopeOpenID)
+
 	oauth2Config := oauth2.Config{
 		ClientID:     oidcRequest.ClientID,
 		ClientSecret: oidcRequest.ClientSecret,
 		RedirectURL:  oidcRequest.RedirectURL,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{oidc.ScopeOpenID},
+		Scopes:       scopes,
 	}
 
 	oidcResponse := OIDCResponse{
@@ -111,12 +117,16 @@ func (c *Client) oidcGetRefreshTokenHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	oidcRequest.Scopes = strings.ReplaceAll(oidcRequest.Scopes, " ", "")
+	scopes := strings.Split(oidcRequest.Scopes, ",")
+	scopes = append(scopes, oidc.ScopeOpenID)
+
 	oauth2Config := oauth2.Config{
 		ClientID:     oidcRequest.ClientID,
 		ClientSecret: oidcRequest.ClientSecret,
 		RedirectURL:  oidcRequest.RedirectURL,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{oidc.ScopeOpenID},
+		Scopes:       scopes,
 	}
 
 	oauth2Token, err := oauth2Config.Exchange(ctx, oidcRequest.Code)
@@ -172,12 +182,16 @@ func (c *Client) oidcGetAccessTokenHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	oidcRequest.Scopes = strings.ReplaceAll(oidcRequest.Scopes, " ", "")
+	scopes := strings.Split(oidcRequest.Scopes, ",")
+	scopes = append(scopes, oidc.ScopeOpenID)
+
 	oauth2Config := oauth2.Config{
 		ClientID:     oidcRequest.ClientID,
 		ClientSecret: oidcRequest.ClientSecret,
 		RedirectURL:  oidcRequest.RedirectURL,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{oidc.ScopeOpenID},
+		Scopes:       scopes,
 	}
 
 	ts := oauth2Config.TokenSource(ctx, &oauth2.Token{RefreshToken: oidcRequest.RefreshToken})

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -245,6 +245,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
         authProviderOIDC.clientID,
         authProviderOIDC.clientSecret,
         authProviderOIDC.certificateAuthority,
+        authProviderOIDC.scopes,
       );
 
       setShowModal(false);
@@ -599,6 +600,16 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
                     required={true}
                     value={authProviderOIDC.clientSecret}
                     name="clientSecret"
+                    onIonChange={handleAuthProviderOIDC}
+                  />
+                </IonItem>
+                <IonItem>
+                  <IonLabel position="stacked">Scopes (optional)</IonLabel>
+                  <IonInput
+                    type="text"
+                    required={true}
+                    value={authProviderOIDC.scopes}
+                    name="scopes"
                     onIonChange={handleAuthProviderOIDC}
                   />
                 </IonItem>

--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -26,6 +26,7 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
   const [discoveryURL, setDiscoveryURL] = useState<string>('');
   const [clientID, setClientID] = useState<string>('');
   const [clientSecret, setClientSecret] = useState<string>('');
+  const [scopes, setScopes] = useState<string>('');
   const [certificateAuthority, setCertificateAuthority] = useState<string>('');
   const [refreshToken, setRefreshToken] = useState<string>('');
   const [error, setError] = useState<string>('');
@@ -40,6 +41,10 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
 
   const handleClientSecret = (event) => {
     setClientSecret(event.target.value);
+  };
+
+  const handleScopes = (event) => {
+    setScopes(event.target.value);
   };
 
   const handleCertificateAuthority = (event) => {
@@ -59,6 +64,7 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
       saveTemporaryCredentials({
         clientID: clientID,
         clientSecret: clientSecret,
+        scopes: scopes,
         idpIssuerURL: discoveryURL,
         refreshToken: refreshToken,
         certificateAuthority: ca,
@@ -72,7 +78,7 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
         history.push('/settings/clusters/oidc');
       } else {
         try {
-          const url = await getOIDCLink(discoveryURL, clientID, clientSecret, ca);
+          const url = await getOIDCLink(discoveryURL, clientID, clientSecret, ca, scopes);
           close();
           window.location.replace(url);
         } catch (err) {
@@ -113,6 +119,10 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
           <IonItem>
             <IonLabel position="stacked">Client Secret</IonLabel>
             <IonInput type="text" required={true} value={clientSecret} onInput={handleClientSecret} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Scopes (optional)</IonLabel>
+            <IonInput type="text" required={true} value={scopes} onInput={handleScopes} />
           </IonItem>
           <IonItem>
             <IonLabel position="stacked">Certificate Authority (optional)</IonLabel>

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -194,6 +194,7 @@ export interface IClusterAuthProviderGoogle {
 export interface IClusterAuthProviderOIDC {
   clientID: string;
   clientSecret: string;
+  scopes?: string;
   idToken: string;
   idpIssuerURL: string;
   refreshToken: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -857,6 +857,7 @@ export const getOIDCAccessToken = async (credentials: IClusterAuthProviderOIDC):
         certificateAuthority: credentials.certificateAuthority ? credentials.certificateAuthority : '',
         redirectURL: OIDC_REDIRECT_URL_WEB,
         refreshToken: credentials.refreshToken,
+        scopes: credentials.scopes ? credentials.scopes : '',
       }),
     });
 
@@ -887,6 +888,7 @@ export const getOIDCLink = async (
   clientID: string,
   clientSecret: string,
   certificateAuthority: string,
+  scopes?: string,
 ): Promise<string> => {
   try {
     await checkServer();
@@ -899,6 +901,7 @@ export const getOIDCLink = async (
         clientSecret: clientSecret,
         certificateAuthority: certificateAuthority,
         redirectURL: OIDC_REDIRECT_URL_WEB,
+        scopes: scopes ? scopes : '',
       }),
     });
 
@@ -936,6 +939,7 @@ export const getOIDCRefreshToken = async (
         certificateAuthority: credentials.certificateAuthority,
         redirectURL: OIDC_REDIRECT_URL_WEB,
         code: code,
+        scopes: credentials.scopes ? credentials.scopes : '',
       }),
     });
 


### PR DESCRIPTION
It is now possible to specify additional scopes for the OIDC provider. The scopes can be specified as comma separated list via the new "Scopes" field.

Closes #303.