### PR TITLE
Use FutureBuilder to Fetch Namespaces

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:kubenav/utils/storage.dart';
 import 'package:provider/provider.dart';
 import 'package:window_size/window_size.dart';
 
@@ -15,6 +14,7 @@ import 'package:kubenav/repositories/terminal_repository.dart';
 import 'package:kubenav/services/kubenav_desktop.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/utils/storage.dart';
 import 'package:kubenav/widgets/home/home.dart';
 
 void main() async {

--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -2,12 +2,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:kubenav/utils/storage.dart';
 
 import 'package:local_auth/local_auth.dart';
 
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/storage.dart';
 
 /// The [AppRepository] is responsible for managing the users app settings and
 /// some global values for the current user session, like the active tab for the

--- a/lib/utils/resources/general.dart
+++ b/lib/utils/resources/general.dart
@@ -1,7 +1,8 @@
+import 'package:json_path/json_path.dart';
+
 import 'package:kubenav/models/kubernetes/io_k8s_api_rbac_v1_policy_rule.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_apimachinery_pkg_apis_meta_v1_label_selector.dart';
 import 'package:kubenav/models/resource.dart';
-import 'package:json_path/json_path.dart';
 
 /// [getAge] returns the age of a Kubernetes resources in a human readable format. This is mostly used to dertermine the
 /// age of a resource via the `metadata.creationTimestamp` field. If the given [timestamp] is `null` we return a dash as

--- a/lib/widgets/resources/details/details_item_additional_printer_columns.dart
+++ b/lib/widgets/resources/details/details_item_additional_printer_columns.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:kubenav/models/resource.dart';
 
+import 'package:kubenav/models/resource.dart';
 import 'package:kubenav/utils/resources/general.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/resources/details/details_item.dart';

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:kubenav/widgets/resources/details/details_item_additional_printer_columns.dart';
 
 import 'package:provider/provider.dart';
 
@@ -15,6 +14,7 @@ import 'package:kubenav/widgets/resources/details/details_create_job.dart';
 import 'package:kubenav/widgets/resources/details/details_delete_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_edit_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_get_logs.dart';
+import 'package:kubenav/widgets/resources/details/details_item_additional_printer_columns.dart';
 import 'package:kubenav/widgets/resources/details/details_item_conditions.dart';
 import 'package:kubenav/widgets/resources/details/details_item_metadata.dart';
 import 'package:kubenav/widgets/resources/details/details_live_metrics_containers.dart';

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -11,7 +10,6 @@ import 'package:kubenav/services/kubernetes_service.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
 import 'package:kubenav/utils/helpers.dart';
-import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 import 'package:kubenav/widgets/shared/app_error_widget.dart';
@@ -32,15 +30,10 @@ class AppNamespacesWidget extends StatefulWidget {
 }
 
 class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
-  bool _isLoading = false;
-  String _error = '';
-  List<IoK8sApiCoreV1Namespace> _namespaces = <IoK8sApiCoreV1Namespace>[];
+  late Future<List<IoK8sApiCoreV1Namespace>> _futureFetchNamespaces;
 
-  /// [_getNamespaces] executes a request against the Kubernetes API of the
-  /// currently active cluster, to load all namespaces. If the API returns a
-  /// list of namespaces, we set the [_namespaces] state. If the API call
-  /// returns an error we set the [_error] state.
-  Future<void> _getNamespaces() async {
+  /// [_fetchNamespaces] fetches all Namespaces of the currently active cluster.
+  Future<List<IoK8sApiCoreV1Namespace>> _fetchNamespaces() async {
     AppRepository appRepository = Provider.of<AppRepository>(
       context,
       listen: false,
@@ -50,55 +43,17 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
       listen: false,
     );
 
-    try {
-      setState(() {
-        _isLoading = true;
-        _error = '';
-      });
+    final cluster = await clustersRepository.getClusterWithCredentials(
+      clustersRepository.activeClusterId,
+    );
 
-      final cluster = await clustersRepository.getClusterWithCredentials(
-        clustersRepository.activeClusterId,
-      );
+    final result = await KubernetesService(
+      cluster: cluster!,
+      proxy: appRepository.settings.proxy,
+      timeout: appRepository.settings.timeout,
+    ).getRequest('/api/v1/namespaces');
 
-      final result = await KubernetesService(
-        cluster: cluster!,
-        proxy: appRepository.settings.proxy,
-        timeout: appRepository.settings.timeout,
-      ).getRequest('/api/v1/namespaces');
-
-      Logger.log(
-        'AppNamespacesWidget _getNamespaces',
-        'Namespaces were returned successfully',
-        result,
-      );
-
-      final namespaceList = IoK8sApiCoreV1NamespaceList.fromJson(result);
-      setState(() {
-        _isLoading = false;
-        _namespaces = namespaceList!.items;
-      });
-    } on PlatformException catch (err) {
-      Logger.log(
-        'AppNamespacesWidget _getNamespaces',
-        'Could not get namespaces',
-        'Code: ${err.code}\nMessage: ${err.message}\nDetails: ${err.details.toString()}',
-      );
-      setState(() {
-        _isLoading = false;
-        _error =
-            'Code: ${err.code}\nMessage: ${err.message}\nDetails: ${err.details.toString()}';
-      });
-    } catch (err) {
-      Logger.log(
-        'AppNamespacesWidget _getNamespaces',
-        'Could not get namespaces',
-        err,
-      );
-      setState(() {
-        _isLoading = false;
-        _error = err.toString();
-      });
-    }
+    return IoK8sApiCoreV1NamespaceList.fromJson(result)!.items;
   }
 
   /// [_changeNamespace] sets the namespace of the currently active cluster to
@@ -282,126 +237,21 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
     ];
   }
 
