### PR TITLE
Add live resource usage metrics

### DIFF
--- a/src/components/resources/misc/details/Details.tsx
+++ b/src/components/resources/misc/details/Details.tsx
@@ -8,6 +8,7 @@ import Bookmark from '../shared/Bookmark';
 import CreateJobItem, { CreateJobItemActivator } from './CreateJobItem';
 import DeleteItem, { DeleteItemActivator } from './DeleteItem';
 import EditItem, { EditItemActivator } from './EditItem';
+import LiveMetricsItem, { LiveMetricsItemActivator } from './LiveMetricsItem';
 import LogsItem, { LogsItemActivator } from './LogsItem';
 import RestartItem, { RestartItemActivator } from './RestartItem';
 import ScaleItem, { ScaleItemActivator } from './ScaleItem';
@@ -15,7 +16,18 @@ import ShellItem, { ShellItemActivator } from './ShellItem';
 import SSHItem, { SSHItemActivator } from './SSHItem';
 import ViewItem, { ViewItemActivator } from './ViewItem';
 
-type TShow = '' | 'createjob' | 'delete' | 'edit' | 'logs' | 'restart' | 'scale' | 'shell' | 'ssh' | 'view';
+type TShow =
+  | ''
+  | 'createjob'
+  | 'delete'
+  | 'edit'
+  | 'livemetrics'
+  | 'logs'
+  | 'restart'
+  | 'scale'
+  | 'shell'
+  | 'ssh'
+  | 'view';
 
 interface IDetailsProps {
   refresh: () => void;
@@ -74,6 +86,9 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, type, item, 
           {(isPlatform('hybrid') || isPlatform('mobile') || width < 992) && type === 'nodes' ? (
             <SSHItemActivator activator="item" onClick={() => showType('ssh')} item={item} />
           ) : null}
+          {type === 'pods' ? (
+            <LiveMetricsItemActivator activator="item" onClick={() => showType('livemetrics')} />
+          ) : null}
           <ViewItemActivator activator="item" onClick={() => showType('view')} />
           <EditItemActivator activator="item" onClick={() => showType('edit')} />
           <DeleteItemActivator activator="item" onClick={() => showType('delete')} />
@@ -86,6 +101,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ refresh, type, item, 
       <LogsItem show={show === 'logs'} hide={() => setShow('')} item={item} url={url} />
       <ShellItem show={show === 'shell'} hide={() => setShow('')} item={item} url={url} />
       <SSHItem show={show === 'ssh'} hide={() => setShow('')} item={item} />
+      <LiveMetricsItem show={show === 'livemetrics'} hide={() => setShow('')} item={item} />
       <ViewItem show={show === 'view'} hide={() => setShow('')} item={item} />
       <EditItem show={show === 'edit'} hide={() => setShow('')} item={item} url={url} />
       <DeleteItem show={show === 'delete'} hide={() => setShow('')} item={item} url={url} />

--- a/src/components/resources/misc/details/LiveMetricsItem.tsx
+++ b/src/components/resources/misc/details/LiveMetricsItem.tsx
@@ -1,0 +1,225 @@
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonTitle,
+  IonToolbar,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+} from '@ionic/react';
+import { analytics, close } from 'ionicons/icons';
+import React, { useContext, useEffect, useState } from 'react';
+import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+
+import { IContext, TActivator, IPodMetrics } from '../../../../declarations';
+import { kubernetesRequest } from '../../../../utils/api';
+import { AppContext } from '../../../../utils/context';
+import { formatResourceValue } from '../../../../utils/helpers';
+
+const reducer = (previousValue: number, currentValue: number) => previousValue + currentValue;
+
+interface ILiveMetric {
+  timestamp: number;
+  cpu: number;
+  memory: number;
+}
+
+interface ILiveMetricsItemActivatorProps {
+  activator: TActivator;
+  onClick: () => void;
+}
+
+export const LiveMetricsItemActivator: React.FunctionComponent<ILiveMetricsItemActivatorProps> = ({
+  activator,
+  onClick,
+}: ILiveMetricsItemActivatorProps) => {
+  if (activator === 'item') {
+    return (
+      <IonItem button={true} detail={false} onClick={onClick}>
+        <IonIcon slot="end" color="primary" icon={analytics} />
+        <IonLabel>Live Metrics</IonLabel>
+      </IonItem>
+    );
+  } else {
+    return null;
+  }
+};
+
+interface ILiveMetricsItemProps {
+  show: boolean;
+  hide: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+}
+
+const LiveMetricsItem: React.FunctionComponent<ILiveMetricsItemProps> = ({
+  show,
+  hide,
+  item,
+}: ILiveMetricsItemProps) => {
+  const context = useContext<IContext>(AppContext);
+  const [metrics, setMetrics] = useState<ILiveMetric[]>([]);
+
+  const fetchMetrics = async () => {
+    try {
+      if (show) {
+        const data: IPodMetrics = await kubernetesRequest(
+          'GET',
+          `/apis/metrics.k8s.io/v1beta1/namespaces/${
+            item.metadata && item.metadata.namespace ? item.metadata.namespace : ''
+          }/pods/${item.metadata && item.metadata.name ? item.metadata.name : ''}`,
+          '',
+          context.settings,
+          await context.kubernetesAuthWrapper(''),
+        );
+
+        const containerMetrics: ILiveMetric[] = [];
+
+        if (data.containers) {
+          for (const container of data.containers) {
+            containerMetrics.push({
+              timestamp: 0,
+              cpu: parseInt(formatResourceValue('cpu', container?.usage?.cpu || '0')),
+              memory: parseInt(formatResourceValue('memory', container?.usage?.memory || '0')),
+            });
+          }
+        }
+
+        setMetrics((prevMetrics) => {
+          if (prevMetrics.length > 14) {
+            return [
+              ...prevMetrics.slice(-14),
+              {
+                timestamp: Math.floor(new Date().getTime() / 1000),
+                cpu: containerMetrics.map((m) => m.cpu).reduce(reducer),
+                memory: containerMetrics.map((m) => m.memory).reduce(reducer),
+              },
+            ];
+          } else {
+            return [
+              ...prevMetrics,
+              {
+                timestamp: Math.floor(new Date().getTime() / 1000),
+                cpu: containerMetrics.map((m) => m.cpu).reduce(reducer),
+                memory: containerMetrics.map((m) => m.memory).reduce(reducer),
+              },
+            ];
+          }
+        });
+      }
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  const formatTime = (time: number): string => {
+    const d = new Date(time * 1000);
+    return `${('0' + d.getHours()).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}`;
+  };
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchMetrics();
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    <React.Fragment>
+      <IonModal isOpen={show} onDidDismiss={hide}>
+        <IonHeader>
+          <IonToolbar>
+            <IonButtons slot="start">
+              <IonButton onClick={hide}>
+                <IonIcon slot="icon-only" icon={close} />
+              </IonButton>
+            </IonButtons>
+            <IonTitle>{item.metadata ? item.metadata.name : ''}</IonTitle>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent>
+          <IonCard>
+            <IonCardHeader>
+              <IonCardTitle>CPU Usage</IonCardTitle>
+            </IonCardHeader>
+            <IonCardContent>
+              <div style={{ height: '300px', width: '100%' }}>
+                {metrics.length > 0 && (
+                  <ResponsiveContainer>
+                    <AreaChart data={metrics}>
+                      <XAxis
+                        dataKey="timestamp"
+                        scale="time"
+                        type="number"
+                        domain={['dataMin', 'dataMax']}
+                        tickFormatter={formatTime}
+                      />
+                      <YAxis dataKey="cpu" unit="m" />
+                      <Area
+                        dataKey="cpu"
+                        // NOTE: https://github.com/recharts/recharts/issues/2487
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        data={metrics}
+                        name="CPU Usage"
+                        stroke="#326ce5"
+                        fill="#326ce5"
+                        fillOpacity={0.2}
+                        isAnimationActive={false}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
+            </IonCardContent>
+          </IonCard>
+          <IonCard>
+            <IonCardHeader>
+              <IonCardTitle>Memory Usage</IonCardTitle>
+            </IonCardHeader>
+            <IonCardContent>
+              <div style={{ height: '300px', width: '100%' }}>
+                {metrics.length > 0 && (
+                  <ResponsiveContainer>
+                    <AreaChart data={metrics}>
+                      <XAxis
+                        dataKey="timestamp"
+                        scale="time"
+                        type="number"
+                        domain={['dataMin', 'dataMax']}
+                        tickFormatter={formatTime}
+                      />
+                      <YAxis dataKey="memory" unit="Mi" />
+                      <Area
+                        dataKey="memory"
+                        // NOTE: https://github.com/recharts/recharts/issues/2487
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        data={metrics}
+                        name="Memory Usage"
+                        stroke="#326ce5"
+                        fill="#326ce5"
+                        fillOpacity={0.2}
+                        isAnimationActive={false}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
+            </IonCardContent>
+          </IonCard>
+        </IonContent>
+      </IonModal>
+    </React.Fragment>
+  );
+};
+
+export default LiveMetricsItem;


### PR DESCRIPTION
This commit adds live resource usage metrics for Pods. The metrics can
be viewed via the new "Live Metrics" action in the Pod details. When a
user selects this option a new modal is shown with the CPU and Memory
usage of the selected Pod. The metrics are updated every 3 seconds.

Closes #368