### PR TITLE
Rework Storage

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -128,8 +128,6 @@ jobs:
           # Required for Flutter
           sudo apt-get update -y
           sudo apt-get install -y ninja-build libgtk-3-dev
-          # Required for Flutter Secure Storage
-          sudo apt-get install -y libsecret-1-dev libjsoncpp-dev libsecret-1-0
           # Required for AppImage
           sudo add-apt-repository universe
           sudo apt install libfuse2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
+  - shared_preferences_ios (0.0.1):
+    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -23,6 +25,7 @@ DEPENDENCIES:
   - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
@@ -40,6 +43,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
+  shared_preferences_ios:
+    :path: ".symlinks/plugins/shared_preferences_ios/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -51,6 +56,7 @@ SPEC CHECKSUMS:
   local_auth_ios: 0d333dde7780f669e66f19d2ff6005f3ea84008d
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
 PODFILE CHECKSUM: 4edb9fe21ef782edabd91e17f4b0817ee2c836b0

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:kubenav/utils/storage.dart';
 import 'package:provider/provider.dart';
 import 'package:window_size/window_size.dart';
 
@@ -28,7 +29,8 @@ void main() async {
     setWindowMaxSize(Size.infinite);
   }
 
-  FlutterNativeSplash.remove();
+  await Storage().init();
+
   runApp(const App());
 }
 

--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:kubenav/utils/storage.dart';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:local_auth/local_auth.dart';
 
 import 'package:kubenav/utils/constants.dart';