-  /// [_buildContent] returns the content of the namespaces modal. If
-  /// [_isLoading] is `true` while we are loading the namespaces of the cluster
-  /// we display, the users favorite namespaces and a loading indicator. When an
-  /// [_error] was returned during the API call to get all namespaces, we show
-  /// the users favorite namespaces and the error message. If we were able to
-  /// get the list of namespaces, we show the users favorite namespaces and the
-  /// list of retrieved namespaces.
-  Widget _buildContent(BuildContext context) {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    setState(() {
+      _futureFetchNamespaces = _fetchNamespaces();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
     );
 
-    if (_isLoading) {
-      return ListView(
-        children: [
-          ..._buildFavoriteNamespace(context),
-          const Center(
-            child: CircularProgressIndicator(
-              color: Constants.colorPrimary,
-            ),
-          ),
-        ],
-      );
-    }
-
-    if (_error != '') {
-      return ListView(
-        children: [
-          ..._buildFavoriteNamespace(context),
-          Wrap(
-            children: [
-              AppErrorWidget(
-                message: 'Could not load Namespaces',
-                details: _error,
-                icon: CustomIcons.namespaces,
-              ),
-            ],
-          ),
-        ],
-      );
-    }
-
-    return ListView(
-      children: [
-        ..._buildFavoriteNamespace(context),
-        ...List.generate(
-          _namespaces.length,
-          (index) {
-            final name = _namespaces[index].metadata?.name;
-
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
-              ),
-              padding: const EdgeInsets.all(12.0),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).shadowColor,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).cardColor,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
-              ),
-              child: InkWell(
-                onTap: () {
-                  _changeNamespace(context, name ?? 'default');
-                },
-                child: Row(
-                  children: [
-                    Icon(
-                      name != null &&
-                              name ==
-                                  clustersRepository
-                                      .getCluster(
-                                          clustersRepository.activeClusterId)!
-                                      .namespace
-                          ? Icons.radio_button_checked
-                          : Icons.radio_button_unchecked,
-                      size: 24,
-                      color: Constants.colorPrimary,
-                    ),
-                    const SizedBox(width: Constants.spacingSmall),
-                    Expanded(
-                      flex: 1,
-                      child: Text(
-                        name ?? '',
-                        style: noramlTextStyle(
-                          context,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
-      ],
-    );
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _getNamespaces();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return AppBottomSheetWidget(
       title: 'Namespaces',
       subtitle: 'Select the active namespace',
@@ -414,7 +264,113 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: _buildContent(context),
+      child: FutureBuilder(
+        future: _futureFetchNamespaces,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<IoK8sApiCoreV1Namespace>> snapshot,
+        ) {
+          switch (snapshot.connectionState) {
+            case ConnectionState.none:
+            case ConnectionState.waiting:
+              return ListView(
+                children: [
+                  ..._buildFavoriteNamespace(context),
+                  const Center(
+                    child: CircularProgressIndicator(
+                      color: Constants.colorPrimary,
+                    ),
+                  ),
+                ],
+              );
+            default:
+              if (snapshot.hasError) {
+                return ListView(
+                  children: [
+                    ..._buildFavoriteNamespace(context),
+                    Wrap(
+                      children: [
+                        AppErrorWidget(
+                          message: 'Could not load Namespaces',
+                          details: snapshot.error.toString(),
+                          icon: CustomIcons.namespaces,
+                        ),
+                      ],
+                    ),
+                  ],
+                );
+              }
+
+              return ListView(
+                children: [
+                  ..._buildFavoriteNamespace(context),
+                  ...List.generate(
+                    snapshot.data!.length,
+                    (index) {
+                      final name = snapshot.data![index].metadata?.name;
+
+                      return Container(
+                        margin: const EdgeInsets.only(
+                          top: Constants.spacingSmall,
+                          bottom: Constants.spacingSmall,
+                          left: Constants.spacingExtraSmall,
+                          right: Constants.spacingExtraSmall,
+                        ),
+                        padding: const EdgeInsets.all(12.0),
+                        decoration: BoxDecoration(
+                          boxShadow: [
+                            BoxShadow(
+                              color: Theme.of(context).shadowColor,
+                              blurRadius: Constants.sizeBorderBlurRadius,
+                              spreadRadius: Constants.sizeBorderSpreadRadius,
+                              offset: const Offset(0.0, 0.0),
+                            ),
+                          ],
+                          color: Theme.of(context).cardColor,
+                          borderRadius: const BorderRadius.all(
+                            Radius.circular(Constants.sizeBorderRadius),
+                          ),
+                        ),
+                        child: InkWell(
+                          onTap: () {
+                            _changeNamespace(context, name ?? 'default');
+                          },
+                          child: Row(
+                            children: [
+                              Icon(
+                                name != null &&
+                                        name ==
+                                            clustersRepository
+                                                .getCluster(clustersRepository
+                                                    .activeClusterId)!
+                                                .namespace
+                                    ? Icons.radio_button_checked
+                                    : Icons.radio_button_unchecked,
+                                size: 24,
+                                color: Constants.colorPrimary,
+                              ),
+                              const SizedBox(width: Constants.spacingSmall),
+                              Expanded(
+                                flex: 1,
+                                child: Text(
+                                  name ?? '',
+                                  style: noramlTextStyle(
+                                    context,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              );
+          }
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
Instead of our custom logic to fetch the list of all available namespaces in a cluster we are now using a FutureBuilder in the AppNamespacesWidget. This is more aligned with the way of fetching data in other widgets where we are also using a FutureBuilder.