### PR TITLE
Bugfix/google check api for project

### DIFF
--- a/src/components/settings/clusters/google/GooglePage.tsx
+++ b/src/components/settings/clusters/google/GooglePage.tsx
@@ -59,10 +59,10 @@ const GooglePage: React.FunctionComponent<IGooglePageProps> = ({ location, histo
             credentials = await getGoogleTokens(credentials.clientID, params.code);
             const projects = await getGoogleProjects(credentials.accessToken);
 
+            const tmpClusters: ICluster[] = [];
+
             for (const project of projects) {
               const projectClusters = await getGoogleClusters(credentials.accessToken, project.projectId);
-
-              const tmpClusters: ICluster[] = [];
 
               if (projectClusters) {
                 // eslint-disable-next-line
@@ -85,10 +85,9 @@ const GooglePage: React.FunctionComponent<IGooglePageProps> = ({ location, histo
                     namespace: 'default',
                   });
                 });
-
-                return tmpClusters;
               }
             }
+            return tmpClusters;
           }
         } else {
           throw new Error('Could not read credentials for Google');

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -415,9 +415,9 @@ export const getGoogleAccessToken = async (
 
 // isGoogleAPIEnabled returns true if the given API is enabled for the provided project. For the authentication against the
 // Google API a valid access token is required.
-const isGoogleAPIEnabled = async (accessToken: string, project: string, api: string): Promise<boolean> => {
+const isGoogleAPIEnabled = async (accessToken: string, projectId: string, api: string): Promise<boolean> => {
   try {
-    const response = await fetch(`https://serviceusage.googleapis.com/v1/projects/${project}/services/${api}`, {
+    const response = await fetch(`https://serviceusage.googleapis.com/v1/projects/${projectId}/services/${api}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
@@ -442,9 +442,9 @@ const isGoogleAPIEnabled = async (accessToken: string, project: string, api: str
 
 // getGoogleClusters returns all available GKE clusters for the provided project. For the authentication against the
 // Google API a valid access token is required.
-export const getGoogleClusters = async (accessToken: string, project: string): Promise<IGoogleCluster[]> => {
+export const getGoogleClusters = async (accessToken: string, projectId: string): Promise<IGoogleCluster[]> => {
   try {
-    const response = await fetch(`https://container.googleapis.com/v1/projects/${project}/locations/-/clusters`, {
+    const response = await fetch(`https://container.googleapis.com/v1/projects/${projectId}/locations/-/clusters`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
@@ -471,19 +471,26 @@ export const getGoogleClusters = async (accessToken: string, project: string): P
 // access token is required.
 export const getGoogleProjects = async (accessToken: string): Promise<IGoogleProject[]> => {
   try {
-    const response = await fetch('https://cloudresourcemanager.googleapis.com/v1/projects', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+    const response = await fetch(
+      'https://cloudresourcemanager.googleapis.com/v1/projects?filter=lifecycleState%3AACTIVE',
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        method: 'GET',
       },
-      method: 'GET',
-    });
+    );
 
     const json = await response.json();
 
     if (response.status >= 200 && response.status < 300) {
       const projectList: IGoogleProject[] = [];
       for (const project of json.projects) {
-        const isContainerEngineEnabled = await isGoogleAPIEnabled(accessToken, project, GOOGLE_CONTAINER_ENGINE_API);
+        const isContainerEngineEnabled = await isGoogleAPIEnabled(
+          accessToken,
+          project.projectId,
+          GOOGLE_CONTAINER_ENGINE_API,
+        );
 
         if (isContainerEngineEnabled) {
           projectList.push(project);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -53,6 +53,8 @@ export const GOOGLE_OAUTH2_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/a
 export const GOOGLE_REDIRECT_URI = `${CUSTOM_URI_SCHEME}:/settings/clusters/google`;
 export const GOOGLE_RESPONSE_TYPE = 'code';
 export const GOOGLE_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+export const GOOGLE_CONTAINER_ENGINE_API = 'container.googleapis.com';
+export const GOOGLE_SERVICE_USAGE_STATE_ENABLED = 'ENABLED';
 
 export const OIDC_REDIRECT_URL = `${CUSTOM_URI_SCHEME}:/settings/clusters/oidc/redirect`;
 export const OIDC_REDIRECT_URL_WEB = 'https://kubenav.io/oidc.html';


### PR DESCRIPTION
This PR fixes that only 1 Google Cluster gets listed.

There are basically 3 possible Errors in it.

1. The most problematic point was the GooglePage.tsx where the List of Clusters was returned after the first Project.
     So it never was able to retreive the Clusters of any other Project.
2. A Google Project may not have the Kubernetes Engine API enabled and can run into an Error while trying to fetch the Clusters from it. There is now an API-Check for each Project, so it does not return any Project, where the API is not enabled.
3. A Google Project can be in a State of "Pending Deletion", resulting in an Error because you don´t have access to it anymore.
    With the "Filter"-Argument you can adjust the Response from the Projects-API to only list "ACTIVE" Projects.

fixes #397

If there is anything missing in the PR let me know.