### PR TITLE
Add events timestamp

### DIFF
--- a/src/components/overview/Warnings.tsx
+++ b/src/components/overview/Warnings.tsx
@@ -20,7 +20,7 @@ import { kubernetesRequest } from '../../utils/api';
 import { AppContext } from '../../utils/context';
 import useWindowWidth from '../../utils/useWindowWidth';
 import { involvedObjectLink } from '../resources/cluster/events/eventHelper';
-import { readableDate } from '../resources/cluster/events/eventHelper';
+import { timeDifference } from '../../utils/helpers';
 
 interface IEvent {
   name: string;
@@ -28,7 +28,6 @@ interface IEvent {
   routerLink: string;
   reason: string;
   message: string;
-  firstTimestamp: string;
   lastTimestamp: string;
 }
 
@@ -64,8 +63,9 @@ const Warnings: React.FunctionComponent = () => {
               routerLink: involvedObjectLink(event.involvedObject),
               reason: event.reason ? event.reason : '',
               message: event.message ? event.message : '',
-              firstTimestamp: readableDate(event.firstTimestamp),
-              lastTimestamp: readableDate(event.lastTimestamp),
+              lastTimestamp: event.lastTimestamp
+                ? timeDifference(new Date().getTime(), event.lastTimestamp.getTime())
+                : 'N/A',
             });
           }
         }
@@ -118,10 +118,9 @@ const Warnings: React.FunctionComponent = () => {
                   <table>
                     <thead>
                       <tr>
-                        <th>First Event</th>
-                        <th>Last Event</th>
                         <th>Name</th>
                         <th>Namespace</th>
+                        <th>Last Seen</th>
                         <th>Reason</th>
                         <th>Message</th>
                       </tr>
@@ -131,8 +130,6 @@ const Warnings: React.FunctionComponent = () => {
                         ? data.map((event, index) => {
                             return (
                               <tr key={index}>
-                                <td>{event.firstTimestamp}</td>
-                                <td>{event.lastTimestamp}</td>
                                 <td>
                                   {event.routerLink === '' ? (
                                     event.name
@@ -143,6 +140,7 @@ const Warnings: React.FunctionComponent = () => {
                                   )}
                                 </td>
                                 <td>{event.namespace}</td>
+                                <td>{event.lastTimestamp}</td>
                                 <td>{event.reason}</td>
                                 <td>{event.message}</td>
                               </tr>

--- a/src/components/overview/Warnings.tsx
+++ b/src/components/overview/Warnings.tsx
@@ -20,6 +20,7 @@ import { kubernetesRequest } from '../../utils/api';
 import { AppContext } from '../../utils/context';
 import useWindowWidth from '../../utils/useWindowWidth';
 import { involvedObjectLink } from '../resources/cluster/events/eventHelper';
+import { readableDate } from '../resources/cluster/events/eventHelper';
 
 interface IEvent {
   name: string;
@@ -27,6 +28,8 @@ interface IEvent {
   routerLink: string;
   reason: string;
   message: string;
+  firstTimestamp: string;
+  lastTimestamp: string;
 }
 
 const Warnings: React.FunctionComponent = () => {
@@ -61,6 +64,8 @@ const Warnings: React.FunctionComponent = () => {
               routerLink: involvedObjectLink(event.involvedObject),
               reason: event.reason ? event.reason : '',
               message: event.message ? event.message : '',
+              firstTimestamp: readableDate(event.firstTimestamp),
+              lastTimestamp: readableDate(event.lastTimestamp),
             });
           }
         }
@@ -113,6 +118,8 @@ const Warnings: React.FunctionComponent = () => {
                   <table>
                     <thead>
                       <tr>
+                        <th>First Event</th>
+                        <th>Last Event</th>
                         <th>Name</th>
                         <th>Namespace</th>
                         <th>Reason</th>
@@ -124,6 +131,8 @@ const Warnings: React.FunctionComponent = () => {
                         ? data.map((event, index) => {
                             return (
                               <tr key={index}>
+                                <td>{event.firstTimestamp}</td>
+                                <td>{event.lastTimestamp}</td>
                                 <td>
                                   {event.routerLink === '' ? (
                                     event.name

--- a/src/components/resources/cluster/events/eventHelper.ts
+++ b/src/components/resources/cluster/events/eventHelper.ts
@@ -51,3 +51,11 @@ export const involvedObjectLink = (involvedObject: V1ObjectReference): string =>
     return '';
   }
 };
+
+export const readableDate = (date: Date | undefined): string => {
+  if (!date) {
+    return '';
+  }
+  const jsonDate = date.toJSON();
+  return new Date(jsonDate).toUTCString().toString();
+};

--- a/src/components/resources/cluster/events/eventHelper.ts
+++ b/src/components/resources/cluster/events/eventHelper.ts
@@ -54,7 +54,7 @@ export const involvedObjectLink = (involvedObject: V1ObjectReference): string =>
 
 export const readableDate = (date: Date | undefined): string => {
   if (!date) {
-    return '';
+    return 'N/A';
   }
   const jsonDate = date.toJSON();
   return new Date(jsonDate).toUTCString().toString();

--- a/src/components/resources/cluster/events/eventHelper.ts
+++ b/src/components/resources/cluster/events/eventHelper.ts
@@ -51,11 +51,3 @@ export const involvedObjectLink = (involvedObject: V1ObjectReference): string =>
     return '';
   }
 };
-
-export const readableDate = (date: Date | undefined): string => {
-  if (!date) {
-    return 'N/A';
-  }
-  const jsonDate = date.toJSON();
-  return new Date(jsonDate).toUTCString().toString();
-};


### PR DESCRIPTION
I would find it helpful to have a timestamp information to better analyze when events happened via the kubenav Overview Warnings UI. If you find that those two columns may clutter the UI (we could also just use the most recent timestamp), I could think of two ways to handle this:

- introduce a checkbox/switch, like "enable event timestamps" or something like this
- make it configurable