### PR TITLE
Add force delete option

### DIFF
--- a/pkg/kube/request.go
+++ b/pkg/kube/request.go
@@ -49,7 +49,7 @@ func KubernetesRequest(ctx context.Context, method, url, body string, clientset 
 	if method == "GET" {
 		return clientset.RESTClient().Get().RequestURI(url).DoRaw(ctx)
 	} else if method == "DELETE" {
-		return clientset.RESTClient().Delete().RequestURI(url).DoRaw(ctx)
+		return clientset.RESTClient().Delete().RequestURI(url).Body([]byte(body)).DoRaw(ctx)
 	} else if method == "PATCH" {
 		return clientset.RESTClient().Patch(types.JSONPatchType).RequestURI(url).Body([]byte(body)).DoRaw(ctx)
 	} else if method == "POST" {

--- a/src/components/resources/misc/details/DeleteItem.tsx
+++ b/src/components/resources/misc/details/DeleteItem.tsx
@@ -52,9 +52,11 @@ const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ show, hide, ite
 
   const [error, setError] = useState<string>('');
 
-  const handleDelete = async () => {
+  const handleDelete = async (force: boolean) => {
+    const body = force ? '{"gracePeriodSeconds": 0}' : '';
+
     try {
-      await kubernetesRequest('DELETE', url, '', context.settings, await context.kubernetesAuthWrapper(''));
+      await kubernetesRequest('DELETE', url, body, context.settings, await context.kubernetesAuthWrapper(''));
     } catch (err) {
       setError(err);
     }
@@ -79,9 +81,22 @@ const DeleteItem: React.FunctionComponent<IDeleteItemProps> = ({ show, hide, ite
         message={`Do you really want to delete ${
           item.metadata && item.metadata.namespace ? `${item.metadata.namespace}/` : ''
         }${item.metadata ? item.metadata.name : ''}?`}
+        inputs={[
+          {
+            name: 'force',
+            type: 'checkbox',
+            label: 'Force',
+            value: 'force',
+            checked: false,
+          },
+        ]}
         buttons={[
           { text: 'Cancel', role: 'cancel', handler: hide },
-          { text: 'Delete', cssClass: 'delete-button', handler: () => handleDelete() },
+          {
+            text: 'Delete',
+            cssClass: 'delete-button',
+            handler: (data) => handleDelete(data && data.includes('force')),
+          },
         ]}
       />
     </React.Fragment>


### PR DESCRIPTION
When the user deletes a resource it is now possible to select a checkbox
named force, which sets the grace periode seconds to zero, so that the
resource is instantly deleted.