### PR TITLE
Add Support for Additional Printer Columns

### DIFF
--- a/lib/models/resource.dart
+++ b/lib/models/resource.dart
@@ -95,6 +95,42 @@ ResourceScope getResourceScopeFromString(String? scope) {
   return ResourceScope.cluster;
 }
 
+/// [AdditionalPrinterColumns] adds additional columns from a manifest file to
+/// a resource, which should be rendered within the list / details view for a
+/// resource. This is similar to the [IoK8sApiextensionsApiserverPkgApisApiextensionsV1CustomResourceColumnDefinition]
+/// type and mainly used to render some custom fields for CRDs.
+class AdditionalPrinterColumns {
+  String description;
+  String jsonPath;
+  String name;
+  String type;
+
+  AdditionalPrinterColumns({
+    required this.description,
+    required this.jsonPath,
+    required this.name,
+    required this.type,
+  });
+
+  factory AdditionalPrinterColumns.fromJson(Map<String, dynamic> data) {
+    return AdditionalPrinterColumns(
+      description: data['description'],
+      jsonPath: data['jsonPath'],
+      name: data['name'],
+      type: data['type'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'description': description,
+      'jsonPath': jsonPath,
+      'name': name,
+      'type': type,
+    };
+  }
+}
+
 /// A [Resource] represents a single Kubernetes resource. Each resource must
 /// contain a [resourceType], a human readable [title], a [description] and the
 /// [resource], [path] and [scope] so the corresponding Kubernetes manifests can
@@ -114,12 +150,14 @@ class Resource {
   String resource;
   String path;
   ResourceScope scope;
+  List<AdditionalPrinterColumns> additionalPrinterColumns;
   String template;
   Widget Function(
     String title,
     String resource,
     String path,
     ResourceScope scope,
+    List<AdditionalPrinterColumns> additionalPrinterColumns,
     dynamic item,
     dynamic metrics,
   )? buildListItem;
@@ -133,6 +171,7 @@ class Resource {
     required this.path,
     required this.scope,
     required this.template,
+    required this.additionalPrinterColumns,
     this.buildListItem,
     this.buildDetailsItem,
   });
@@ -151,6 +190,7 @@ abstract class Resources {
       resource: 'cronjobs',
       path: '/apis/batch/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"batch/v1","kind":"CronJob","metadata":{"name":"","namespace":""},"spec":{"schedule":"5 4 * * *","suspend":false,"successfulJobsHistoryLimit":1,"failedJobsHistoryLimit":1,"jobTemplate":{"spec":{"backoffLimit":0,"template":{"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}}}}}',
       buildListItem: (
@@ -158,6 +198,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -166,6 +207,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => CronJobDetailsItem(item: item),
@@ -178,6 +220,7 @@ abstract class Resources {
       resource: 'daemonsets',
       path: '/apis/apps/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"name":"","namespace":""},"spec":{"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}}}',
       buildListItem: (
@@ -185,6 +228,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -193,6 +237,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => DaemonSetDetailsItem(item: item),
@@ -205,6 +250,7 @@ abstract class Resources {
       resource: 'deployments',
       path: '/apis/apps/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"","namespace":""},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}}}',
       buildListItem: (
@@ -212,6 +258,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -220,6 +267,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => DeploymentDetailsItem(item: item),
@@ -232,6 +280,7 @@ abstract class Resources {
       resource: 'jobs',
       path: '/apis/batch/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"batch/v1","kind":"Job","metadata":{"name":"","namespace":""},"spec":{"backoffLimit":0,"completions":1,"parallelism":1,"template":{"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}}}',
       buildListItem: (
@@ -239,6 +288,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -247,6 +297,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => JobDetailsItem(item: item),
@@ -259,6 +310,7 @@ abstract class Resources {
       resource: 'pods',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"","namespace":""},"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}',
       buildListItem: (
@@ -266,6 +318,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -274,6 +327,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
         metrics: metrics,
       ),
@@ -287,12 +341,14 @@ abstract class Resources {
       resource: 'replicasets',
       path: '/apis/apps/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -301,6 +357,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => ReplicaSetDetailsItem(item: item),
@@ -313,6 +370,7 @@ abstract class Resources {
       resource: 'statefulsets',
       path: '/apis/apps/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"","namespace":""},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"nginx"}},"serviceName":"nginx","template":{"metadata":{"labels":{"app":"nginx"},"name":"nginx"},"spec":{"containers":[{"name":"nginx","image":"nginx:1.14.2"}]}}}}',
       buildListItem: (
@@ -320,6 +378,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -328,6 +387,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => StatefulSetDetailsItem(item: item),
@@ -340,12 +400,14 @@ abstract class Resources {
       resource: 'endpoints',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -354,6 +416,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => EndpointDetailsItem(item: item),
@@ -366,12 +429,14 @@ abstract class Resources {
       resource: 'horizontalpodautoscalers',
       path: '/apis/autoscaling/v2',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -380,6 +445,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) =>
@@ -393,12 +459,14 @@ abstract class Resources {
       resource: 'ingresses',
       path: '/apis/networking.k8s.io/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -407,6 +475,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => IngressDetailsItem(item: item),
@@ -419,12 +488,14 @@ abstract class Resources {
       resource: 'networkpolicies',
       path: '/apis/networking.k8s.io/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -433,6 +504,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => NetworkPolicyDetailsItem(item: item),
@@ -445,12 +517,14 @@ abstract class Resources {
       resource: 'services',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -459,6 +533,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => ServiceDetailsItem(item: item),
@@ -471,12 +546,14 @@ abstract class Resources {
       resource: 'configmaps',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -485,6 +562,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => ConfigMapDetailsItem(item: item),
@@ -497,12 +575,14 @@ abstract class Resources {
       resource: 'persistentvolumes',
       path: '/api/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -511,6 +591,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) =>
@@ -524,12 +605,14 @@ abstract class Resources {
       resource: 'persistentvolumeclaims',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -538,6 +621,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) =>
@@ -551,12 +635,14 @@ abstract class Resources {
       resource: 'poddisruptionbudgets',
       path: '/apis/policy/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -565,6 +651,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) =>
@@ -578,12 +665,14 @@ abstract class Resources {
       resource: 'secrets',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -592,6 +681,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => SecretDetailsItem(item: item),
@@ -604,12 +694,14 @@ abstract class Resources {
       resource: 'serviceaccounts',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -618,6 +710,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => ServiceAccountDetailsItem(item: item),
@@ -630,12 +723,14 @@ abstract class Resources {
       resource: 'storageclasses',
       path: '/apis/storage.k8s.io/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -644,6 +739,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => StorageClassDetailsItem(item: item),
@@ -656,6 +752,7 @@ abstract class Resources {
       resource: 'clusterroles',
       path: '/apis/rbac.authorization.k8s.io/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
       buildDetailsItem: (dynamic item) => ClusterRoleDetailsItem(item: item),
     ),
@@ -667,12 +764,14 @@ abstract class Resources {
       resource: 'clusterrolebindings',
       path: '/apis/rbac.authorization.k8s.io/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -681,6 +780,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) =>
@@ -694,6 +794,7 @@ abstract class Resources {
       resource: 'roles',
       path: '/apis/rbac.authorization.k8s.io/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildDetailsItem: (dynamic item) => RoleDetailsItem(item: item),
     ),
@@ -705,12 +806,14 @@ abstract class Resources {
       resource: 'rolebindings',
       path: '/apis/rbac.authorization.k8s.io/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -719,6 +822,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => RoleBindingDetailsItem(item: item),
@@ -731,12 +835,14 @@ abstract class Resources {
       resource: 'events',
       path: '/api/v1',
       scope: ResourceScope.namespaced,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -745,6 +851,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => EventDetailsItem(item: item),
@@ -756,6 +863,7 @@ abstract class Resources {
       resource: 'customresourcedefinitions',
       path: '/apis/apiextensions.k8s.io/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
     ),
     'namespaces': Resource(
@@ -766,6 +874,7 @@ abstract class Resources {
       resource: 'namespaces',
       path: '/api/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template:
           '{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"nginx"}}',
       buildListItem: (
@@ -773,6 +882,7 @@ abstract class Resources {
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -781,6 +891,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
       ),
       buildDetailsItem: (dynamic item) => NamespaceDetailsItem(item: item),
@@ -793,12 +904,14 @@ abstract class Resources {
       resource: 'nodes',
       path: '/api/v1',
       scope: ResourceScope.cluster,
+      additionalPrinterColumns: [],
       template: '',
       buildListItem: (
         String title,
         String resource,
         String path,
         ResourceScope scope,
+        List<AdditionalPrinterColumns> additionalPrinterColumns,
         dynamic item,
         dynamic metrics,
       ) =>
@@ -807,6 +920,7 @@ abstract class Resources {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         item: item,
         metrics: metrics,
       ),

--- a/lib/repositories/bookmarks_repository.dart
+++ b/lib/repositories/bookmarks_repository.dart
@@ -38,7 +38,7 @@ class BookmarksRepository with ChangeNotifier {
       notifyListeners();
     } catch (err) {
       Logger.log(
-        'BookmarksRepository _init',
+        'BookmarksRepository init',
         'Could not load bookmarks',
         err,
       );

--- a/lib/repositories/bookmarks_repository.dart
+++ b/lib/repositories/bookmarks_repository.dart
@@ -52,6 +52,7 @@ class BookmarksRepository with ChangeNotifier {
     String resource,
     String path,
     ResourceScope scope,
+    List<AdditionalPrinterColumns> additionalPrinterColumns,
     String? name,
     String? namespace,
   ) async {
@@ -63,6 +64,7 @@ class BookmarksRepository with ChangeNotifier {
         resource: resource,
         path: path,
         scope: scope,
+        additionalPrinterColumns: additionalPrinterColumns,
         name: name,
         namespace: namespace,
       ),
@@ -174,6 +176,7 @@ class Bookmark {
   String resource;
   String path;
   ResourceScope scope;
+  List<AdditionalPrinterColumns> additionalPrinterColumns;
   String? name;
   String? namespace;
 
@@ -184,6 +187,7 @@ class Bookmark {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.name,
     required this.namespace,
   });
@@ -196,6 +200,11 @@ class Bookmark {
       resource: data['resource'],
       path: data['path'],
       scope: getResourceScopeFromString(data['scope']),
+      additionalPrinterColumns: data.containsKey('additionalPrinterColumns') &&
+              data['additionalPrinterColumns'] != null
+          ? List<AdditionalPrinterColumns>.from(data['additionalPrinterColumns']
+              .map((v) => AdditionalPrinterColumns.fromJson(v)))
+          : [],
       name: data.containsKey('name') && data['name'] != null
           ? data['name']
           : null,
@@ -213,6 +222,8 @@ class Bookmark {
       'resource': resource,
       'path': path,
       'scope': scope.toShortString(),
+      'additionalPrinterColumns':
+          additionalPrinterColumns.map((e) => e.toJson()).toList(),
       'name': name,
       'namespace': namespace,
     };

--- a/lib/repositories/bookmarks_repository.dart
+++ b/lib/repositories/bookmarks_repository.dart
@@ -38,7 +38,7 @@ class BookmarksRepository with ChangeNotifier {
       notifyListeners();
     } catch (err) {
       Logger.log(
-        'BookmarksRepository init',
+        'BookmarksRepository _init',
         'Could not load bookmarks',
         err,
       );

--- a/lib/utils/resources/general.dart
+++ b/lib/utils/resources/general.dart
@@ -1,5 +1,7 @@
 import 'package:kubenav/models/kubernetes/io_k8s_api_rbac_v1_policy_rule.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_apimachinery_pkg_apis_meta_v1_label_selector.dart';
+import 'package:kubenav/models/resource.dart';
+import 'package:json_path/json_path.dart';
 
 /// [getAge] returns the age of a Kubernetes resources in a human readable format. This is mostly used to dertermine the
 /// age of a resource via the `metadata.creationTimestamp` field. If the given [timestamp] is `null` we return a dash as
@@ -201,4 +203,30 @@ String formatMemoryMetric(double size, [int round = 2]) {
   }
 
   return '${(size / divider / divider).toStringAsFixed(round)}Gi';
+}
+
+/// [getAdditionalPrinterColumnValue] formats the value for an additional
+/// printer column value.
+String getAdditionalPrinterColumnValue(
+  AdditionalPrinterColumns additionalPrinterColumns,
+  dynamic item,
+) {
+  final values = JsonPath(r'$' + additionalPrinterColumns.jsonPath)
+      .read(item)
+      .map((e) => e.value)
+      .toList();
+
+  String formattedValue = '';
+  if (additionalPrinterColumns.type == 'integer' && values.isEmpty) {
+    formattedValue = '0';
+  } else if (values.isEmpty) {
+    formattedValue = '';
+  } else if (additionalPrinterColumns.type == 'date') {
+    formattedValue =
+        values.map((e) => getAge(DateTime.parse(e))).toList().join(', ');
+  } else {
+    formattedValue = values.join(', ');
+  }
+
+  return formattedValue;
 }

--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -93,6 +93,8 @@ class _OverviewEventsState extends State<OverviewEvents> {
       resource: Resources.map['events']!.resource,
       path: Resources.map['events']!.path,
       scope: Resources.map['events']!.scope,
+      additionalPrinterColumns:
+          Resources.map['events']!.additionalPrinterColumns,
       name: event.metadata.name ?? '',
       namespace: event.metadata.namespace,
       info: info,

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -79,6 +79,8 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
               resource: bookmarksRepository.bookmarks[index].resource,
               path: bookmarksRepository.bookmarks[index].path,
               scope: bookmarksRepository.bookmarks[index].scope,
+              additionalPrinterColumns:
+                  bookmarksRepository.bookmarks[index].additionalPrinterColumns,
               namespace: bookmarksRepository.bookmarks[index].namespace,
               selector: null,
             ),
@@ -104,6 +106,8 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
               resource: bookmarksRepository.bookmarks[index].resource,
               path: bookmarksRepository.bookmarks[index].path,
               scope: bookmarksRepository.bookmarks[index].scope,
+              additionalPrinterColumns:
+                  bookmarksRepository.bookmarks[index].additionalPrinterColumns,
               name: bookmarksRepository.bookmarks[index].name!,
               namespace: bookmarksRepository.bookmarks[index].namespace,
             ),

--- a/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
@@ -57,6 +57,8 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
               resource: bookmarksRepository.bookmarks[index].resource,
               path: bookmarksRepository.bookmarks[index].path,
               scope: bookmarksRepository.bookmarks[index].scope,
+              additionalPrinterColumns:
+                  bookmarksRepository.bookmarks[index].additionalPrinterColumns,
               namespace: bookmarksRepository.bookmarks[index].namespace,
               selector: null,
             ),
@@ -82,6 +84,8 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
               resource: bookmarksRepository.bookmarks[index].resource,
               path: bookmarksRepository.bookmarks[index].path,
               scope: bookmarksRepository.bookmarks[index].scope,
+              additionalPrinterColumns:
+                  bookmarksRepository.bookmarks[index].additionalPrinterColumns,
               name: bookmarksRepository.bookmarks[index].name!,
               namespace: bookmarksRepository.bookmarks[index].namespace,
             ),

--- a/lib/widgets/resources/details/clusterrole_details_item.dart
+++ b/lib/widgets/resources/details/clusterrole_details_item.dart
@@ -96,6 +96,8 @@ class ClusterRoleDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/clusterrolebinding_details_item.dart
+++ b/lib/widgets/resources/details/clusterrolebinding_details_item.dart
@@ -94,6 +94,8 @@ class ClusterRoleBindingDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/configmap_details_item.dart
+++ b/lib/widgets/resources/details/configmap_details_item.dart
@@ -141,6 +141,8 @@ class ConfigMapDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/cronjob_details_item.dart
+++ b/lib/widgets/resources/details/cronjob_details_item.dart
@@ -101,6 +101,8 @@ class CronJobDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['jobs']!.resource,
           path: Resources.map['jobs']!.path,
           scope: Resources.map['jobs']!.scope,
+          additionalPrinterColumns:
+              Resources.map['jobs']!.additionalPrinterColumns,
           namespace: cronJob.metadata?.namespace,
           selector: '',
           filter: (items) {
@@ -122,6 +124,8 @@ class CronJobDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: cronJob.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${cronJob.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/daemonset_details_item.dart
+++ b/lib/widgets/resources/details/daemonset_details_item.dart
@@ -86,6 +86,8 @@ class DaemonSetDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: daemonSet.metadata?.namespace,
           selector: getSelector(daemonSet.spec!.selector),
         ),
@@ -95,6 +97,8 @@ class DaemonSetDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: daemonSet.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${daemonSet.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/deployment_details_item.dart
+++ b/lib/widgets/resources/details/deployment_details_item.dart
@@ -94,6 +94,8 @@ class DeploymentDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: deployment.metadata?.namespace,
           selector: getSelector(deployment.spec?.selector),
         ),
@@ -103,6 +105,8 @@ class DeploymentDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: deployment.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${deployment.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/details_item_additional_printer_columns.dart
+++ b/lib/widgets/resources/details/details_item_additional_printer_columns.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:kubenav/models/resource.dart';
+
+import 'package:kubenav/utils/resources/general.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/details/details_item.dart';
+
+class DetailsItemAdditionalPrinterColumns extends StatelessWidget {
+  const DetailsItemAdditionalPrinterColumns({
+    Key? key,
+    required this.additionalPrinterColumns,
+    required this.item,
+  }) : super(key: key);
+
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
+  final dynamic item;
+
+  List<DetailsItemModel> _buildDetailsItems() {
+    List<DetailsItemModel> detailsItems = [];
+
+    for (final additionalPrinterColumn in additionalPrinterColumns) {
+      final value = getAdditionalPrinterColumnValue(
+        additionalPrinterColumn,
+        item,
+      );
+
+      detailsItems.add(
+        DetailsItemModel(
+          name: additionalPrinterColumn.name,
+          values: value,
+          onTap: additionalPrinterColumn.description == ''
+              ? null
+              : (index) {
+                  showSnackbar(
+                    '${additionalPrinterColumn.name}: $value',
+                    additionalPrinterColumn.description,
+                  );
+                },
+        ),
+      );
+    }
+
+    return detailsItems;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (additionalPrinterColumns.isEmpty) {
+      return Container();
+    }
+
+    return DetailsItemWidget(
+      title: 'Additional Information',
+      details: _buildDetailsItems(),
+    );
+  }
+}

--- a/lib/widgets/resources/details/details_resources_preview.dart
+++ b/lib/widgets/resources/details/details_resources_preview.dart
@@ -42,6 +42,7 @@ class DetailsResourcesPreview extends StatefulWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.namespace,
     required this.selector,
     this.filter,
@@ -51,6 +52,7 @@ class DetailsResourcesPreview extends StatefulWidget {
   final String resource;
   final String path;
   final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final String? namespace;
   final String selector;
   final List<dynamic> Function(List<dynamic> items)? filter;
@@ -264,6 +266,8 @@ class _DetailsResourcesPreviewState extends State<DetailsResourcesPreview> {
                         resource: widget.resource,
                         path: widget.path,
                         scope: widget.scope,
+                        additionalPrinterColumns:
+                            widget.additionalPrinterColumns,
                         name: snapshot.data![index]['metadata']?['name'],
                         namespace: snapshot.data![index]['metadata']
                             ?['namespace'],
@@ -286,6 +290,7 @@ class _DetailsResourcesPreviewState extends State<DetailsResourcesPreview> {
                     resource: widget.resource,
                     path: widget.path,
                     scope: widget.scope,
+                    additionalPrinterColumns: widget.additionalPrinterColumns,
                     namespace: widget.selector
                             .startsWith('fieldSelector=spec.nodeName=')
                         ? null

--- a/lib/widgets/resources/details/endpoint_details_item.dart
+++ b/lib/widgets/resources/details/endpoint_details_item.dart
@@ -73,6 +73,8 @@ class EndpointDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/horizontalpodautoscaler_details_item.dart
+++ b/lib/widgets/resources/details/horizontalpodautoscaler_details_item.dart
@@ -32,6 +32,7 @@ class HorizontalPodAutoscalerDetailsItem extends StatelessWidget
         resource: '${hpa.spec!.scaleTargetRef.kind.toLowerCase()}s',
         path: '/apis/${hpa.spec!.scaleTargetRef.apiVersion}',
         scope: ResourceScope.namespaced,
+        additionalPrinterColumns: const [],
         namespace: item['metadata']['namespace'],
         selector:
             'fieldSelector=metadata.name=${hpa.spec!.scaleTargetRef.name}',
@@ -93,6 +94,8 @@ class HorizontalPodAutoscalerDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/ingress_details_item.dart
+++ b/lib/widgets/resources/details/ingress_details_item.dart
@@ -95,6 +95,8 @@ class IngressDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/job_details_item.dart
+++ b/lib/widgets/resources/details/job_details_item.dart
@@ -77,6 +77,8 @@ class JobDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: job.metadata?.namespace,
           selector: getSelector(job.spec!.selector),
         ),
@@ -86,6 +88,8 @@ class JobDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: job.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${job.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/namespace_details_item.dart
+++ b/lib/widgets/resources/details/namespace_details_item.dart
@@ -46,6 +46,8 @@ class NamespaceDetailsItem extends StatelessWidget
           resource: Resources.map['cronjobs']!.resource,
           path: Resources.map['cronjobs']!.path,
           scope: Resources.map['cronjobs']!.scope,
+          additionalPrinterColumns:
+              Resources.map['cronjobs']!.additionalPrinterColumns,
           namespace: item['metadata']['name'],
           selector: '',
         ),
@@ -55,6 +57,8 @@ class NamespaceDetailsItem extends StatelessWidget
           resource: Resources.map['deployments']!.resource,
           path: Resources.map['deployments']!.path,
           scope: Resources.map['deployments']!.scope,
+          additionalPrinterColumns:
+              Resources.map['deployments']!.additionalPrinterColumns,
           namespace: item['metadata']['name'],
           selector: '',
         ),
@@ -64,6 +68,8 @@ class NamespaceDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: item['metadata']['name'],
           selector: '',
         ),
@@ -73,6 +79,8 @@ class NamespaceDetailsItem extends StatelessWidget
           resource: Resources.map['statefulsets']!.resource,
           path: Resources.map['statefulsets']!.path,
           scope: Resources.map['statefulsets']!.scope,
+          additionalPrinterColumns:
+              Resources.map['statefulsets']!.additionalPrinterColumns,
           namespace: item['metadata']['name'],
           selector: '',
         ),
@@ -82,6 +90,8 @@ class NamespaceDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['name'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/networkpolicy_details_item.dart
+++ b/lib/widgets/resources/details/networkpolicy_details_item.dart
@@ -58,6 +58,8 @@ class NetworkPolicyDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: np.metadata?.namespace,
           selector: getSelector(np.spec?.podSelector),
         ),
@@ -67,6 +69,8 @@ class NetworkPolicyDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/node_details_item.dart
+++ b/lib/widgets/resources/details/node_details_item.dart
@@ -130,6 +130,8 @@ class NodeDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: null,
           selector: 'fieldSelector=spec.nodeName=${item['metadata']['name']}',
         ),
@@ -139,6 +141,8 @@ class NodeDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/persistentvolume_details_item.dart
+++ b/lib/widgets/resources/details/persistentvolume_details_item.dart
@@ -79,6 +79,8 @@ class PersistentVolumeDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/persistentvolumeclaim_details_item.dart
+++ b/lib/widgets/resources/details/persistentvolumeclaim_details_item.dart
@@ -86,6 +86,8 @@ class PersistentVolumeClaimDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/pod_details_item.dart
+++ b/lib/widgets/resources/details/pod_details_item.dart
@@ -267,6 +267,8 @@ class _PodDetailsItemState extends State<PodDetailsItem> {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: pod.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${pod.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/poddisruptionbudget_details_item.dart
+++ b/lib/widgets/resources/details/poddisruptionbudget_details_item.dart
@@ -82,6 +82,8 @@ class PodDisruptionBudgetDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector: getSelector(pdb.spec!.selector),
         ),
@@ -91,6 +93,8 @@ class PodDisruptionBudgetDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/replicaset_details_item.dart
+++ b/lib/widgets/resources/details/replicaset_details_item.dart
@@ -78,6 +78,8 @@ class ReplicaSetDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: replicaSet.metadata?.namespace,
           selector: getSelector(replicaSet.spec?.selector),
         ),
@@ -87,6 +89,8 @@ class ReplicaSetDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: replicaSet.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${replicaSet.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/role_details_item.dart
+++ b/lib/widgets/resources/details/role_details_item.dart
@@ -95,6 +95,8 @@ class RoleDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/rolebinding_details_item.dart
+++ b/lib/widgets/resources/details/rolebinding_details_item.dart
@@ -93,6 +93,8 @@ class RoleBindingDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/secret_details_item.dart
+++ b/lib/widgets/resources/details/secret_details_item.dart
@@ -142,6 +142,8 @@ class SecretDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/service_details_item.dart
+++ b/lib/widgets/resources/details/service_details_item.dart
@@ -100,6 +100,8 @@ class ServiceDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector: getMatchLabelsSelector(service.spec!.selector),
         ),
@@ -108,6 +110,8 @@ class ServiceDetailsItem extends StatelessWidget implements IDetailsItemWidget {
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/serviceaccount_details_item.dart
+++ b/lib/widgets/resources/details/serviceaccount_details_item.dart
@@ -83,6 +83,8 @@ class ServiceAccountDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/details/statefulset_details_item.dart
+++ b/lib/widgets/resources/details/statefulset_details_item.dart
@@ -106,6 +106,8 @@ class StatefulSetDetailsItem extends StatelessWidget
           resource: Resources.map['pods']!.resource,
           path: Resources.map['pods']!.path,
           scope: Resources.map['pods']!.scope,
+          additionalPrinterColumns:
+              Resources.map['pods']!.additionalPrinterColumns,
           namespace: statefulSet.metadata?.namespace,
           selector: getSelector(statefulSet.spec?.selector),
         ),
@@ -115,6 +117,8 @@ class StatefulSetDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: statefulSet.metadata?.namespace,
           selector:
               'fieldSelector=involvedObject.name=${statefulSet.metadata?.name ?? ''}',

--- a/lib/widgets/resources/details/storageclass_details_item.dart
+++ b/lib/widgets/resources/details/storageclass_details_item.dart
@@ -81,6 +81,8 @@ class StorageClassDetailsItem extends StatelessWidget
           resource: Resources.map['events']!.resource,
           path: Resources.map['events']!.path,
           scope: Resources.map['events']!.scope,
+          additionalPrinterColumns:
+              Resources.map['events']!.additionalPrinterColumns,
           namespace: item['metadata']['namespace'],
           selector:
               'fieldSelector=involvedObject.name=${item['metadata']['name']}',

--- a/lib/widgets/resources/list/clusterrolebinding_list_item.dart
+++ b/lib/widgets/resources/list/clusterrolebinding_list_item.dart
@@ -14,6 +14,7 @@ class ClusterRoleBindingListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class ClusterRoleBindingListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -39,6 +42,7 @@ class ClusterRoleBindingListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: clusterRoleBinding?.metadata?.name ?? '',
       namespace: null,
       info: [

--- a/lib/widgets/resources/list/configmap_list_item.dart
+++ b/lib/widgets/resources/list/configmap_list_item.dart
@@ -13,6 +13,7 @@ class ConfigMapListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class ConfigMapListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -37,6 +40,7 @@ class ConfigMapListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: configMap?.metadata?.name ?? '',
       namespace: configMap?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/cronjob_list_item.dart
+++ b/lib/widgets/resources/list/cronjob_list_item.dart
@@ -13,6 +13,7 @@ class CronJobListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class CronJobListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -40,6 +43,7 @@ class CronJobListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: cronJob?.metadata?.name ?? '',
       namespace: cronJob?.metadata?.namespace,
       info: info,

--- a/lib/widgets/resources/list/daemonset_list_item.dart
+++ b/lib/widgets/resources/list/daemonset_list_item.dart
@@ -13,6 +13,7 @@ class DaemonSetListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class DaemonSetListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -69,6 +72,7 @@ class DaemonSetListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: daemonSet?.metadata?.name ?? '',
       namespace: daemonSet?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/default_list_item.dart
+++ b/lib/widgets/resources/list/default_list_item.dart
@@ -12,6 +12,7 @@ class DefaultListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,7 +24,38 @@ class DefaultListItem extends StatelessWidget implements IListItemWidget {
   @override
   final ResourceScope scope;
   @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
+  @override
   final dynamic item;
+
+  List<String> _buildInfo(String? namespace, String age) {
+    if (additionalPrinterColumns.isEmpty) {
+      if (namespace != null) {
+        return [
+          'Namespace: $namespace',
+          'Age: $age',
+        ];
+      }
+
+      return [
+        'Age: $age',
+      ];
+    }
+
+    if (namespace != null) {
+      return [
+        'Namespace: $namespace',
+        ...additionalPrinterColumns
+            .map(
+                (e) => '${e.name}: ${getAdditionalPrinterColumnValue(e, item)}')
+            .toList(),
+      ];
+    }
+
+    return additionalPrinterColumns
+        .map((e) => '${e.name}: ${getAdditionalPrinterColumnValue(e, item)}')
+        .toList();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,16 +74,10 @@ class DefaultListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: name,
       namespace: namespace,
-      info: namespace != null
-          ? [
-              'Namespace: $namespace',
-              'Age: $age',
-            ]
-          : [
-              'Age: $age',
-            ],
+      info: _buildInfo(namespace, age),
     );
   }
 }

--- a/lib/widgets/resources/list/deployment_list_item.dart
+++ b/lib/widgets/resources/list/deployment_list_item.dart
@@ -13,6 +13,7 @@ class DeploymentListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class DeploymentListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -61,6 +64,7 @@ class DeploymentListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: deplyoment?.metadata?.name ?? '',
       namespace: deplyoment?.metadata?.namespace,
       info: info,

--- a/lib/widgets/resources/list/endpoint_list_item.dart
+++ b/lib/widgets/resources/list/endpoint_list_item.dart
@@ -13,6 +13,7 @@ class EndpointListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class EndpointListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -40,6 +43,7 @@ class EndpointListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: endpoint?.metadata?.name ?? '',
       namespace: endpoint?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/event_list_item.dart
+++ b/lib/widgets/resources/list/event_list_item.dart
@@ -13,6 +13,7 @@ class EventListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class EventListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -37,6 +40,7 @@ class EventListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: event?.metadata.name ?? '',
       namespace: event?.metadata.namespace,
       info: info,

--- a/lib/widgets/resources/list/horizontalpodautoscaler_list_item.dart
+++ b/lib/widgets/resources/list/horizontalpodautoscaler_list_item.dart
@@ -14,6 +14,7 @@ class HorizontalPodAutoscalerListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class HorizontalPodAutoscalerListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -54,6 +57,7 @@ class HorizontalPodAutoscalerListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: hpa?.metadata?.name ?? '',
       namespace: hpa?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/ingress_list_item.dart
+++ b/lib/widgets/resources/list/ingress_list_item.dart
@@ -13,6 +13,7 @@ class IngressListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class IngressListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -41,6 +44,7 @@ class IngressListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: ingress?.metadata?.name ?? '',
       namespace: ingress?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/job_list_item.dart
+++ b/lib/widgets/resources/list/job_list_item.dart
@@ -13,6 +13,7 @@ class JobListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class JobListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -38,6 +41,7 @@ class JobListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: job?.metadata?.name ?? '',
       namespace: job?.metadata?.namespace,
       info: info,

--- a/lib/widgets/resources/list/list_item.dart
+++ b/lib/widgets/resources/list/list_item.dart
@@ -19,13 +19,15 @@ abstract class IListItemWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.item,
   });
 
-  final String? title;
-  final String? resource;
-  final String? path;
-  final ResourceScope? scope;
+  final String title;
+  final String resource;
+  final String path;
+  final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final dynamic item;
 }
 
@@ -36,6 +38,7 @@ class ListItemWidget extends StatelessWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.name,
     required this.namespace,
     required this.info,
@@ -47,6 +50,7 @@ class ListItemWidget extends StatelessWidget {
   final String resource;
   final String path;
   final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final String name;
   final String? namespace;
   final List<String> info;
@@ -125,6 +129,7 @@ class ListItemWidget extends StatelessWidget {
               resource: resource,
               path: path,
               scope: scope,
+              additionalPrinterColumns: additionalPrinterColumns,
               name: name,
               namespace: namespace,
             ),

--- a/lib/widgets/resources/list/namespace_list_item.dart
+++ b/lib/widgets/resources/list/namespace_list_item.dart
@@ -13,6 +13,7 @@ class NamespaceListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class NamespaceListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -37,6 +40,7 @@ class NamespaceListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: namespace?.metadata?.name ?? '',
       namespace: null,
       info: [

--- a/lib/widgets/resources/list/networkpolicy_list_item.dart
+++ b/lib/widgets/resources/list/networkpolicy_list_item.dart
@@ -13,6 +13,7 @@ class NetworkPolicyListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class NetworkPolicyListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -39,6 +42,7 @@ class NetworkPolicyListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: np?.metadata?.name ?? '',
       namespace: np?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/node_list_item.dart
+++ b/lib/widgets/resources/list/node_list_item.dart
@@ -13,6 +13,7 @@ class NodeListItem extends StatelessWidget implements IListItemWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.item,
     required this.metrics,
   }) : super(key: key);
@@ -25,6 +26,8 @@ class NodeListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
   final dynamic metrics;
@@ -59,6 +62,7 @@ class NodeListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: node?.metadata?.name ?? '',
       namespace: null,
       info: info,

--- a/lib/widgets/resources/list/persistentvolume_list_item.dart
+++ b/lib/widgets/resources/list/persistentvolume_list_item.dart
@@ -14,6 +14,7 @@ class PersistentVolumeListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class PersistentVolumeListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -48,6 +51,7 @@ class PersistentVolumeListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: pv?.metadata?.name ?? '',
       namespace: null,
       info: [

--- a/lib/widgets/resources/list/persistentvolumeclaim_list_item.dart
+++ b/lib/widgets/resources/list/persistentvolumeclaim_list_item.dart
@@ -14,6 +14,7 @@ class PersistentVolumeClaimListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class PersistentVolumeClaimListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -42,6 +45,7 @@ class PersistentVolumeClaimListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: pvc?.metadata?.name ?? '',
       namespace: pvc?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/pod_list_item.dart
+++ b/lib/widgets/resources/list/pod_list_item.dart
@@ -12,6 +12,7 @@ class PodListItem extends StatelessWidget implements IListItemWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.item,
     required this.metrics,
   }) : super(key: key);
@@ -24,6 +25,8 @@ class PodListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
   final dynamic metrics;
@@ -48,6 +51,7 @@ class PodListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: pod?.metadata?.name ?? '',
       namespace: pod?.metadata?.namespace,
       info: info,

--- a/lib/widgets/resources/list/poddisruptionbudget_list_item.dart
+++ b/lib/widgets/resources/list/poddisruptionbudget_list_item.dart
@@ -14,6 +14,7 @@ class PodDisruptionBudgetListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class PodDisruptionBudgetListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -57,6 +60,7 @@ class PodDisruptionBudgetListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: pdb?.metadata?.name ?? '',
       namespace: pdb?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/replicaset_list_item.dart
+++ b/lib/widgets/resources/list/replicaset_list_item.dart
@@ -13,6 +13,7 @@ class ReplicaSetListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class ReplicaSetListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -55,6 +58,7 @@ class ReplicaSetListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: replicaSet?.metadata?.name ?? '',
       namespace: replicaSet?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/rolebinding_list_item.dart
+++ b/lib/widgets/resources/list/rolebinding_list_item.dart
@@ -13,6 +13,7 @@ class RoleBindingListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class RoleBindingListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -38,6 +41,7 @@ class RoleBindingListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: roleBinding?.metadata?.name ?? '',
       namespace: roleBinding?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/secret_list_item.dart
+++ b/lib/widgets/resources/list/secret_list_item.dart
@@ -13,6 +13,7 @@ class SecretListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class SecretListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -53,6 +56,7 @@ class SecretListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: secret?.metadata?.name ?? '',
       namespace: secret?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/service_list_item.dart
+++ b/lib/widgets/resources/list/service_list_item.dart
@@ -13,6 +13,7 @@ class ServiceListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class ServiceListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -45,6 +48,7 @@ class ServiceListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: service?.metadata?.name ?? '',
       namespace: service?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/serviceaccount_list_item.dart
+++ b/lib/widgets/resources/list/serviceaccount_list_item.dart
@@ -14,6 +14,7 @@ class ServiceAccountListItem extends StatelessWidget
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -24,6 +25,8 @@ class ServiceAccountListItem extends StatelessWidget
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -38,6 +41,7 @@ class ServiceAccountListItem extends StatelessWidget
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: sa?.metadata?.name ?? '',
       namespace: sa?.metadata?.namespace,
       info: [

--- a/lib/widgets/resources/list/statefulset_list_item.dart
+++ b/lib/widgets/resources/list/statefulset_list_item.dart
@@ -13,6 +13,7 @@ class StatefulSetListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class StatefulSetListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -59,6 +62,7 @@ class StatefulSetListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: sts?.metadata?.name ?? '',
       namespace: sts?.metadata?.namespace,
       info: info,

--- a/lib/widgets/resources/list/storageclass_list_item.dart
+++ b/lib/widgets/resources/list/storageclass_list_item.dart
@@ -13,6 +13,7 @@ class StorageClassListItem extends StatelessWidget implements IListItemWidget {
     required this.path,
     required this.scope,
     required this.item,
+    required this.additionalPrinterColumns,
   }) : super(key: key);
 
   @override
@@ -23,6 +24,8 @@ class StorageClassListItem extends StatelessWidget implements IListItemWidget {
   final String path;
   @override
   final ResourceScope scope;
+  @override
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   @override
   final dynamic item;
 
@@ -43,6 +46,7 @@ class StorageClassListItem extends StatelessWidget implements IListItemWidget {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       name: sc?.metadata?.name ?? '',
       namespace: null,
       info: [

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kubenav/widgets/resources/details/details_item_additional_printer_columns.dart';
 
 import 'package:provider/provider.dart';
 
@@ -41,6 +42,7 @@ class ResourcesDetails extends StatefulWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.name,
     required this.namespace,
   }) : super(key: key);
@@ -49,6 +51,7 @@ class ResourcesDetails extends StatefulWidget {
   final String resource;
   final String path;
   final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final String name;
   final String? namespace;
 
@@ -109,6 +112,8 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
         resource: Resources.map['events']!.resource,
         path: Resources.map['events']!.path,
         scope: Resources.map['events']!.scope,
+        additionalPrinterColumns:
+            Resources.map['events']!.additionalPrinterColumns,
         namespace: item['metadata']['namespace'],
         selector:
             'fieldSelector=involvedObject.name=${item['metadata']['name']}',
@@ -468,6 +473,7 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
                                     widget.resource,
                                     widget.path,
                                     widget.scope,
+                                    widget.additionalPrinterColumns,
                                     widget.name,
                                     widget.namespace,
                                   );
@@ -485,6 +491,11 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
                           ],
                         ),
                         DetailsItemMetadata(
+                          item: snapshot.data,
+                        ),
+                        DetailsItemAdditionalPrinterColumns(
+                          additionalPrinterColumns:
+                              widget.additionalPrinterColumns,
                           item: snapshot.data,
                         ),
                         DetailsItemConditions(

--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -48,6 +48,7 @@ class Resources extends StatelessWidget {
                       scope: value.scope,
                       namespace: null,
                       selector: null,
+                      additionalPrinterColumns: value.additionalPrinterColumns,
                     ),
                   );
                 }

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -46,6 +46,7 @@ class ResourcesList extends StatefulWidget {
     required this.resource,
     required this.path,
     required this.scope,
+    required this.additionalPrinterColumns,
     required this.namespace,
     required this.selector,
   });
@@ -54,6 +55,7 @@ class ResourcesList extends StatefulWidget {
   final String resource;
   final String path;
   final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final String? namespace;
   final String? selector;
 
@@ -162,6 +164,7 @@ class _ResourcesListState extends State<ResourcesList> {
     String resource,
     String path,
     ResourceScope scope,
+    List<AdditionalPrinterColumns> additionalPrinterColumns,
     dynamic item,
     dynamic metrics,
   ) {
@@ -174,6 +177,7 @@ class _ResourcesListState extends State<ResourcesList> {
         resource,
         path,
         scope,
+        additionalPrinterColumns,
         item,
         metrics,
       );
@@ -184,6 +188,7 @@ class _ResourcesListState extends State<ResourcesList> {
       resource: resource,
       path: path,
       scope: scope,
+      additionalPrinterColumns: additionalPrinterColumns,
       item: item,
     );
   }
@@ -481,6 +486,7 @@ class _ResourcesListState extends State<ResourcesList> {
                                     widget.resource,
                                     widget.path,
                                     widget.scope,
+                                    widget.additionalPrinterColumns,
                                     null,
                                     clustersRepository
                                         .getCluster(
@@ -514,6 +520,7 @@ class _ResourcesListState extends State<ResourcesList> {
                                 widget.resource,
                                 widget.path,
                                 widget.scope,
+                                widget.additionalPrinterColumns,
                                 _getFilteredItems(snapshot.data!.items)[index],
                                 snapshot.data!.metrics,
                               );

--- a/lib/widgets/resources/resources_list_crds.dart
+++ b/lib/widgets/resources/resources_list_crds.dart
@@ -69,16 +69,28 @@ class _ResourcesListCRDsState extends State<ResourcesListCRDs> {
       final List<Resource> resources = [];
       for (final crd in crds.items) {
         for (final version in crd.spec.versions) {
-          resources.add(Resource(
-            resourceType: ResourceType.cluster,
-            title: crd.spec.names.kind,
-            description: '${crd.spec.group}/${version.name}',
-            resource: crd.spec.names.plural,
-            path: '/apis/${crd.spec.group}/${version.name}',
-            scope: getResourceScopeFromString(crd.spec.scope),
-            template: '',
-            buildDetailsItem: (dynamic item) => const Text('test'),
-          ));
+          resources.add(
+            Resource(
+              resourceType: ResourceType.cluster,
+              title: crd.spec.names.kind,
+              description: '${crd.spec.group}/${version.name}',
+              resource: crd.spec.names.plural,
+              path: '/apis/${crd.spec.group}/${version.name}',
+              scope: getResourceScopeFromString(crd.spec.scope),
+              template: '',
+              additionalPrinterColumns: version.additionalPrinterColumns
+                  .where((e) => e.priority == null || e.priority == 0)
+                  .map(
+                    (e) => AdditionalPrinterColumns(
+                      description: e.description ?? '',
+                      jsonPath: e.jsonPath,
+                      name: e.name,
+                      type: e.type,
+                    ),
+                  )
+                  .toList(),
+            ),
+          );
         }
       }
       return resources;
@@ -136,6 +148,7 @@ class _ResourcesListCRDsState extends State<ResourcesListCRDs> {
               scope: resource.scope,
               namespace: null,
               selector: null,
+              additionalPrinterColumns: resource.additionalPrinterColumns,
             ),
           );
         },

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -425,10 +425,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -560,10 +558,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -589,10 +585,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -425,8 +425,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -558,8 +560,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -585,8 +589,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 75AP6HWLUD;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)io.kubenav.kubenav</string>
-	</array>
 </dict>
 </plist>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)io.kubenav.kubenav</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)io.kubenav.kubenav</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)io.kubenav.kubenav</string>
+	</array>
+</dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -303,6 +303,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.7.0"
+  json_path:
+    dependency: "direct main"
+    description:
+      name: json_path
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.2"
   jwt_decode:
     dependency: "direct main"
     description:
@@ -520,6 +527,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.1"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_secure_storage: ^7.0.1
   highlight: ^0.7.0
   http: ^0.13.4
+  json_path: ^0.4.2
   jwt_decode: ^0.3.1
   local_auth: ^2.1.2
   package_info_plus: ^3.0.2


### PR DESCRIPTION
We are now supporting the additionalPrinterColumn field from CRDs, so that we can show the specified columns within a List of CRs and in the details view of a CR.

We forgot to add the Keychain Sharing capability, so that the users settings and bookmarks were not saved on macOS. The capability is added now so that the app settings and bookmarks are saved properly.