### PR TITLE
Use namespace from kubeconfig during import

### DIFF
--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -59,6 +59,7 @@ export const getClustersFromKubeconfig = (kubeconfig: string): ICluster[] => {
       for (const ctx of config.contexts) {
         const cluster = getKubeconfigCluster(ctx.context.cluster, config.clusters);
         const user = getKubeconfigUser(ctx.context.user, config.users);
+        const namespace = ctx.context.namespace ? ctx.context.namespace : 'default';
 
         if (ctx.name === '' || cluster === null || user === null || !cluster.server) {
           throw new Error('Invalid kubeconfig');
@@ -110,7 +111,7 @@ export const getClustersFromKubeconfig = (kubeconfig: string): ICluster[] => {
               accessToken: '',
               expiry: Math.floor(Date.now() / 1000),
             },
-            namespace: 'default',
+            namespace: namespace,
           });
         } else {
           clusters.push({
@@ -127,7 +128,7 @@ export const getClustersFromKubeconfig = (kubeconfig: string): ICluster[] => {
             password: user.password ? user.password : '',
             insecureSkipTLSVerify: cluster['insecure-skip-tls-verify'] ? cluster['insecure-skip-tls-verify'] : false,
             authProvider: 'kubeconfig',
-            namespace: 'default',
+            namespace: namespace,
           });
         }
       }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -384,6 +384,7 @@ export interface IKubeconfigContextRef {
 
 export interface IKubeconfigContext {
   cluster: string;
+  namespace?: string;
   user: string;
 }
 


### PR DESCRIPTION
Instead of setting the namespace for imported clusters from a kubeconfig
file to "default", we are now using the namespace from the kubeconfig
context if it is present.