### PR TITLE
Fix time range selection in Prometheus charts

### DIFF
--- a/src/components/plugins/prometheus/Dashboard.tsx
+++ b/src/components/plugins/prometheus/Dashboard.tsx
@@ -58,7 +58,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({ title, variables,
   // If kubenav is running inside a Kubernetes cluster (incluster mode), we are not using port forwarding. Instead we
   // are using the configured cluster url.
   const { isError, isFetching, data, error, refetch } = useQuery<IDashboardResult, Error>(
-    ['Dashboard', title, variables, charts],
+    ['Dashboard', title, variables, charts, timeDiff],
     async () => {
       try {
         let portforwardingPath = '';
@@ -103,7 +103,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({ title, variables,
         throw err;
       }
     },
-    context.settings.queryConfig,
+    { ...context.settings.queryConfig, keepPreviousData: true },
   );
 
   return (


### PR DESCRIPTION
When a user selected a new time range for the Prometheus charts, the new
data wasn't loaded. This should be fixed by adding the time range to the
query keys for react-query.

When the new data for the charts is loaded we also keep the previous
data, so that the UI isn't changed that often.