### PR TITLE
[BUGFIX] Fix typo Ingresse => Ingress

### DIFF
--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -231,10 +231,10 @@ export const resources: IAppSections = {
         detailsComponent: HorizontalPodAutoscalerDetails,
       },
       ingresses: {
-        singleText: 'Ingresse',
+        singleText: 'Ingress',
         pluralText: 'Ingresses',
         icon: '/assets/icons/kubernetes/ing.png',
-        kind: 'Ingresse',
+        kind: 'Ingress',
         apiVersion: 'networking.k8s.io/v1',
         listURL: (namespace: string): string => {
           return namespace


### PR DESCRIPTION
This PR addresses a typo that refers to the singular of `Ingresses` as `Ingresse` (rather than [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/))