### PR TITLE
Namespaces: Add filter bar

### DIFF
--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -58,44 +58,56 @@ const Namespaces: React.FunctionComponent = () => {
   const [filterText, setFilterText] = useState('');
   const filterRegex = new RegExp(filterText, 'gi');
 
+  function renderItems(items: V1Namespace[]) {
+    return (
+      <IonContent>
+        <IonSearchbar placeholder="Filter" onIonChange={(event) => setFilterText(event.detail.value ?? '')} />
+        <IonList>
+          <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
+            {cluster && cluster.namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
+            <IonLabel>All Namespaces</IonLabel>
+          </IonItem>
+
+          {items
+            .filter((item) => {
+              return item.metadata?.name?.match(filterRegex);
+            })
+            .map((namespace, index) => {
+              return (
+                <IonItem key={index} button={true} detail={false} onClick={() => setNamespace(namespace)}>
+                  {namespace.metadata && cluster && cluster.namespace === namespace.metadata.name ? (
+                    <IonIcon slot="end" color="primary" icon={checkmark} />
+                  ) : null}
+                  <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
+                </IonItem>
+              );
+            })}
+        </IonList>
+      </IonContent>
+    );
+  }
+
+  function renderError() {
+    return (
+      <IonList>
+        <IonItem>{error ? error.message : 'Could not get Namespaces'}</IonItem>
+      </IonList>
+    );
+  }
+
+  function renderLoading() {
+    return (
+      <IonItem>
+        <IonLabel>Loading ...</IonLabel>
+        <IonSpinner />
+      </IonItem>
+    );
+  }
+
   return (
     <React.Fragment>
       <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
-        {isError ? (
-          <IonList>
-            <IonItem>{error ? error.message : 'Could not get Namespaces'}</IonItem>
-          </IonList>
-        ) : data ? (
-          <IonContent>
-            <IonSearchbar placeholder="Filter" onIonChange={(event) => setFilterText(event.detail.value ?? '')} />
-            <IonList>
-              <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
-                {cluster && cluster.namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
-                <IonLabel>All Namespaces</IonLabel>
-              </IonItem>
-
-              {data.items
-                .filter((item) => {
-                  return item.metadata?.name?.match(filterRegex);
-                })
-                .map((namespace, index) => {
-                  return (
-                    <IonItem key={index} button={true} detail={false} onClick={() => setNamespace(namespace)}>
-                      {namespace.metadata && cluster && cluster.namespace === namespace.metadata.name ? (
-                        <IonIcon slot="end" color="primary" icon={checkmark} />
-                      ) : null}
-                      <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
-                    </IonItem>
-                  );
-                })}
-            </IonList>
-          </IonContent>
-        ) : isLoading ? (
-          <IonItem>
-            <IonLabel>Loading ...</IonLabel>
-            <IonSpinner />
-          </IonItem>
-        ) : null}
+        {isError ? renderError() : data ? renderItems(data.items) : isLoading ? renderLoading() : null}
       </IonPopover>
 
       <IonButton

--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -58,7 +58,7 @@ const Namespaces: React.FunctionComponent = () => {
   const [filterText, setFilterText] = useState('');
   const filterRegex = new RegExp(filterText, 'gi');
 
-  function renderItems(items: V1Namespace[]) {
+  const renderItems = (items: V1Namespace[]) => {
     const showFilterbar = filterText || items.length > 5;
     return (
       <IonContent>
@@ -88,24 +88,20 @@ const Namespaces: React.FunctionComponent = () => {
         </IonList>
       </IonContent>
     );
-  }
+  };
 
-  function renderError() {
-    return (
-      <IonList>
-        <IonItem>{error ? error.message : 'Could not get Namespaces'}</IonItem>
-      </IonList>
-    );
-  }
+  const renderError = () => (
+    <IonList>
+      <IonItem>{error ? error.message : 'Could not get Namespaces'}</IonItem>
+    </IonList>
+  );
 
-  function renderLoading() {
-    return (
-      <IonItem>
-        <IonLabel>Loading ...</IonLabel>
-        <IonSpinner />
-      </IonItem>
-    );
-  }
+  const renderLoading = () => (
+    <IonItem>
+      <IonLabel>Loading ...</IonLabel>
+      <IonSpinner />
+    </IonItem>
+  );
 
   return (
     <React.Fragment>

--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -59,9 +59,12 @@ const Namespaces: React.FunctionComponent = () => {
   const filterRegex = new RegExp(filterText, 'gi');
 
   function renderItems(items: V1Namespace[]) {
+    const showFilterbar = filterText || items.length > 5;
     return (
       <IonContent>
-        <IonSearchbar placeholder="Filter" onIonChange={(event) => setFilterText(event.detail.value ?? '')} />
+        {showFilterbar && (
+          <IonSearchbar placeholder="Filter" onIonChange={(event) => setFilterText(event.detail.value ?? '')} />
+        )}
         <IonList>
           <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
             {cluster && cluster.namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}

--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -1,4 +1,14 @@
-import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover, IonSpinner } from '@ionic/react';
+import {
+  IonButton,
+  IonContent,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPopover,
+  IonSearchbar,
+  IonSpinner,
+} from '@ionic/react';
 import { V1Namespace, V1NamespaceList } from '@kubernetes/client-node';
 import { checkmark, options } from 'ionicons/icons';
 import React, { useContext, useEffect, useState } from 'react';
@@ -45,6 +55,9 @@ const Namespaces: React.FunctionComponent = () => {
     }
   }, [showPopover, refetch]);
 
+  const [filterText, setFilterText] = useState('');
+  const filterRegex = new RegExp(filterText, 'gi');
+
   return (
     <React.Fragment>
       <IonPopover isOpen={showPopover} event={popoverEvent} onDidDismiss={() => setShowPopover(false)}>
@@ -53,23 +66,30 @@ const Namespaces: React.FunctionComponent = () => {
             <IonItem>{error ? error.message : 'Could not get Namespaces'}</IonItem>
           </IonList>
         ) : data ? (
-          <IonList>
-            <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
-              {cluster && cluster.namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
-              <IonLabel>All Namespaces</IonLabel>
-            </IonItem>
+          <IonContent>
+            <IonSearchbar placeholder="Filter" onIonChange={(event) => setFilterText(event.detail.value ?? '')} />
+            <IonList>
+              <IonItem button={true} detail={false} onClick={() => setAllNamespaces()}>
+                {cluster && cluster.namespace === '' ? <IonIcon slot="end" color="primary" icon={checkmark} /> : null}
+                <IonLabel>All Namespaces</IonLabel>
+              </IonItem>
 
-            {data.items.map((namespace, index) => {
-              return (
-                <IonItem key={index} button={true} detail={false} onClick={() => setNamespace(namespace)}>
-                  {namespace.metadata && cluster && cluster.namespace === namespace.metadata.name ? (
-                    <IonIcon slot="end" color="primary" icon={checkmark} />
-                  ) : null}
-                  <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
-                </IonItem>
-              );
-            })}
-          </IonList>
+              {data.items
+                .filter((item) => {
+                  return item.metadata?.name?.match(filterRegex);
+                })
+                .map((namespace, index) => {
+                  return (
+                    <IonItem key={index} button={true} detail={false} onClick={() => setNamespace(namespace)}>
+                      {namespace.metadata && cluster && cluster.namespace === namespace.metadata.name ? (
+                        <IonIcon slot="end" color="primary" icon={checkmark} />
+                      ) : null}
+                      <IonLabel>{namespace.metadata ? namespace.metadata.name : ''}</IonLabel>
+                    </IonItem>
+                  );
+                })}
+            </IonList>
+          </IonContent>
         ) : isLoading ? (
           <IonItem>
             <IonLabel>Loading ...</IonLabel>


### PR DESCRIPTION
**Corresponding Tickets / Related Links**

- fixes https://github.com/kubenav/kubenav/issues/327


**What has been done?**

- Add filter bar to namespace pop over
- Only visible if more than 5 namespaces exist

**Why was this done?**

- To find a namespace faster


**How to test the changes?**

1. Go to pods
2. Open namespace pop over
3. Type into the filter box

![Screenshot 2021-04-15 at 13 34 44](https://user-images.githubusercontent.com/318533/114862959-71fbbd00-9def-11eb-93d1-482fa3d38a15.png)


---

*Dear reviewer, please make sure to perform your review according to the [Code Review Checklist](https://github.com/Staffbase/son-doku/blob/master/text/0033-code-review-checklist.md).*