@@ -19,7 +19,6 @@ import 'package:kubenav/utils/logger.dart';
 /// The settings of the user are stored via the Flutter Secure Storage package
 /// and must be loaded by calling the [init] function as early as possible.
 class AppRepository with ChangeNotifier {
-  final _secureStorage = const FlutterSecureStorage();
   int _currentPageIndex = Constants.pageIndexHome;
   bool _isAuthenticated = false;
   AppRepositorySettings _settings = AppRepositorySettings.fromDefault();
@@ -40,9 +39,9 @@ class AppRepository with ChangeNotifier {
   /// and should be callled every time the user changes his app settings.
   Future<void> _save() async {
     try {
-      await _secureStorage.write(
-        key: 'kubenav-settings',
-        value: json.encode(_settings.toJson()),
+      await Storage().write(
+        'kubenav-settings',
+        json.encode(_settings.toJson()),
       );
     } catch (err) {
       Logger.log(
@@ -62,7 +61,7 @@ class AppRepository with ChangeNotifier {
   /// authenticated before he can continue using the app.
   Future<void> init() async {
     try {
-      final data = await _secureStorage.read(key: 'kubenav-settings');
+      final data = await Storage().read('kubenav-settings');
       if (data != null) {
         _settings = AppRepositorySettings.fromJson(json.decode(data));
       }

--- a/lib/repositories/bookmarks_repository.dart
+++ b/lib/repositories/bookmarks_repository.dart
@@ -2,22 +2,20 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import 'package:kubenav/models/resource.dart';
 import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/storage.dart';
 
 class BookmarksRepository with ChangeNotifier {
-  final _secureStorage = const FlutterSecureStorage();
   List<Bookmark> _bookmarks = [];
 
   List<Bookmark> get bookmarks => _bookmarks;
 
   Future<void> _save() async {
     try {
-      await _secureStorage.write(
-        key: 'kubenav-bookmarks',
-        value: json.encode(_bookmarks.map((e) => e.toJson()).toList()),
+      await Storage().write(
+        'kubenav-bookmarks',
+        json.encode(_bookmarks.map((e) => e.toJson()).toList()),
       );
     } catch (err) {
       Logger.log(
@@ -30,7 +28,7 @@ class BookmarksRepository with ChangeNotifier {
 
   Future<void> init() async {
     try {
-      final data = await _secureStorage.read(key: 'kubenav-bookmarks');
+      final data = await Storage().read('kubenav-bookmarks');
       if (data != null) {
         _bookmarks = List<Bookmark>.from(
             json.decode(data).map((e) => Bookmark.fromJson(e)));

--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 
 import 'package:kubenav/models/cluster.dart';
@@ -14,6 +13,7 @@ import 'package:kubenav/services/providers/google_service.dart';
 import 'package:kubenav/services/providers/oidc_service.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/storage.dart';
 
 /// The [ClustersRepository] contains all the users configured [clusters],
 /// [providers] and the users [activeClusterId]. The repository is initialized
@@ -21,7 +21,6 @@ import 'package:kubenav/utils/logger.dart';
 /// to it. Each time a user modifys an entry in the repository all subscribed
 /// widgets are notified and we [_save] the changes back to our storage backend.
 class ClustersRepository with ChangeNotifier {
-  final _secureStorage = const FlutterSecureStorage();
   List<Cluster> _clusters = [];
   List<ClusterProvider> _providers = [];
   String _activeClusterId = '';
@@ -44,9 +43,9 @@ class ClustersRepository with ChangeNotifier {
           'ClustersRepository _save',
           'Call save function',
         );
-        await _secureStorage.write(
-          key: 'kubenavClustersRepository',
-          value: json.encode(
+        await Storage().write(
+          'kubenavClustersRepository',
+          json.encode(
             ClustersRepositoryStorage(
               clusters: _clusters,
               providers: _providers,
@@ -95,8 +94,7 @@ class ClustersRepository with ChangeNotifier {
         /// provider configs in the secure storage. If we found saved clusters
         /// we also set the active cluster to the one which was saved in an
         /// older session.
-        final storedData =
-            await _secureStorage.read(key: 'kubenavClustersRepository');
+        final storedData = await Storage().read('kubenavClustersRepository');
         if (storedData != null) {
           final parsedStoredData =
               ClustersRepositoryStorage.fromJson(json.decode(storedData));

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Storage {
+  static final Storage _instance = Storage._internal();
+
+  factory Storage() {
+    return _instance;
+  }
+
+  Storage._internal();
+
+  FlutterSecureStorage? _mobileStorage;
+  SharedPreferences? _desktopStorage;
+
+  Future<void> init() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      _mobileStorage = const FlutterSecureStorage();
+    } else {
+      _desktopStorage = await SharedPreferences.getInstance();
+    }
+  }
+
+  Future<void> write(String key, String value) async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      await _mobileStorage?.write(key: key, value: value);
+    } else {
+      await _desktopStorage?.setString(key, value);
+    }
+  }
+
+  Future<String?> read(String key) async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await _mobileStorage?.read(key: key);
+    } else {
+      return _desktopStorage?.getString(key);
+    }
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_size/window_size_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
-  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  flutter_secure_storage_linux
   url_launcher_linux
   window_size
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,16 @@
 import FlutterMacOS
 import Foundation
 
-import flutter_secure_storage_macos
 import package_info_plus
 import path_provider_macos
+import shared_preferences_macos
 import url_launcher_macos
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - flutter_secure_storage_macos (6.1.1):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_macos (0.0.1):
+    - FlutterMacOS
+  - shared_preferences_macos (0.0.1):
     - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
@@ -12,32 +12,32 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
-  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
+  - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_size (from `Flutter/ephemeral/.symlinks/plugins/window_size/macos`)
 
 EXTERNAL SOURCES:
-  flutter_secure_storage_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
+  shared_preferences_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_size:
     :path: Flutter/ephemeral/.symlinks/plugins/window_size/macos
 
 SPEC CHECKSUMS:
-  flutter_secure_storage_macos: 75c8cadfdba05ca007c0fa4ea0c16e5cf85e521b
   FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
+  shared_preferences_macos: a64dc611287ed6cbe28fd1297898db1336975727
   url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
   window_size: 339dafa0b27a95a62a843042038fa6c3c48de195
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -191,24 +191,12 @@ packages:
   flutter_secure_storage:
     dependency: "direct main"
     description:
-      name: flutter_secure_storage
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: flutter_secure_storage
+      ref: kubenav
+      resolved-ref: "1ffc324534b89d4986b6c62642cab8931946c005"
+      url: "https://github.com/kubenav/flutter_secure_storage"
+    source: git
     version: "7.0.1"
-  flutter_secure_storage_linux:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.2"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -216,20 +204,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
-  flutter_secure_storage_web:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  flutter_secure_storage_windows:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -534,6 +508,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.15"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.14"
+  shared_preferences_ios:
+    dependency: transitive
+    description:
+      name: shared_preferences_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,12 @@ dependencies:
   flutter_highlight: ^0.7.0
   flutter_markdown: ^0.6.12
   flutter_native_splash: ^2.2.9
-  flutter_secure_storage: ^7.0.1
+  # flutter_secure_storage: ^7.0.1
+  flutter_secure_storage:
+    git:
+      url: https://github.com/kubenav/flutter_secure_storage
+      path: flutter_secure_storage
+      ref: kubenav
   highlight: ^0.7.0
   http: ^0.13.4
   json_path: ^0.4.2
@@ -50,6 +55,7 @@ dependencies:
   package_info_plus: ^3.0.2
   path_provider: ^2.0.9
   provider: ^6.0.4
+  shared_preferences: ^2.0.15
   url_launcher: ^6.0.20
   uuid: ^3.0.7
   web_socket_channel: ^2.1.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,11 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_size/window_size_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  flutter_secure_storage_windows
   local_auth_windows
   url_launcher_windows
   window_size


### PR DESCRIPTION
We are now using the Flutter Secure Storage package only on iOS and Android. On macOS, Linux and Windows we are using now the shared preferences package to store the users settings and bookmarks.

To only use the Flutter Secure Storage package on iOS and Android we are using a fork of the package where we removed the other implementations: https://github.com/kubenav/flutter_secure_storage/tree/kubenav

We decided to not use the package for desktop, because it was not working correctly for macOS, because the required provisioning profile for the Keychain Sharing capability could not be added in the GitHub Action :-(.

If someone nows how we can build the app with the correct provisioning profile via our GitHub Action we can switch back to the Flutter Secure Storage package on desktop.