### PR TITLE
Fix re-authentication for AWS SSO

### DIFF
--- a/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
+++ b/src/components/settings/clusters/aws/AWSSSOReAuthenticate.tsx
@@ -42,7 +42,7 @@ const AWSSSOReAuthenticate: React.FunctionComponent<IAWSSSOReAuthenticateProps> 
         );
 
         const tmpCluster = cluster;
-        tmpCluster.authProviderAWSSSO = credentials;
+        tmpCluster.authProviderAWSSSO = { ...credentials, clusterID: tmpCluster.authProviderAWSSSO?.clusterID || '' };
 
         context.editCluster(tmpCluster);
         history.go(0);


### PR DESCRIPTION
In the re-authentication method for the AWS SSO provider the cluster id
wasn't passed to the new cluster credentials, which brokes the
re-authentication method.

Fixes #373