### PR TITLE
Remove camera and photo library access on iOS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "io.kubenav.kubenav"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 42
+        versionCode 44
         versionName "3.7.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>42</string>
+	<string>44</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -196,8 +196,18 @@ const KubeconfigPage: React.FunctionComponent<IKubeconfigPageProps> = ({ history
       <IonContent>
         <IonList lines="full">
           <div className="select-kubeconfig-wrapper">
+            <p>
+              <b>Attention:</b> To select a Kubeconfig it must have one of the following extensions: <code>.yaml</code>,{' '}
+              <code>.yml</code>, <code>.txt</code>, <code>.conf</code>.
+            </p>
             <IonButton expand="block">
-              <input id="file" hidden type="file" onChange={handleKubeconfigFile} />
+              <input
+                id="file"
+                hidden={true}
+                type="file"
+                accept=".yaml,.yml,.txt,.conf"
+                onChange={handleKubeconfigFile}
+              />
               <label htmlFor="file" className="select-kubeconfig">
                 Select Kubeconfig
               </label>


### PR DESCRIPTION
The latest iOS version of kubenav was rejected because it was possible to select the camera and photo library in the Kubeconfig file selector. This is fixed by only allowing `.yaml`, `.yml`, `.txt` and `.conf` files in the select dialog.

Fixes #343.