### PR TITLE
Add selected namespace for ListPages into URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ const App: React.FunctionComponent = () => (
                   <Route path="/resources/:section/:type/:namespace?" component={ListPage} exact={true} />
                   <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />
                   <Route
-                    path="/customresources/:group/:version/:name"
+                    path="/customresources/:group/:version/:name/:crnamespace?"
                     component={CustomResourcesListPage}
                     exact={true}
                   />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ const App: React.FunctionComponent = () => (
                 <IonRouterOutlet id="main">
                   <Route path="/" component={OverviewPage} exact={true} />
                   <Route path="/bookmarks" component={BookmarksPage} exact={true} />
-                  <Route path="/resources/:section/:type" component={ListPage} exact={true} />
+                  <Route path="/resources/:section/:type/:namespace?" component={ListPage} exact={true} />
                   <Route path="/resources/:section/:type/:namespace/:name" component={DetailsPage} exact={true} />
                   <Route
                     path="/customresources/:group/:version/:name"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ const App: React.FunctionComponent = () => (
                     exact={true}
                   />
                   <Route path="/plugins/elasticsearch" component={ElasticsearchQueryPage} exact={true} />
-                  <Route path="/plugins/helm" component={HelmReleasesPage} exact={true} />
+                  <Route path="/plugins/helm/:namespace?" component={HelmReleasesPage} exact={true} />
                   <Route path="/plugins/helm/:namespace/:name" component={HelmReleasePage} exact={true} />
                   <Route path="/plugins/jaeger" component={JaegerTracesPage} exact={true} />
                   <Route path="/plugins/jaeger/trace/:trace" component={JaegerTracePage} exact={true} />

--- a/src/components/plugins/helm/ReleasesPage.tsx
+++ b/src/components/plugins/helm/ReleasesPage.tsx
@@ -28,10 +28,27 @@ import Namespaces from '../../resources/misc/list/Namespaces';
 import ItemStatus from '../../resources/misc/template/ItemStatus';
 import Details from './Details';
 import { IHelmRelease, IHelmReleases } from './helpers';
+import { RouteComponentProps } from 'react-router';
 
-const ReleasesPage: React.FunctionComponent = () => {
+interface IMatchParams {
+  section: string;
+  type: string;
+  namespace?: string;
+}
+
+type IReleasesPageProps = RouteComponentProps<IMatchParams>;
+
+const ReleasesPage: React.FunctionComponent<IReleasesPageProps> = ({ match }: IReleasesPageProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
+
+  if (cluster) {
+    if (match.params.namespace !== undefined) {
+      cluster.namespace = match.params.namespace;
+    } else {
+      cluster.namespace = '';
+    }
+  }
 
   let namespace = '';
   let showNamespace = false;
@@ -136,7 +153,7 @@ const ReleasesPage: React.FunctionComponent = () => {
           </IonButtons>
           <IonTitle>Helm</IonTitle>
           <IonButtons slot="primary">
-            <Namespaces />
+            <Namespaces baseUrl={`plugins/helm`} />
             <Details
               refresh={refetch}
               showAllVersions={context.settings.helmShowAllVersions}

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -46,8 +46,12 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
 
-  if (cluster && match.params.namespace !== undefined) {
-    cluster.namespace = match.params.namespace;
+  if (cluster) {
+    if (match.params.namespace !== undefined) {
+      cluster.namespace = match.params.namespace;
+    } else {
+      cluster.namespace = '';
+    }
   }
 
   // Determine one which page we are currently (which items for a resource do we want to show) by the section and type
@@ -123,7 +127,9 @@ const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageP
           </IonButtons>
           <IonTitle>{page.pluralText}</IonTitle>
           <IonButtons slot="primary">
-            {isNamespaced(match.params.type) ? <Namespaces /> : null}
+            {isNamespaced(match.params.type) ? (
+              <Namespaces baseUrl={`resources/${match.params.section}/${match.params.type}`} />
+            ) : null}
             <Details
               refresh={refetch}
               bookmark={{

--- a/src/components/resources/ListPage.tsx
+++ b/src/components/resources/ListPage.tsx
@@ -35,6 +35,7 @@ import ItemOptions from './misc/details/ItemOptions';
 interface IMatchParams {
   section: string;
   type: string;
+  namespace?: string;
 }
 
 type IListPageProps = RouteComponentProps<IMatchParams>;
@@ -44,6 +45,10 @@ type IListPageProps = RouteComponentProps<IMatchParams>;
 const ListPage: React.FunctionComponent<IListPageProps> = ({ match }: IListPageProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
+
+  if (cluster && match.params.namespace !== undefined) {
+    cluster.namespace = match.params.namespace;
+  }
 
   // Determine one which page we are currently (which items for a resource do we want to show) by the section and type
   // parameter. Get the component 'ResourceItem' we want to render.

--- a/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
+++ b/src/components/resources/cluster/customResourceDefinitions/CustomResourcesListPage.tsx
@@ -34,6 +34,7 @@ interface IMatchParams {
   group: string;
   version: string;
   name: string;
+  crnamespace?: string;
 }
 
 type ICustomResourcesListPageProps = RouteComponentProps<IMatchParams>;
@@ -48,6 +49,14 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
 }: ICustomResourcesListPageProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
+
+  if (cluster) {
+    if (match.params.crnamespace !== undefined) {
+      cluster.namespace = match.params.crnamespace;
+    } else {
+      cluster.namespace = '';
+    }
+  }
 
   // scope can be "Cluster" or "Namespaced", for a cluster scoped CRD we have to set the namespace to "" to retrive all
   // CRs.
@@ -124,7 +133,9 @@ const CustomResourcesListPage: React.FunctionComponent<ICustomResourcesListPageP
           </IonButtons>
           <IonTitle>{match.params.name}</IonTitle>
           <IonButtons slot="primary">
-            <Namespaces />
+            <Namespaces
+              baseUrl={`customresources/${match.params.group}/${match.params.version}/${match.params.name}`}
+            />
             <Details
               refresh={refetch}
               bookmark={{

--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -20,7 +20,7 @@ import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 
 interface INamespaceProps {
-  baseUrl?: string;
+  baseUrl: string;
 }
 
 const Namespaces: React.FunctionComponent<INamespaceProps> = (props: INamespaceProps) => {
@@ -45,22 +45,11 @@ const Namespaces: React.FunctionComponent<INamespaceProps> = (props: INamespaceP
   );
 
   const setNamespace = (ns: V1Namespace) => {
-    if (props.baseUrl) {
-      router.push(`/${props.baseUrl}/${ns.metadata?.name || ''}`);
-    } else {
-      const namespace: string = ns.metadata !== undefined ? (ns.metadata.name ? ns.metadata.name : '') : '';
-      context.setNamespace(namespace);
-      setShowPopover(false);
-    }
+    router.push(`/${props.baseUrl}/${ns.metadata?.name || ''}`);
   };
 
   const setAllNamespaces = () => {
-    if (props.baseUrl) {
-      router.push(`/${props.baseUrl}`);
-    } else {
-      context.setNamespace('');
-      setShowPopover(false);
-    }
+    router.push(`/${props.baseUrl}`);
   };
 
   useEffect(() => {

--- a/src/components/resources/misc/list/Namespaces.tsx
+++ b/src/components/resources/misc/list/Namespaces.tsx
@@ -1,4 +1,4 @@
-import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover, IonSpinner } from '@ionic/react';
+import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonPopover, IonSpinner, useIonRouter } from '@ionic/react';
 import { V1Namespace, V1NamespaceList } from '@kubernetes/client-node';
 import { checkmark, options } from 'ionicons/icons';
 import React, { useContext, useEffect, useState } from 'react';
@@ -8,9 +8,14 @@ import { IContext } from '../../../../declarations';
 import { kubernetesRequest } from '../../../../utils/api';
 import { AppContext } from '../../../../utils/context';
 
-const Namespaces: React.FunctionComponent = () => {
+interface INamespaceProps {
+  baseUrl?: string;
+}
+
+const Namespaces: React.FunctionComponent<INamespaceProps> = (props: INamespaceProps) => {
   const context = useContext<IContext>(AppContext);
   const cluster = context.currentCluster();
+  const router = useIonRouter();
 
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const [popoverEvent, setPopoverEvent] = useState();
@@ -29,14 +34,22 @@ const Namespaces: React.FunctionComponent = () => {
   );
 
   const setNamespace = (ns: V1Namespace) => {
-    const namespace: string = ns.metadata !== undefined ? (ns.metadata.name ? ns.metadata.name : '') : '';
-    context.setNamespace(namespace);
-    setShowPopover(false);
+    if (props.baseUrl) {
+      router.push(`/${props.baseUrl}/${ns.metadata?.name || ''}`);
+    } else {
+      const namespace: string = ns.metadata !== undefined ? (ns.metadata.name ? ns.metadata.name : '') : '';
+      context.setNamespace(namespace);
+      setShowPopover(false);
+    }
   };
 
   const setAllNamespaces = () => {
-    context.setNamespace('');
-    setShowPopover(false);
+    if (props.baseUrl) {
+      router.push(`/${props.baseUrl}`);
+    } else {
+      context.setNamespace('');
+      setShowPopover(false);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds the selected Namespaces from ListPages to the URL. This way, it is now possible to bookmark or send URLs with, for example, all pods in a given namespace.