### PR TITLE
Remove resource group for Azure

### DIFF
--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -509,16 +509,6 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
                     onIonChange={handleAuthProviderAzure}
                   />
                 </IonItem>
-                <IonItem>
-                  <IonLabel position="stacked">Resource Group Name</IonLabel>
-                  <IonInput
-                    type="text"
-                    required={true}
-                    value={authProviderAzure.resourceGroupName}
-                    name="resourceGroupName"
-                    onIonChange={handleAuthProviderAzure}
-                  />
-                </IonItem>
               </IonItemGroup>
             ) : null}
             {authProvider === 'digitalocean' && authProviderDigitalOcean ? (

--- a/src/components/settings/clusters/azure/Azure.tsx
+++ b/src/components/settings/clusters/azure/Azure.tsx
@@ -25,7 +25,6 @@ const Azure: React.FunctionComponent<IAzureProps> = ({ close, history }: IAzureP
   const [clientID, setClientID] = useState<string>('');
   const [clientSecret, setClientSecret] = useState<string>('');
   const [tenantID, setTenantID] = useState<string>('');
-  const [resourceGroupName, setResourceGroupName] = useState<string>('');
   const [admin, setAdmin] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -45,22 +44,12 @@ const Azure: React.FunctionComponent<IAzureProps> = ({ close, history }: IAzureP
     setTenantID(event.target.value);
   };
 
-  const handleResourceGroupName = (event) => {
-    setResourceGroupName(event.target.value);
-  };
-
   const toggleAdmin = (event) => {
     setAdmin(event.detail.checked);
   };
 
   const importClusters = () => {
-    if (
-      subscriptionID === '' ||
-      clientID === '' ||
-      clientSecret === '' ||
-      tenantID === '' ||
-      resourceGroupName === ''
-    ) {
+    if (subscriptionID === '' || clientID === '' || clientSecret === '' || tenantID === '') {
       setError('Subscription ID, Client ID, Client Secret, Tenant ID and Resource Group Name are required.');
     } else {
       saveTemporaryCredentials({
@@ -68,7 +57,6 @@ const Azure: React.FunctionComponent<IAzureProps> = ({ close, history }: IAzureP
         clientID: clientID,
         clientSecret: clientSecret,
         tenantID: tenantID,
-        resourceGroupName: resourceGroupName,
         admin: admin,
       });
 
@@ -114,10 +102,6 @@ const Azure: React.FunctionComponent<IAzureProps> = ({ close, history }: IAzureP
           <IonItem>
             <IonLabel position="stacked">Tenant ID</IonLabel>
             <IonInput type="text" required={true} value={tenantID} onInput={handleTenantID} />
-          </IonItem>
-          <IonItem>
-            <IonLabel position="stacked">Resource Group Name</IonLabel>
-            <IonInput type="text" required={true} value={resourceGroupName} onInput={handleResourceGroupName} />
           </IonItem>
           <IonItem>
             <IonLabel>Admin Credentials</IonLabel>

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -173,7 +173,6 @@ export interface IClusterAuthProviderAzure {
   admin: boolean;
   clientID: string;
   clientSecret: string;
-  resourceGroupName: string;
   subscriptionID: string;
   tenantID: string;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -248,7 +248,6 @@ export const getAzureClusters = async (credentials: IClusterAuthProviderAzure): 
         clientID: credentials.clientID,
         clientSecret: credentials.clientSecret,
         tenantID: credentials.tenantID,
-        resourceGroupName: credentials.resourceGroupName,
         admin: credentials.admin,
       }),
     });


### PR DESCRIPTION
The user doesn't have to provide the resource group to add AKS clusters
from Azure. Instead we are using the returned id to get the resource
group.

Fixes #324.