### PR TITLE
Fix OIDC PKCE

### DIFF
--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -93,8 +93,10 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
             scopes,
             pkceMethod !== 'disabled' ? pkceMethod : undefined,
           );
-          if (verifier !== '') {
+          if (pkceMethod !== 'disabled') {
             saveTemporaryCredentials({ ...temporaryCredentials, verifier });
+          } else {
+            saveTemporaryCredentials(temporaryCredentials);
           }
           close();
           window.location.replace(url);

--- a/src/components/settings/clusters/oidc/OIDC.tsx
+++ b/src/components/settings/clusters/oidc/OIDC.tsx
@@ -67,6 +67,7 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
       setError('Discovery URL, Client ID and Client Secret are required.');
     } else {
       const ca = isBase64(certificateAuthority) ? atob(certificateAuthority) : certificateAuthority;
+      const clientPkceMethod = pkceMethod !== 'disabled' ? pkceMethod : undefined;
 
       const temporaryCredentials = {
         clientID: clientID,
@@ -78,9 +79,11 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
         idToken: '',
         accessToken: '',
         expiry: 0,
+        pkceMethod: clientPkceMethod,
       };
 
       if (refreshToken) {
+        saveTemporaryCredentials(temporaryCredentials);
         close();
         history.push('/settings/clusters/oidc');
       } else {
@@ -91,10 +94,10 @@ const OIDC: React.FunctionComponent<IOIDCProps> = ({ close, history }: IOIDCProp
             clientSecret,
             ca,
             scopes,
-            pkceMethod !== 'disabled' ? pkceMethod : undefined,
+            clientPkceMethod,
           );
           if (pkceMethod !== 'disabled') {
-            saveTemporaryCredentials({ ...temporaryCredentials, verifier });
+            saveTemporaryCredentials({ ...temporaryCredentials, verifier, pkceMethod: clientPkceMethod });
           } else {
             saveTemporaryCredentials(temporaryCredentials);
           }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1065,6 +1065,7 @@ export const getOIDCRefreshToken = async (
         redirectURL: OIDC_REDIRECT_URL_WEB,
         code: code,
         scopes: credentials.scopes ? credentials.scopes : '',
+        pkceMethod: credentials.pkceMethod,
         verifier: credentials.verifier,
       }),
     });


### PR DESCRIPTION
I accidentally removed the call to `saveTemporaryCredentials` when pkce was disabled and wasn't sending the pkceMethod parameter to the backend. Locally it worked previously because my build was old, with these fixes it works again with a `ionic serve` + `mobile-server` dev setup. I'll also try it on an iOS device today to be sure.