### PR TITLE
Add json editor

### DIFF
--- a/src/components/plugins/helm/ReleasePage.tsx
+++ b/src/components/plugins/helm/ReleasePage.tsx
@@ -136,13 +136,26 @@ const ReleasePage: React.FunctionComponent<IReleasePageProps> = ({ match }: IRel
                     </IonCardHeader>
                     <IonCardContent>
                       <Editor
-                        value={yaml.dump(
-                          data.details.config
-                            ? data.details.config
-                            : data.details.chart.values
-                            ? data.details.chart.values
-                            : '',
-                        )}
+                        mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+                        value={
+                          context.settings.editorFormat === 'json'
+                            ? JSON.stringify(
+                                data.details.config
+                                  ? data.details.config
+                                  : data.details.chart.values
+                                  ? data.details.chart.values
+                                  : '',
+                                null,
+                                2,
+                              )
+                            : yaml.dump(
+                                data.details.config
+                                  ? data.details.config
+                                  : data.details.chart.values
+                                  ? data.details.chart.values
+                                  : '',
+                              )
+                        }
                         readOnly={true}
                       />
                     </IonCardContent>

--- a/src/components/resources/misc/details/EditItem.tsx
+++ b/src/components/resources/misc/details/EditItem.tsx
@@ -69,14 +69,24 @@ const EditItem: React.FunctionComponent<IEditItemProps> = ({ show, hide, item, u
   const [value, setValue] = useState<string>('');
 
   useEffect(() => {
-    setValue(yaml.dump(item));
-  }, [item]);
+    if (context.settings.editorFormat === 'json') {
+      setValue(JSON.stringify(item, null, 2));
+    } else {
+      setValue(yaml.dump(item));
+    }
+  }, [item, context.settings.editorFormat]);
 
   const handleSave = async () => {
     try {
-      const yamlObj = yaml.load(value);
-      if (yamlObj) {
-        const diff = jsonpatch.compare(item, yamlObj);
+      let parsedObj = null;
+      if (context.settings.editorFormat === 'json') {
+        parsedObj = JSON.parse(value);
+      } else {
+        parsedObj = yaml.load(value);
+      }
+
+      if (parsedObj) {
+        const diff = jsonpatch.compare(item, parsedObj);
         await kubernetesRequest(
           'PATCH',
           url,
@@ -118,7 +128,13 @@ const EditItem: React.FunctionComponent<IEditItemProps> = ({ show, hide, item, u
           </IonToolbar>
         </IonHeader>
         <IonContent>
-          <Editor readOnly={false} value={value} onChange={(newValue) => setValue(newValue)} fullHeight={true} />
+          <Editor
+            readOnly={false}
+            mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+            fullHeight={true}
+          />
         </IonContent>
       </IonModal>
     </React.Fragment>

--- a/src/components/resources/misc/details/ViewItem.tsx
+++ b/src/components/resources/misc/details/ViewItem.tsx
@@ -15,9 +15,10 @@ import {
 } from '@ionic/react';
 import { close, documentText } from 'ionicons/icons';
 import yaml from 'js-yaml';
-import React from 'react';
+import React, { useContext } from 'react';
 
-import { TActivator } from '../../../../declarations';
+import { IContext, TActivator } from '../../../../declarations';
+import { AppContext } from '../../../../utils/context';
 import Editor from '../../../misc/Editor';
 
 const { Filesystem } = Plugins;
@@ -62,6 +63,8 @@ interface IViewItemProps {
 }
 
 const ViewItem: React.FunctionComponent<IViewItemProps> = ({ show, hide, item }: IViewItemProps) => {
+  const context = useContext<IContext>(AppContext);
+
   const handleExport = async () => {
     if (isPlatform('hybrid')) {
       try {
@@ -99,7 +102,12 @@ const ViewItem: React.FunctionComponent<IViewItemProps> = ({ show, hide, item }:
           </IonToolbar>
         </IonHeader>
         <IonContent>
-          <Editor readOnly={true} value={yaml.dump(item)} fullHeight={true} />
+          <Editor
+            readOnly={true}
+            mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+            value={context.settings.editorFormat === 'json' ? JSON.stringify(item, null, 2) : yaml.dump(item)}
+            fullHeight={true}
+          />
         </IonContent>
       </IonModal>
     </React.Fragment>

--- a/src/components/resources/workloads/pods/containers/Details.tsx
+++ b/src/components/resources/workloads/pods/containers/Details.tsx
@@ -24,9 +24,11 @@ import {
 } from '@kubernetes/client-node';
 import { close } from 'ionicons/icons';
 import yaml from 'js-yaml';
-import React from 'react';
+import React, { useContext } from 'react';
 
+import { IContext } from '../../../../../declarations';
 import { IS_INCLUSTER } from '../../../../../utils/constants';
+import { AppContext } from '../../../../../utils/context';
 import Editor from '../../../../misc/Editor';
 import IonCardEqualHeight from '../../../../misc/IonCardEqualHeight';
 import Row from '../../../misc/template/Row';
@@ -49,6 +51,8 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
   showModal,
   setShowModal,
 }: IDetailsProps) => {
+  const context = useContext<IContext>(AppContext);
+
   const containerState = (state: V1ContainerState): string => {
     if (state.running) {
       return `Started at ${state.running.startedAt}`;
@@ -244,7 +248,15 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
                     <IonCardTitle>Liveness Probe</IonCardTitle>
                   </IonCardHeader>
                   <IonCardContent>
-                    <Editor readOnly={true} value={yaml.dump(container.livenessProbe)} />
+                    <Editor
+                      readOnly={true}
+                      mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+                      value={
+                        context.settings.editorFormat === 'json'
+                          ? JSON.stringify(container.livenessProbe, null, 2)
+                          : yaml.dump(container.livenessProbe)
+                      }
+                    />
                   </IonCardContent>
                 </IonCardEqualHeight>
               </IonCol>
@@ -257,7 +269,15 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
                     <IonCardTitle>Readiness Probe</IonCardTitle>
                   </IonCardHeader>
                   <IonCardContent>
-                    <Editor readOnly={true} value={yaml.dump(container.readinessProbe)} />
+                    <Editor
+                      readOnly={true}
+                      mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+                      value={
+                        context.settings.editorFormat === 'json'
+                          ? JSON.stringify(container.readinessProbe, null, 2)
+                          : yaml.dump(container.readinessProbe)
+                      }
+                    />
                   </IonCardContent>
                 </IonCardEqualHeight>
               </IonCol>
@@ -270,7 +290,15 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
                     <IonCardTitle>Startup Probe</IonCardTitle>
                   </IonCardHeader>
                   <IonCardContent>
-                    <Editor readOnly={true} value={yaml.dump(container.startupProbe)} />
+                    <Editor
+                      readOnly={true}
+                      mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+                      value={
+                        context.settings.editorFormat === 'json'
+                          ? JSON.stringify(container.startupProbe, null, 2)
+                          : yaml.dump(container.startupProbe)
+                      }
+                    />
                   </IonCardContent>
                 </IonCardEqualHeight>
               </IonCol>
@@ -283,7 +311,15 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
                     <IonCardTitle>Security Context</IonCardTitle>
                   </IonCardHeader>
                   <IonCardContent>
-                    <Editor readOnly={true} value={yaml.dump(container.securityContext)} />
+                    <Editor
+                      readOnly={true}
+                      mode={context.settings.editorFormat === 'json' ? 'json' : 'yaml'}
+                      value={
+                        context.settings.editorFormat === 'json'
+                          ? JSON.stringify(container.securityContext, null, 2)
+                          : yaml.dump(container.securityContext)
+                      }
+                    />
                   </IonCardContent>
                 </IonCardEqualHeight>
               </IonCol>

--- a/src/components/settings/GeneralPage.tsx
+++ b/src/components/settings/GeneralPage.tsx
@@ -149,6 +149,18 @@ const GeneralPage: React.FunctionComponent = () => {
               />
             </IonItem>
             <IonItem>
+              <IonLabel>Editor Format</IonLabel>
+              <IonSelect
+                value={context.settings.editorFormat}
+                name="editorFormat"
+                onIonChange={handleSelect}
+                interface="popover"
+              >
+                <IonSelectOption value="yaml">Yaml</IonSelectOption>
+                <IonSelectOption value="json">Json</IonSelectOption>
+              </IonSelect>
+            </IonItem>
+            <IonItem>
               <IonLabel>Enable Pod Metrics</IonLabel>
               <IonToggle
                 name="enablePodMetrics"

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -36,6 +36,7 @@ export interface IAppSettings {
   timeout: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  editorFormat: string;
   enablePodMetrics: boolean;
   queryLimit: number;
   queryRefetchInterval: number;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_SETTINGS: IAppSettings = {
   timeout: 60,
   terminalFontSize: 12,
   terminalScrollback: 10000,
+  editorFormat: 'yaml',
   enablePodMetrics: true,
   queryLimit: 100,
   queryRefetchInterval: 5 * 60 * 1000,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -169,6 +169,7 @@ export const readSettings = (): IAppSettings => {
       terminalScrollback: settings.terminalScrollback
         ? settings.terminalScrollback
         : DEFAULT_SETTINGS.terminalScrollback,
+      editorFormat: settings.editorFormat ? settings.editorFormat : DEFAULT_SETTINGS.editorFormat,
       enablePodMetrics: settings.hasOwnProperty('enablePodMetrics')
         ? settings.enablePodMetrics
         : DEFAULT_SETTINGS.enablePodMetrics,


### PR DESCRIPTION
Until now, the Kubernetes manifests were always shown in yaml format.
Now it is possible to also show them as json. For that a new setting was
introduced, where the user can select the editor format.

Closes #333.