### PR TITLE
Fix kubeconfig selection for some Android devices

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,19 +1,16 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
-android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
-
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+#Sun Nov 21 21:17:14 CET 2021
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+android.enableJetifier=true
+android.useAndroidX=true

--- a/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/settings/clusters/kubeconfig/KubeconfigPage.tsx
@@ -12,6 +12,7 @@ import {
   IonTextarea,
   IonTitle,
   IonToolbar,
+  isPlatform,
 } from '@ionic/react';
 import yaml from 'js-yaml';
 import React, { memo, useContext, useState } from 'react';
@@ -197,16 +198,18 @@ const KubeconfigPage: React.FunctionComponent<IKubeconfigPageProps> = ({ history
       <IonContent>
         <IonList lines="full">
           <div className="select-kubeconfig-wrapper">
-            <p>
-              <b>Attention:</b> To select a Kubeconfig it must have one of the following extensions: <code>.yaml</code>,{' '}
-              <code>.yml</code>, <code>.txt</code>, <code>.conf</code>.
-            </p>
+            {isPlatform('ios') ? (
+              <p>
+                <b>Attention:</b> To select a Kubeconfig it must have one of the following extensions:{' '}
+                <code>.yaml</code>, <code>.yml</code>, <code>.txt</code>, <code>.conf</code>.
+              </p>
+            ) : null}
             <IonButton expand="block">
               <input
                 id="file"
                 hidden={true}
                 type="file"
-                accept=".yaml,.yml,.txt,.conf"
+                accept={isPlatform('ios') ? '.yaml,.yml,.txt,.conf' : undefined}
                 onChange={handleKubeconfigFile}
               />
               <label htmlFor="file" className="select-kubeconfig">


### PR DESCRIPTION
On some Android devices it looks like the selection of a Kubeconfig file
is still not working. To fix the issue we do not limit the accepted
files for the file input anymore on Android.

This shouldn't be a problem, because the filetype limit was mainly
introduced for iOS, to get through the review process.