### PR TITLE
Improve Cursor Style and Other Fixes

### DIFF
--- a/lib/utils/showmodal.dart
+++ b/lib/utils/showmodal.dart
@@ -58,13 +58,6 @@ void showSnackbar(BuildContext context, String title, String message) {
           ),
         ],
       ),
-      action: SnackBarAction(
-        label: 'Dissmiss',
-        textColor: theme(context).colorMessageForeground,
-        onPressed: () {
-          ScaffoldMessenger.of(context).hideCurrentSnackBar();
-        },
-      ),
     ),
   );
 }

--- a/lib/widgets/home/overview/overview_metrics.dart
+++ b/lib/widgets/home/overview/overview_metrics.dart
@@ -30,41 +30,44 @@ class OverviewMetrics extends StatelessWidget {
     IconData icon, [
     void Function()? onTap,
   ]) {
-    return InkWell(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.all(
-          Constants.spacingMiddle,
-        ),
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: theme(context).colorShadow,
-              blurRadius: Constants.sizeBorderBlurRadius,
-              spreadRadius: Constants.sizeBorderSpreadRadius,
-              offset: const Offset(0.0, 0.0),
-            ),
-          ],
-          color: theme(context).colorCard,
-          borderRadius: const BorderRadius.all(
-            Radius.circular(Constants.sizeBorderRadius),
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.all(
+            Constants.spacingMiddle,
           ),
-        ),
-        child: Column(
-          children: [
-            Icon(
-              icon,
-              color: theme(context).colorPrimary,
-              size: 64,
-            ),
-            const SizedBox(height: Constants.spacingSmall),
-            Text(
-              title,
-              style: primaryTextStyle(
-                context,
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: theme(context).colorShadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
+            ],
+            color: theme(context).colorCard,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
             ),
-          ],
+          ),
+          child: Column(
+            children: [
+              Icon(
+                icon,
+                color: theme(context).colorPrimary,
+                size: 64,
+              ),
+              const SizedBox(height: Constants.spacingSmall),
+              Text(
+                title,
+                style: primaryTextStyle(
+                  context,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_get_logs.dart
+++ b/lib/widgets/resources/details/details_get_logs.dart
@@ -213,10 +213,7 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );
@@ -262,10 +259,7 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );

--- a/lib/widgets/resources/details/details_item.dart
+++ b/lib/widgets/resources/details/details_item.dart
@@ -58,19 +58,17 @@ class DetailsItemWidget extends StatelessWidget {
         child: Wrap(
           children: List.generate(
             values.length,
-            (index) => InkWell(
-              onTap: () {
-                if (onTap != null) {
-                  onTap(index);
-                } else {
-                  showSnackbar(context, name, values[index]);
-                }
-              },
-              child: Container(
-                margin: const EdgeInsets.all(Constants.spacingExtraSmall),
-                child: Chip(
-                  label: Text(values[index]),
-                ),
+            (index) => Container(
+              margin: const EdgeInsets.all(Constants.spacingExtraSmall),
+              child: ActionChip(
+                onPressed: () {
+                  if (onTap != null) {
+                    onTap(index);
+                  } else {
+                    showSnackbar(context, name, values[index]);
+                  }
+                },
+                label: Text(values[index]),
               ),
             ),
           ),
@@ -78,24 +76,31 @@ class DetailsItemWidget extends StatelessWidget {
       );
     }
 
-    return Flexible(
-      child: InkWell(
-        onTap: () {
-          if (onTap != null) {
-            onTap(-1);
-          }
-        },
-        child: Text(
-          values.toString(),
-          softWrap: true,
-          style: onTap != null
-              ? TextStyle(
+    if (onTap != null) {
+      return Flexible(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: () {
+              onTap(-1);
+            },
+            child: Text(values.toString(),
+                softWrap: true,
+                style: TextStyle(
                   color: theme(context).colorTextPrimary,
                   decoration: TextDecoration.underline,
-                )
-              : TextStyle(
-                  color: theme(context).colorTextPrimary,
-                ),
+                )),
+          ),
+        ),
+      );
+    }
+
+    return Flexible(
+      child: Text(
+        values.toString(),
+        softWrap: true,
+        style: TextStyle(
+          color: theme(context).colorTextPrimary,
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_item_conditions.dart
+++ b/lib/widgets/resources/details/details_item_conditions.dart
@@ -80,44 +80,48 @@ class DetailsItemConditions extends StatelessWidget {
                             Radius.circular(Constants.sizeBorderRadius),
                           ),
                         ),
-                        child: InkWell(
-                          onTap: () {
-                            final age = item['status']['conditions'][index]
-                                        ['lastTransitionTime'] !=
-                                    null
-                                ? getAge(DateTime.parse(item['status']
-                                        ['conditions'][index]
-                                    ['lastTransitionTime']))
-                                : '-';
+                        child: MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: GestureDetector(
+                            onTap: () {
+                              final age = item['status']['conditions'][index]
+                                          ['lastTransitionTime'] !=
+                                      null
+                                  ? getAge(DateTime.parse(item['status']
+                                          ['conditions'][index]
+                                      ['lastTransitionTime']))
+                                  : '-';
 
-                            showSnackbar(
-                              context,
-                              item['status']['conditions'][index]['type'],
-                              'Status: ${item['status']['conditions'][index]['status']}\nAge: $age\nReason: ${item['status']['conditions'][index]['reason'] ?? '-'}\nMessage: ${item['status']['conditions'][index]['message'] ?? '-'}',
-                            );
-                          },
-                          child: Row(
-                            children: [
-                              Icon(
-                                item['status']['conditions'][index]['status'] ==
-                                        'True'
-                                    ? Icons.radio_button_checked
-                                    : Icons.radio_button_unchecked,
-                                size: 24,
-                                color: theme(context).colorPrimary,
-                              ),
-                              const SizedBox(width: Constants.spacingSmall),
-                              Expanded(
-                                flex: 1,
-                                child: Text(
-                                  item['status']['conditions'][index]['type'],
-                                  style: noramlTextStyle(
-                                    context,
-                                  ),
-                                  overflow: TextOverflow.ellipsis,
+                              showSnackbar(
+                                context,
+                                item['status']['conditions'][index]['type'],
+                                'Status: ${item['status']['conditions'][index]['status']}\nAge: $age\nReason: ${item['status']['conditions'][index]['reason'] ?? '-'}\nMessage: ${item['status']['conditions'][index]['message'] ?? '-'}',
+                              );
+                            },
+                            child: Row(
+                              children: [
+                                Icon(
+                                  item['status']['conditions'][index]
+                                              ['status'] ==
+                                          'True'
+                                      ? Icons.radio_button_checked
+                                      : Icons.radio_button_unchecked,
+                                  size: 24,
+                                  color: theme(context).colorPrimary,
                                 ),
-                              ),
-                            ],
+                                const SizedBox(width: Constants.spacingSmall),
+                                Expanded(
+                                  flex: 1,
+                                  child: Text(
+                                    item['status']['conditions'][index]['type'],
+                                    style: noramlTextStyle(
+                                      context,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       );

--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -207,10 +207,7 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );
@@ -248,10 +245,7 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );

--- a/lib/widgets/settings/providers/settings_aws_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_aws_provider_config.dart
@@ -250,10 +250,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );

--- a/lib/widgets/settings/providers/settings_awssso_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_provider_config.dart
@@ -377,10 +377,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );
@@ -439,10 +436,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );

--- a/lib/widgets/settings/providers/settings_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_oidc_provider_config.dart
@@ -367,10 +367,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
                         child: Text(
                           value,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       );

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -94,34 +94,37 @@ class Settings extends StatelessWidget {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: InkWell(
-                onTap: () {
-                  clustersRepository.setActiveCluster(
-                    clustersRepository.clusters[index].id,
-                  );
-                },
-                child: Row(
-                  children: [
-                    Icon(
-                      clustersRepository.clusters[index].id ==
-                              clustersRepository.activeClusterId
-                          ? Icons.radio_button_checked
-                          : Icons.radio_button_unchecked,
-                      size: 24,
-                      color: theme(context).colorPrimary,
-                    ),
-                    const SizedBox(width: Constants.spacingSmall),
-                    Expanded(
-                      flex: 1,
-                      child: Text(
-                        clustersRepository.clusters[index].name,
-                        style: noramlTextStyle(
-                          context,
-                        ),
-                        overflow: TextOverflow.ellipsis,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: () {
+                    clustersRepository.setActiveCluster(
+                      clustersRepository.clusters[index].id,
+                    );
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        clustersRepository.clusters[index].id ==
+                                clustersRepository.activeClusterId
+                            ? Icons.radio_button_checked
+                            : Icons.radio_button_unchecked,
+                        size: 24,
+                        color: theme(context).colorPrimary,
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          clustersRepository.clusters[index].name,
+                          style: noramlTextStyle(
+                            context,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             );
@@ -148,26 +151,31 @@ class Settings extends StatelessWidget {
             flex: 1,
             child: Text('Clusters', style: primaryTextStyle(context, size: 18)),
           ),
-          InkWell(
-            onTap: () {
-              navigate(context, const SettingsClusters());
-            },
-            child: Wrap(
-              children: [
-                Text('View all',
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: () {
+                navigate(context, const SettingsClusters());
+              },
+              child: Wrap(
+                children: [
+                  Text(
+                    'View all',
                     style: secondaryTextStyle(
                       context,
                       color: theme(context).colorPrimary,
-                    )),
-                const SizedBox(width: Constants.spacingExtraSmall),
-                Icon(
-                  Icons.keyboard_arrow_right,
-                  color: theme(context).colorPrimary,
-                  size: 16,
-                ),
-              ],
+                    ),
+                  ),
+                  const SizedBox(width: Constants.spacingExtraSmall),
+                  Icon(
+                    Icons.keyboard_arrow_right,
+                    color: theme(context).colorPrimary,
+                    size: 16,
+                  ),
+                ],
+              ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -155,10 +155,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
                         child: Text(
                           licenseText,
                           style: TextStyle(
-                            color: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .color,
+                            color: theme(context).colorTextPrimary,
                           ),
                         ),
                       ),

--- a/lib/widgets/shared/app_actions_header_widget.dart
+++ b/lib/widgets/shared/app_actions_header_widget.dart
@@ -75,33 +75,40 @@ class AppActionsHeaderWidget extends StatelessWidget {
           spacing: Constants.spacingSmall,
           children: actions.map(
             (action) {
-              return InkWell(
-                onTap: action.onTap,
-                child: Container(
-                  constraints: BoxConstraints(
-                    minWidth: MediaQuery.of(context).size.width * 0.25,
-                  ),
-                  padding: const EdgeInsets.only(
-                    top: Constants.spacingMiddle,
-                    bottom: Constants.spacingMiddle,
-                  ),
-                  child: Column(
-                    children: [
-                      Icon(
-                        action.icon,
-                        color: theme(context).colorPrimary,
-                        size: 28,
+              return Container(
+                constraints: BoxConstraints(
+                  minWidth: MediaQuery.of(context).size.width * 0.25,
+                ),
+                padding: const EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                  bottom: Constants.spacingMiddle,
+                ),
+                child: Column(
+                  children: [
+                    MouseRegion(
+                      cursor: SystemMouseCursors.click,
+                      child: GestureDetector(
+                        onTap: action.onTap,
+                        child: Column(
+                          children: [
+                            Icon(
+                              action.icon,
+                              color: theme(context).colorPrimary,
+                              size: 28,
+                            ),
+                            const SizedBox(
+                              height: Constants.spacingSmall,
+                            ),
+                            Text(
+                              action.title,
+                              style: primaryTextStyle(context, size: 12),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        ),
                       ),
-                      const SizedBox(
-                        height: Constants.spacingSmall,
-                      ),
-                      Text(
-                        action.title,
-                        style: primaryTextStyle(context, size: 12),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               );
             },

--- a/lib/widgets/shared/app_actions_widget.dart
+++ b/lib/widgets/shared/app_actions_widget.dart
@@ -72,14 +72,12 @@ class AppActionsWidget extends StatelessWidget {
             if (index == actions.length - 1) {
               return Wrap(
                 children: [
-                  InkWell(
+                  ListTile(
                     onTap: actions[index].onTap,
-                    child: ListTile(
-                      title: Text(
-                        actions[index].title,
-                        textAlign: TextAlign.center,
-                        style: TextStyle(color: actions[index].color),
-                      ),
+                    title: Text(
+                      actions[index].title,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: actions[index].color),
                     ),
                   ),
                   const Divider(
@@ -89,14 +87,12 @@ class AppActionsWidget extends StatelessWidget {
                 ],
               );
             } else {
-              return InkWell(
+              return ListTile(
                 onTap: actions[index].onTap,
-                child: ListTile(
-                  title: Text(
-                    actions[index].title,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: actions[index].color),
-                  ),
+                title: Text(
+                  actions[index].title,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: actions[index].color),
                 ),
               );
             }

--- a/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
+++ b/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
@@ -44,9 +44,8 @@ class AppBottomNavigationBarWidget extends StatelessWidget {
     return BottomNavigationBar(
       type: BottomNavigationBarType.fixed,
       backgroundColor: theme(context).colorPrimary,
-      selectedItemColor: Theme.of(context).appBarTheme.foregroundColor,
-      unselectedItemColor:
-          Theme.of(context).appBarTheme.foregroundColor?.withOpacity(0.60),
+      selectedItemColor: theme(context).colorOnPrimary,
+      unselectedItemColor: theme(context).colorOnPrimary.withOpacity(0.60),
       selectedFontSize: 14,
       unselectedFontSize: 14,
       currentIndex: appRepository.currentPageIndex,

--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -93,119 +93,121 @@ class AppBottomSheetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: MediaQuery.of(context).size.height * 0.75,
-      color: Colors.transparent,
-      child: Scaffold(
-        backgroundColor: Colors.transparent,
-        body: Container(
-          padding: const EdgeInsets.only(
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Container(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Flexible(
-                      child: Row(
-                        children: [
-                          _buildIcon(context, icon),
-                          Flexible(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  title,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: primaryTextStyle(
-                                    context,
-                                    size: 18,
-                                  ),
-                                ),
-                                Text(
-                                  Characters(subtitle)
-                                      .replaceAll(Characters(''),
-                                          Characters('\u{200B}'))
-                                      .toString(),
-                                  overflow: TextOverflow.ellipsis,
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      icon: Icon(
-                        Icons.close_outlined,
-                        color: Theme.of(context).textTheme.displayMedium!.color,
-                      ),
-                      onPressed: closePressed,
-                    ),
-                  ],
-                ),
-              ),
-              const Divider(
-                height: 0,
-                thickness: 1.0,
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-              Flexible(
-                child: child,
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-              const Divider(
-                height: 0,
-                thickness: 1.0,
-              ),
-              Padding(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: theme(context).colorPrimary,
-                    foregroundColor: Colors.white,
-                    minimumSize: const Size.fromHeight(40),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(
-                        Constants.sizeBorderRadius,
-                      ),
-                    ),
+    return SafeArea(
+      child: Container(
+        height: MediaQuery.of(context).size.height * 0.75,
+        color: Colors.transparent,
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Container(
+            padding: const EdgeInsets.only(
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Container(
+                  padding: const EdgeInsets.only(
+                    top: Constants.spacingMiddle,
+                    bottom: Constants.spacingMiddle,
                   ),
-                  onPressed: actionIsLoading ? null : actionPressed,
-                  child: actionIsLoading
-                      ? const SizedBox(
-                          height: 24,
-                          width: 24,
-                          child: CircularProgressIndicator(
-                            color: Colors.white,
-                          ),
-                        )
-                      : Text(
-                          actionText,
-                          style: primaryTextStyle(
-                            context,
-                            color: Colors.white,
-                          ),
-                          textAlign: TextAlign.center,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Flexible(
+                        child: Row(
+                          children: [
+                            _buildIcon(context, icon),
+                            Flexible(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    title,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: primaryTextStyle(
+                                      context,
+                                      size: 18,
+                                    ),
+                                  ),
+                                  Text(
+                                    Characters(subtitle)
+                                        .replaceAll(Characters(''),
+                                            Characters('\u{200B}'))
+                                        .toString(),
+                                    overflow: TextOverflow.ellipsis,
+                                    style: secondaryTextStyle(
+                                      context,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
                         ),
+                      ),
+                      IconButton(
+                        icon: Icon(
+                          Icons.close_outlined,
+                          color: theme(context).colorTextPrimary,
+                        ),
+                        onPressed: closePressed,
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+                const Divider(
+                  height: 0,
+                  thickness: 1.0,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Flexible(
+                  child: child,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                const Divider(
+                  height: 0,
+                  thickness: 1.0,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    top: Constants.spacingMiddle,
+                    bottom: Constants.spacingMiddle,
+                  ),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: theme(context).colorPrimary,
+                      foregroundColor: Colors.white,
+                      minimumSize: const Size.fromHeight(40),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(
+                          Constants.sizeBorderRadius,
+                        ),
+                      ),
+                    ),
+                    onPressed: actionIsLoading ? null : actionPressed,
+                    child: actionIsLoading
+                        ? const SizedBox(
+                            height: 24,
+                            width: 24,
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          )
+                        : Text(
+                            actionText,
+                            style: primaryTextStyle(
+                              context,
+                              color: Colors.white,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/shared/app_clusters_widget.dart
+++ b/lib/widgets/shared/app_clusters_widget.dart
@@ -78,35 +78,38 @@ class _AppClustersWidgetState extends State<AppClustersWidget> {
                 Radius.circular(Constants.sizeBorderRadius),
               ),
             ),
-            child: InkWell(
-              onTap: () {
-                setActiveCluster(
-                  context,
-                  clustersRepository.clusters[index].id,
-                );
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    clustersRepository.clusters[index].id ==
-                            clustersRepository.activeClusterId
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: theme(context).colorPrimary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      clustersRepository.clusters[index].name,
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () {
+                  setActiveCluster(
+                    context,
+                    clustersRepository.clusters[index].id,
+                  );
+                },
+                child: Row(
+                  children: [
+                    Icon(
+                      clustersRepository.clusters[index].id ==
+                              clustersRepository.activeClusterId
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_unchecked,
+                      size: 24,
+                      color: theme(context).colorPrimary,
                     ),
-                  ),
-                ],
+                    const SizedBox(width: Constants.spacingSmall),
+                    Expanded(
+                      flex: 1,
+                      child: Text(
+                        clustersRepository.clusters[index].name,
+                        style: noramlTextStyle(
+                          context,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/widgets/shared/app_horizontal_list_cards_widget.dart
+++ b/lib/widgets/shared/app_horizontal_list_cards_widget.dart
@@ -74,24 +74,27 @@ class AppHorizontalListCardsWidget extends StatelessWidget {
     void Function()? moreOnTap,
   ) {
     if (moreText != null && moreIcon != null) {
-      return InkWell(
-        onTap: moreOnTap,
-        child: Wrap(
-          children: [
-            Text(
-              moreText,
-              style: secondaryTextStyle(
-                context,
-                color: theme(context).colorPrimary,
+      return MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: moreOnTap,
+          child: Wrap(
+            children: [
+              Text(
+                moreText,
+                style: secondaryTextStyle(
+                  context,
+                  color: theme(context).colorPrimary,
+                ),
               ),
-            ),
-            const SizedBox(width: Constants.spacingExtraSmall),
-            Icon(
-              moreIcon,
-              color: theme(context).colorPrimary,
-              size: 16,
-            ),
-          ],
+              const SizedBox(width: Constants.spacingExtraSmall),
+              Icon(
+                moreIcon,
+                color: theme(context).colorPrimary,
+                size: 16,
+              ),
+            ],
+          ),
         ),
       );
     }

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -133,34 +133,37 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
             Radius.circular(Constants.sizeBorderRadius),
           ),
         ),
-        child: InkWell(
-          onTap: () {
-            _changeNamespace(context, '');
-          },
-          child: Row(
-            children: [
-              Icon(
-                clustersRepository
-                            .getCluster(clustersRepository.activeClusterId)!
-                            .namespace ==
-                        ''
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                size: 24,
-                color: theme(context).colorPrimary,
-              ),
-              const SizedBox(width: Constants.spacingSmall),
-              Expanded(
-                flex: 1,
-                child: Text(
-                  'All Namespaces',
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: () {
+              _changeNamespace(context, '');
+            },
+            child: Row(
+              children: [
+                Icon(
+                  clustersRepository
+                              .getCluster(clustersRepository.activeClusterId)!
+                              .namespace ==
+                          ''
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked,
+                  size: 24,
+                  color: theme(context).colorPrimary,
                 ),
-              ),
-            ],
+                const SizedBox(width: Constants.spacingSmall),
+                Expanded(
+                  flex: 1,
+                  child: Text(
+                    'All Namespaces',
+                    style: noramlTextStyle(
+                      context,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -191,34 +194,38 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
                 Radius.circular(Constants.sizeBorderRadius),
               ),
             ),
-            child: InkWell(
-              onTap: () {
-                _changeNamespace(context, name);
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    name ==
-                            clustersRepository
-                                .getCluster(clustersRepository.activeClusterId)!
-                                .namespace
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: theme(context).colorPrimary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      name,
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () {
+                  _changeNamespace(context, name);
+                },
+                child: Row(
+                  children: [
+                    Icon(
+                      name ==
+                              clustersRepository
+                                  .getCluster(
+                                      clustersRepository.activeClusterId)!
+                                  .namespace
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_unchecked,
+                      size: 24,
+                      color: theme(context).colorPrimary,
                     ),
-                  ),
-                ],
+                    const SizedBox(width: Constants.spacingSmall),
+                    Expanded(
+                      flex: 1,
+                      child: Text(
+                        name,
+                        style: noramlTextStyle(
+                          context,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           );
@@ -333,36 +340,39 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
                             Radius.circular(Constants.sizeBorderRadius),
                           ),
                         ),
-                        child: InkWell(
-                          onTap: () {
-                            _changeNamespace(context, name ?? 'default');
-                          },
-                          child: Row(
-                            children: [
-                              Icon(
-                                name != null &&
-                                        name ==
-                                            clustersRepository
-                                                .getCluster(clustersRepository
-                                                    .activeClusterId)!
-                                                .namespace
-                                    ? Icons.radio_button_checked
-                                    : Icons.radio_button_unchecked,
-                                size: 24,
-                                color: theme(context).colorPrimary,
-                              ),
-                              const SizedBox(width: Constants.spacingSmall),
-                              Expanded(
-                                flex: 1,
-                                child: Text(
-                                  name ?? '',
-                                  style: noramlTextStyle(
-                                    context,
-                                  ),
-                                  overflow: TextOverflow.ellipsis,
+                        child: MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: GestureDetector(
+                            onTap: () {
+                              _changeNamespace(context, name ?? 'default');
+                            },
+                            child: Row(
+                              children: [
+                                Icon(
+                                  name != null &&
+                                          name ==
+                                              clustersRepository
+                                                  .getCluster(clustersRepository
+                                                      .activeClusterId)!
+                                                  .namespace
+                                      ? Icons.radio_button_checked
+                                      : Icons.radio_button_unchecked,
+                                  size: 24,
+                                  color: theme(context).colorPrimary,
                                 ),
-                              ),
-                            ],
+                                const SizedBox(width: Constants.spacingSmall),
+                                Expanded(
+                                  flex: 1,
+                                  child: Text(
+                                    name ?? '',
+                                    style: noramlTextStyle(
+                                      context,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       );

--- a/lib/widgets/shared/app_prometheus_charts_widget.dart
+++ b/lib/widgets/shared/app_prometheus_charts_widget.dart
@@ -132,38 +132,41 @@ class _AppPrometheusChartsWidgetState extends State<AppPrometheusChartsWidget> {
                   style: primaryTextStyle(context, size: 18),
                 ),
               ),
-              InkWell(
-                onTap: () {
-                  showModal(
-                    context,
-                    AppTimeRangeSelectorWidget(
-                      time: _time,
-                      selectTime: (Time time) {
-                        setState(() {
-                          _time = time;
-                        });
-                      },
-                    ),
-                  );
-                },
-                child: Wrap(
-                  children: [
-                    Icon(
-                      Icons.schedule,
-                      color: theme(context).colorPrimary,
-                      size: 16,
-                    ),
-                    const SizedBox(width: Constants.spacingExtraSmall),
-                    Text(
-                      'Time Range',
-                      style: secondaryTextStyle(
-                        context,
-                        color: theme(context).colorPrimary,
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: () {
+                    showModal(
+                      context,
+                      AppTimeRangeSelectorWidget(
+                        time: _time,
+                        selectTime: (Time time) {
+                          setState(() {
+                            _time = time;
+                          });
+                        },
                       ),
-                    ),
-                  ],
+                    );
+                  },
+                  child: Wrap(
+                    children: [
+                      Icon(
+                        Icons.schedule,
+                        color: theme(context).colorPrimary,
+                        size: 16,
+                      ),
+                      const SizedBox(width: Constants.spacingExtraSmall),
+                      Text(
+                        'Time Range',
+                        style: secondaryTextStyle(
+                          context,
+                          color: theme(context).colorPrimary,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              )
+              ),
             ],
           ),
         ),

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -70,190 +70,199 @@ class AppTerminalsWidget extends StatelessWidget {
       child: Container(
         height: MediaQuery.of(context).size.height * 0.75,
         color: Colors.transparent,
-        child: Container(
-          padding: const EdgeInsets.only(
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Container(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Flexible(
-                      child: Row(
-                        children: [
-                          Container(
-                            margin: const EdgeInsets.only(
-                              right: Constants.spacingMiddle,
-                            ),
-                            padding: const EdgeInsets.all(
-                              Constants.spacingExtraSmall,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme(context).colorPrimary,
-                              borderRadius: const BorderRadius.all(
-                                Radius.circular(
-                                  Constants.sizeBorderRadius,
+        child: Scaffold(
+          body: Container(
+            padding: const EdgeInsets.only(
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Container(
+                  padding: const EdgeInsets.only(
+                    top: Constants.spacingMiddle,
+                    bottom: Constants.spacingMiddle,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Flexible(
+                        child: Row(
+                          children: [
+                            Container(
+                              margin: const EdgeInsets.only(
+                                right: Constants.spacingMiddle,
+                              ),
+                              padding: const EdgeInsets.all(
+                                Constants.spacingExtraSmall,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme(context).colorPrimary,
+                                borderRadius: const BorderRadius.all(
+                                  Radius.circular(
+                                    Constants.sizeBorderRadius,
+                                  ),
                                 ),
                               ),
+                              height: 54,
+                              width: 54,
+                              child: const Icon(
+                                Icons.terminal,
+                                color: Colors.white,
+                                size: 36,
+                              ),
                             ),
-                            height: 54,
-                            width: 54,
-                            child: const Icon(
-                              Icons.terminal,
-                              color: Colors.white,
-                              size: 36,
+                            Flexible(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Terminals',
+                                    overflow: TextOverflow.ellipsis,
+                                    style: primaryTextStyle(
+                                      context,
+                                      size: 18,
+                                    ),
+                                  ),
+                                  Text(
+                                    Characters(
+                                      'You have ${terminalRepository.terminals.length} Terminals open',
+                                    )
+                                        .replaceAll(Characters(''),
+                                            Characters('\u{200B}'))
+                                        .toString(),
+                                    overflow: TextOverflow.ellipsis,
+                                    style: secondaryTextStyle(
+                                      context,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                          Flexible(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Terminals',
-                                  overflow: TextOverflow.ellipsis,
-                                  style: primaryTextStyle(
-                                    context,
-                                    size: 18,
-                                  ),
-                                ),
-                                Text(
-                                  Characters(
-                                    'You have ${terminalRepository.terminals.length} Terminals open',
-                                  )
-                                      .replaceAll(Characters(''),
-                                          Characters('\u{200B}'))
-                                      .toString(),
-                                  overflow: TextOverflow.ellipsis,
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      icon: const Icon(
-                        Icons.close_outlined,
-                      ),
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                    ),
-                  ],
-                ),
-              ),
-              const Divider(
-                height: 0,
-                thickness: 1.0,
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-              Flexible(
-                child: DefaultTabController(
-                  length: terminalRepository.terminals.length,
-                  child: Column(
-                    children: [
-                      ClipRRect(
-                        borderRadius: const BorderRadius.all(
-                          Radius.circular(Constants.sizeBorderRadius),
-                        ),
-                        child: TabBar(
-                          isScrollable: true,
-                          labelColor: Colors.white,
-                          unselectedLabelColor: theme(context).colorPrimary,
-                          indicatorSize: TabBarIndicatorSize.tab,
-                          indicator: BoxDecoration(
-                            color: theme(context).colorPrimary,
-                          ),
-                          tabs:
-                              terminalRepository.terminals.asMap().entries.map(
-                            (terminal) {
-                              return Tab(
-                                child: GestureDetector(
-                                  onLongPress: () {
-                                    terminalRepository.deleteTerminal(
-                                      terminal.key,
-                                    );
-                                    if (terminalRepository.terminals.isEmpty) {
-                                      Navigator.pop(context);
-                                    }
-                                  },
-                                  child: Text(
-                                    terminal.value.name,
-                                  ),
-                                ),
-                              );
-                            },
-                          ).toList(),
+                          ],
                         ),
                       ),
-                      const SizedBox(height: Constants.spacingMiddle),
-                      Expanded(
-                        child: TabBarView(
-                          children:
-                              terminalRepository.terminals.asMap().entries.map(
-                            (terminal) {
-                              return terminal.value.type == TerminalType.exec
-                                  ? terminal.value.terminal != null
-                                      ? xtermui.TerminalView(
-                                          terminal.value.terminal!.terminal,
-                                          theme: terminalTheme,
-                                          textStyle: xterm.TerminalStyle(
-                                            fontSize: 14,
-                                            fontFamily:
-                                                getMonospaceFontFamily(),
-                                          ),
-                                        )
-                                      : Container()
-                                  : SingleChildScrollView(
-                                      physics: const ClampingScrollPhysics(),
-                                      child: Container(
-                                        padding: const EdgeInsets.all(
-                                          Constants.spacingSmall,
-                                        ),
-                                        color: const Color(0xff2E3440),
-                                        child: Wrap(
-                                          children: terminal.value.logs == null
-                                              ? []
-                                              : terminal.value.logs!
-                                                  .asMap()
-                                                  .entries
-                                                  .map(
-                                                    (e) => SelectableText(
-                                                      e.value.join('\n\n'),
-                                                      style: TextStyle(
-                                                        color: getColor(e.key),
-                                                        fontSize: 14,
-                                                        fontFamily:
-                                                            getMonospaceFontFamily(),
-                                                      ),
-                                                    ),
-                                                  )
-                                                  .toList(),
-                                        ),
-                                      ),
-                                    );
-                            },
-                          ).toList(),
+                      IconButton(
+                        icon: const Icon(
+                          Icons.close_outlined,
                         ),
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
                       ),
                     ],
                   ),
                 ),
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-            ],
+                const Divider(
+                  height: 0,
+                  thickness: 1.0,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Flexible(
+                  child: DefaultTabController(
+                    length: terminalRepository.terminals.length,
+                    child: Column(
+                      children: [
+                        ClipRRect(
+                          borderRadius: const BorderRadius.all(
+                            Radius.circular(Constants.sizeBorderRadius),
+                          ),
+                          child: TabBar(
+                            isScrollable: true,
+                            labelColor: Colors.white,
+                            unselectedLabelColor: theme(context).colorPrimary,
+                            indicatorSize: TabBarIndicatorSize.tab,
+                            indicator: BoxDecoration(
+                              color: theme(context).colorPrimary,
+                            ),
+                            tabs: terminalRepository.terminals
+                                .asMap()
+                                .entries
+                                .map(
+                              (terminal) {
+                                return Tab(
+                                  child: GestureDetector(
+                                    onLongPress: () {
+                                      terminalRepository.deleteTerminal(
+                                        terminal.key,
+                                      );
+                                      if (terminalRepository
+                                          .terminals.isEmpty) {
+                                        Navigator.pop(context);
+                                      }
+                                    },
+                                    child: Text(
+                                      terminal.value.name,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ).toList(),
+                          ),
+                        ),
+                        const SizedBox(height: Constants.spacingMiddle),
+                        Expanded(
+                          child: TabBarView(
+                            children: terminalRepository.terminals
+                                .asMap()
+                                .entries
+                                .map(
+                              (terminal) {
+                                return terminal.value.type == TerminalType.exec
+                                    ? terminal.value.terminal != null
+                                        ? xtermui.TerminalView(
+                                            terminal.value.terminal!.terminal,
+                                            theme: terminalTheme,
+                                            textStyle: xterm.TerminalStyle(
+                                              fontSize: 14,
+                                              fontFamily:
+                                                  getMonospaceFontFamily(),
+                                            ),
+                                          )
+                                        : Container()
+                                    : SingleChildScrollView(
+                                        physics: const ClampingScrollPhysics(),
+                                        child: Container(
+                                          padding: const EdgeInsets.all(
+                                            Constants.spacingSmall,
+                                          ),
+                                          color: const Color(0xff2E3440),
+                                          child: Wrap(
+                                            children: terminal.value.logs ==
+                                                    null
+                                                ? []
+                                                : terminal.value.logs!
+                                                    .asMap()
+                                                    .entries
+                                                    .map(
+                                                      (e) => SelectableText(
+                                                        e.value.join('\n\n'),
+                                                        style: TextStyle(
+                                                          color:
+                                                              getColor(e.key),
+                                                          fontSize: 14,
+                                                          fontFamily:
+                                                              getMonospaceFontFamily(),
+                                                        ),
+                                                      ),
+                                                    )
+                                                    .toList(),
+                                          ),
+                                        ),
+                                      );
+                              },
+                            ).toList(),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
On some items the cursor style wasn't adjusted on dekstop, so that there was no indication that the item is clickable. We also had the problem that the clickable area was to large for some items (e.g app actions). These issues should be fixed now.

We also removed the dismiss option from the snackbar, because sometimes this could break the app, when the context isn't available anymore.

In some places we still had used "Theme.of", which is now replaced with our new theme() function.