### PR TITLE
Fix Docker Image

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -9,10 +9,11 @@ COPY src /kubenav/src
 COPY .eslintrc.json .prettierrc.json capacitor.config.json ionic.config.json tsconfig.json /kubenav/
 RUN ionic build
 
-FROM golang:1.17 as server
+FROM golang:1.17.3-alpine3.14 as server
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "Building on $BUILDPLATFORM, for $TARGETPLATFORM" > /log
+RUN apk update && apk add git make
 WORKDIR /kubenav
 COPY go.mod go.sum /kubenav/
 RUN go mod download
@@ -20,9 +21,9 @@ COPY .git /kubenav/.git
 COPY cmd /kubenav/cmd
 COPY pkg /kubenav/pkg
 COPY Makefile /kubenav
-RUN make build-server
+RUN export CGO_ENABLED=0 && make build-server
 
-FROM alpine:3.14
+FROM alpine:3.14.2
 RUN apk update && apk add --no-cache ca-certificates
 RUN mkdir /kubenav
 COPY --from=build /kubenav/build /kubenav/build


### PR DESCRIPTION
The Docker image isn't usable since version 3.7.2, because it throws
some errors, when we try to run the kubenav binary. To fix this we have
to adjust the Dockerfile to disable CGO.

Fixes #364