### PR TITLE
Fix dashboards page for Prometheus plugin

### DIFF
--- a/src/components/plugins/prometheus/DashboardsPage.tsx
+++ b/src/components/plugins/prometheus/DashboardsPage.tsx
@@ -93,7 +93,7 @@ const DashboardsPage: React.FunctionComponent = () => {
               value={searchText}
               onIonChange={(e) => setSearchText(e.detail.value ? e.detail.value : '')}
             />
-            {data && data.pages && data.pages.length > 0 && data[0].items.length > 0 ? (
+            {data && data.pages ? (
               <IonList>
                 {data.pages.map((group, i) => (
                   <React.Fragment key={i}>


### PR DESCRIPTION
This PR fixes the dashboards page used in the Prometheus plugin. The page crashed after the ConfigMaps with the dashboards where loaded, because we tried to access item in a array which wasn't defined.

Fixes #370