### PR TITLE
Allow use HTTP in URL with manual cluster

### DIFF
--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -280,7 +280,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
       setError('Name is required');
     } else if (url === '') {
       setError('URL is required');
-    } else if (!url.startsWith('https://')) {
+    } else if (!url.startsWith('https://') && !url.startWith('http://')) {
       setError('Invalid URL');
     } else {
       context.editCluster({

--- a/src/components/settings/clusters/EditCluster.tsx
+++ b/src/components/settings/clusters/EditCluster.tsx
@@ -280,7 +280,7 @@ const EditCluster: React.FunctionComponent<IEditClusterProps> = ({ cluster, clos
       setError('Name is required');
     } else if (url === '') {
       setError('URL is required');
-    } else if (!url.startsWith('https://') && !url.startWith('http://')) {
+    } else if (!url.startsWith('https://') && !url.startsWith('http://')) {
       setError('Invalid URL');
     } else {
       context.editCluster({

--- a/src/components/settings/clusters/manual/ManualPage.tsx
+++ b/src/components/settings/clusters/manual/ManualPage.tsx
@@ -78,7 +78,7 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }: IMan
       setError('Name is required');
     } else if (url === '') {
       setError('Server is required');
-    } else if (!url.startsWith('https://') && !url.startWith('http://')) {
+    } else if (!url.startsWith('https://') && !url.startsWith('http://')) {
       setError('Invalid URL');
     } else if (
       clientCertificateData === '' &&

--- a/src/components/settings/clusters/manual/ManualPage.tsx
+++ b/src/components/settings/clusters/manual/ManualPage.tsx
@@ -78,7 +78,7 @@ const ManualPage: React.FunctionComponent<IManualPageProps> = ({ history }: IMan
       setError('Name is required');
     } else if (url === '') {
       setError('Server is required');
-    } else if (!url.startsWith('https://')) {
+    } else if (!url.startsWith('https://') && !url.startWith('http://')) {
       setError('Invalid URL');
     } else if (
       clientCertificateData === '' &&


### PR DESCRIPTION
When connection to Kubernetes API exposed with `kubectl proxy`, there is no option to use HTTPS, only HTTP exposed.
This patch will allow to use `Kubenav` with HTTP Kubernetes API exposed with `kubectl proxy` without using additional HTTPS-2-HTTP proxy.