### PR TITLE
Add support for OAuth2 PKCE

### DIFF
--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -228,6 +228,15 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
 
   const reAuthenticateOIDC = async () => {
     if (authProviderOIDC) {
+      const { url, verifier } = await getOIDCLink(
+        authProviderOIDC.idpIssuerURL,
+        authProviderOIDC.clientID,
+        authProviderOIDC.clientSecret,
+        authProviderOIDC.certificateAuthority,
+        authProviderOIDC.scopes,
+        authProviderOIDC.pkceMethod,
+      );
+
       saveTemporaryCredentials({
         clientID: authProviderOIDC.clientID,
         clientSecret: authProviderOIDC.clientSecret,
@@ -238,15 +247,9 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
         accessToken: '',
         expiry: 0,
         clusterID: cluster.id,
+        pkceMethod: authProviderOIDC.pkceMethod,
+        verifier,
       });
-
-      const url = await getOIDCLink(
-        authProviderOIDC.idpIssuerURL,
-        authProviderOIDC.clientID,
-        authProviderOIDC.clientSecret,
-        authProviderOIDC.certificateAuthority,
-        authProviderOIDC.scopes,
-      );
 
       setShowModal(false);
       window.location.replace(url);

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -216,9 +216,20 @@ export interface IRancherTokenResponse {
   token: string;
 }
 
+export interface IOIDCLinkResponse {
+  url: string;
+  idToken: string;
+  refreshToken: string;
+  accessToken: string;
+  expiry: string;
+  verifier?: string;
+}
+
 export interface IClusterAuthProviderOIDC {
   clientID: string;
   clientSecret: string;
+  pkceMethod?: 'S256';
+  verifier?: string;
   scopes?: string;
   idToken: string;
   idpIssuerURL: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -29,6 +29,7 @@ import {
   IRancherGeneratedKubeconfig,
   IRancherKubeconfigRequest,
   IRancherTokenResponse,
+  IOIDCLinkResponse,
 } from '../declarations';
 import { GOOGLE_REDIRECT_URI, INCLUSTER_URL, OIDC_REDIRECT_URL_WEB } from './constants';
 import { isJSON } from './helpers';
@@ -1011,7 +1012,8 @@ export const getOIDCLink = async (
   clientSecret: string,
   certificateAuthority: string,
   scopes?: string,
-): Promise<string> => {
+  pkceMethod?: 'S256',
+): Promise<IOIDCLinkResponse> => {
   try {
     await checkServer();
 
@@ -1024,13 +1026,14 @@ export const getOIDCLink = async (
         certificateAuthority: certificateAuthority,
         redirectURL: OIDC_REDIRECT_URL_WEB,
         scopes: scopes ? scopes : '',
+        pkceMethod: pkceMethod,
       }),
     });
 
     const json = await response.json();
 
     if (response.status >= 200 && response.status < 300) {
-      return json.url;
+      return json;
     } else {
       if (json.error) {
         throw new Error(json.message);
@@ -1062,6 +1065,7 @@ export const getOIDCRefreshToken = async (
         redirectURL: OIDC_REDIRECT_URL_WEB,
         code: code,
         scopes: credentials.scopes ? credentials.scopes : '',
+        verifier: credentials.verifier,
       }),
     });
 


### PR DESCRIPTION
This PR adds support for the PKCE ([RFC7636](https://datatracker.ietf.org/doc/html/rfc7636)) extension to the Authorization Code flow. I added a new option "PKCE Method" to the frontend that allows the user to choose between "disabled" and "S256". In the future the "plan" pkce-method could be added here. The backend returns the verifier code it generated in its response which is then used in the next request to allow the backend to fetch the tokens.

The implementation is based on https://auth0.com/docs/flows/authorization-code-flow-with-proof-key-for-code-exchange-pkce. I only tested the code with a keycloak server so far.
