### PR TITLE
Fix flag parsing for macOS

### DIFF
--- a/cmd/electron/main.go
+++ b/cmd/electron/main.go
@@ -27,6 +27,7 @@ var (
 )
 
 var (
+	fs                    = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	debugFlag             bool
 	kubeconfigFlag        string
 	kubeconfigIncludeFlag string
@@ -45,16 +46,16 @@ type Message struct {
 var messageChannel = make(chan Message)
 
 func init() {
-	flag.BoolVar(&debugFlag, "debug", false, "Enable debug mode.")
-	flag.StringVar(&kubeconfigFlag, "kubeconfig", "", "Optional Kubeconfig file.")
-	flag.StringVar(&kubeconfigIncludeFlag, "kubeconfig.include", "", "Comma separated list of globs to include in the Kubeconfig.")
-	flag.StringVar(&kubeconfigExcludeFlag, "kubeconfig.exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '--kubeconfig.include' flag.")
-	flag.BoolVar(&syncFlag, "kubeconfig.sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
-	flag.BoolVar(&showVersion, "version", false, "Print version information.")
+	fs.BoolVar(&debugFlag, "debug", false, "Enable debug mode.")
+	fs.StringVar(&kubeconfigFlag, "kubeconfig", "", "Optional Kubeconfig file.")
+	fs.StringVar(&kubeconfigIncludeFlag, "kubeconfig.include", "", "Comma separated list of globs to include in the Kubeconfig.")
+	fs.StringVar(&kubeconfigExcludeFlag, "kubeconfig.exclude", "", "Comma separated list of globs to exclude from the Kubeconfig. This flag must be used in combination with the '--kubeconfig.include' flag.")
+	fs.BoolVar(&syncFlag, "kubeconfig.sync", false, "Sync the changes from kubenav with the used Kubeconfig file.")
+	fs.BoolVar(&showVersion, "version", false, "Print version information.")
 }
 
 func main() {
-	flag.Parse()
+	fs.Parse(os.Args[1:])
 
 	// If the version flag is true, we just print the version information for kubenav and then we exit kubenav.
 	if showVersion {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 )
 
 var (
+	fs                                  = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	debugFlag                           bool
 	debugIonicFlag                      string
 	inclusterFlag                       bool
@@ -73,28 +74,28 @@ func init() {
 		defaultPluginJaegerPasswordFlag = os.Getenv("KUBENAV_JAEGER_PASSWORD")
 	}
 
-	flag.BoolVar(&debugFlag, "debug", false, "Enable debug mode.")
-	flag.StringVar(&debugIonicFlag, "debug.ionic", "build", "Path to the Ionic app.")
-	flag.BoolVar(&inclusterFlag, "incluster", false, "Use the in cluster configuration.")
-	flag.StringVar(&kubeconfigFlag, "kubeconfig", "", "Optional Kubeconfig file.")
-	flag.StringVar(&pluginElasticsearchAddressFlag, "plugin.elasticsearch.address", "", "The address for Elasticsearch.")
-	flag.BoolVar(&pluginElasticsearchEnabledFlag, "plugin.elasticsearch.enabled", false, "Enable the Elasticsearch plugin.")
-	flag.StringVar(&pluginElasticsearchPasswordFlag, "plugin.elasticsearch.password", defaultPluginElasticsearchPasswordFlag, "The password for Elasticsearch.")
-	flag.StringVar(&pluginElasticsearchUsernameFlag, "plugin.elasticsearch.username", defaultPluginElasticsearchUsernameFlag, "The username for Elasticsearch.")
-	flag.StringVar(&pluginJaegerAddressFlag, "plugin.jaeger.address", "", "The address for Jaeger.")
-	flag.BoolVar(&pluginJaegerEnabledFlag, "plugin.jaeger.enabled", false, "Enable the Jaeger plugin.")
-	flag.StringVar(&pluginJaegerPasswordFlag, "plugin.jaeger.password", defaultPluginJaegerPasswordFlag, "The password for Jaeger.")
-	flag.StringVar(&pluginJaegerUsernameFlag, "plugin.jaeger.username", defaultPluginJaegerUsernameFlag, "The username for Jaeger.")
-	flag.StringVar(&pluginPrometheusAddressFlag, "plugin.prometheus.address", "", "The address for Prometheus.")
-	flag.StringVar(&pluginPrometheusDashboardsNamespace, "plugin.prometheus.dashboards-namespace", "kubenav", "The namespace, where kubenav should look for dashboards.")
-	flag.BoolVar(&pluginPrometheusEnabledFlag, "plugin.prometheus.enabled", false, "Enable the Prometheus plugin.")
-	flag.StringVar(&pluginPrometheusPasswordFlag, "plugin.prometheus.password", defaultPluginPrometheusPasswordFlag, "The password for Prometheus.")
-	flag.StringVar(&pluginPrometheusUsernameFlag, "plugin.prometheus.username", defaultPluginPrometheusUsernameFlag, "The username for Prometheus.")
-	flag.BoolVar(&showVersion, "version", false, "Print version information.")
+	fs.BoolVar(&debugFlag, "debug", false, "Enable debug mode.")
+	fs.StringVar(&debugIonicFlag, "debug.ionic", "build", "Path to the Ionic app.")
+	fs.BoolVar(&inclusterFlag, "incluster", false, "Use the in cluster configuration.")
+	fs.StringVar(&kubeconfigFlag, "kubeconfig", "", "Optional Kubeconfig file.")
+	fs.StringVar(&pluginElasticsearchAddressFlag, "plugin.elasticsearch.address", "", "The address for Elasticsearch.")
+	fs.BoolVar(&pluginElasticsearchEnabledFlag, "plugin.elasticsearch.enabled", false, "Enable the Elasticsearch plugin.")
+	fs.StringVar(&pluginElasticsearchPasswordFlag, "plugin.elasticsearch.password", defaultPluginElasticsearchPasswordFlag, "The password for Elasticsearch.")
+	fs.StringVar(&pluginElasticsearchUsernameFlag, "plugin.elasticsearch.username", defaultPluginElasticsearchUsernameFlag, "The username for Elasticsearch.")
+	fs.StringVar(&pluginJaegerAddressFlag, "plugin.jaeger.address", "", "The address for Jaeger.")
+	fs.BoolVar(&pluginJaegerEnabledFlag, "plugin.jaeger.enabled", false, "Enable the Jaeger plugin.")
+	fs.StringVar(&pluginJaegerPasswordFlag, "plugin.jaeger.password", defaultPluginJaegerPasswordFlag, "The password for Jaeger.")
+	fs.StringVar(&pluginJaegerUsernameFlag, "plugin.jaeger.username", defaultPluginJaegerUsernameFlag, "The username for Jaeger.")
+	fs.StringVar(&pluginPrometheusAddressFlag, "plugin.prometheus.address", "", "The address for Prometheus.")
+	fs.StringVar(&pluginPrometheusDashboardsNamespace, "plugin.prometheus.dashboards-namespace", "kubenav", "The namespace, where kubenav should look for dashboards.")
+	fs.BoolVar(&pluginPrometheusEnabledFlag, "plugin.prometheus.enabled", false, "Enable the Prometheus plugin.")
+	fs.StringVar(&pluginPrometheusPasswordFlag, "plugin.prometheus.password", defaultPluginPrometheusPasswordFlag, "The password for Prometheus.")
+	fs.StringVar(&pluginPrometheusUsernameFlag, "plugin.prometheus.username", defaultPluginPrometheusUsernameFlag, "The username for Prometheus.")
+	fs.BoolVar(&showVersion, "version", false, "Print version information.")
 }
 
 func main() {
-	flag.Parse()
+	fs.Parse(os.Args[1:])
 
 	// If the version flag is true, we just print the version information for kubenav and then we exit kubenav.
 	if showVersion {


### PR DESCRIPTION
macOS adds a random flag on the first start of kubenav. Since this flag
is unknown, kubenav will not start. For that we have to continue the
flag handling in case of an error.

Closes #321.