### PR TITLE
[Security] Update alpine image

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -9,7 +9,7 @@ COPY src /kubenav/src
 COPY .eslintrc.json .prettierrc.json capacitor.config.json ionic.config.json tsconfig.json /kubenav/
 RUN ionic build
 
-FROM golang:1.17.3-alpine3.14 as server
+FROM golang:1.17.3-alpine3.15 as server
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "Building on $BUILDPLATFORM, for $TARGETPLATFORM" > /log
@@ -23,7 +23,7 @@ COPY pkg /kubenav/pkg
 COPY Makefile /kubenav
 RUN export CGO_ENABLED=0 && make build-server
 
-FROM alpine:3.14.2
+FROM alpine:3.15
 RUN apk update && apk add --no-cache ca-certificates
 RUN mkdir /kubenav
 COPY --from=build /kubenav/build /kubenav/build


### PR DESCRIPTION
Hello,

First of all, thanks for providing this fantastic open-source project. I use it myself in my Kubernetes cluster.

The vulnerability scanner from [armosec](https://hub.armo.cloud/docs/cluster-vulnerability-scanning) found 13 vulnerabilities in your image. They originate from an outdated version of alpine.

These vulnerabilities are related to: apk-tools and busybox

Found vulnerabilities (selection): CVE-2021-36159 and CVE-2021-42378

I would really appreciate if you could merge the PR and create a new Docker tag as soon as you have time for it.