### PR TITLE
Add Path Support for Prometheus

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -348,6 +348,7 @@ class AppRepositorySettingsPrometheus {
   String labelSelector;
   String container;
   int port;
+  String path;
   String username;
   String password;
   String token;
@@ -359,6 +360,7 @@ class AppRepositorySettingsPrometheus {
     required this.labelSelector,
     required this.container,
     required this.port,
+    required this.path,
     required this.username,
     required this.password,
     required this.token,
@@ -372,6 +374,7 @@ class AppRepositorySettingsPrometheus {
       labelSelector: 'app=prometheus',
       container: 'prometheus',
       port: 9090,
+      path: '',
       username: '',
       password: '',
       token: '',
@@ -399,6 +402,8 @@ class AppRepositorySettingsPrometheus {
       port: data.containsKey('port') && data['port'] != null
           ? data['port']
           : 9090,
+      path:
+          data.containsKey('path') && data['path'] != null ? data['path'] : '',
       username: data.containsKey('username') && data['username'] != null
           ? data['username']
           : '',
@@ -419,6 +424,7 @@ class AppRepositorySettingsPrometheus {
       'labelSelector': labelSelector,
       'container': container,
       'port': port,
+      'path': path,
       'username': username,
       'password': password,
       'token': token,

--- a/lib/widgets/settings/settings/settings_prometheus.dart
+++ b/lib/widgets/settings/settings/settings_prometheus.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kubenav/utils/helpers.dart';
 
 import 'package:provider/provider.dart';
 
@@ -30,6 +31,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
   final _labelSelectorController = TextEditingController();
   final _containerController = TextEditingController();
   final _portController = TextEditingController();
+  final _pathController = TextEditingController();
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   final _tokenController = TextEditingController();
@@ -62,6 +64,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
     _labelSelectorController.text = widget.currentPrometheus.labelSelector;
     _containerController.text = widget.currentPrometheus.container;
     _portController.text = '${widget.currentPrometheus.port}';
+    _pathController.text = widget.currentPrometheus.path;
     _usernameController.text = widget.currentPrometheus.username;
     _passwordController.text = widget.currentPrometheus.password;
     _tokenController.text = widget.currentPrometheus.token;
@@ -74,6 +77,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
     _labelSelectorController.dispose();
     _containerController.dispose();
     _portController.dispose();
+    _pathController.dispose();
     _usernameController.dispose();
     _passwordController.dispose();
     _tokenController.dispose();
@@ -106,6 +110,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
               labelSelector: _labelSelectorController.text,
               container: _containerController.text,
               port: int.tryParse(_portController.text) ?? 9090,
+              path: _pathController.text,
               username: _usernameController.text,
               password: _passwordController.text,
               token: _tokenController.text,
@@ -125,7 +130,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
                 vertical: Constants.spacingSmall,
               ),
               child: Text(
-                'You can specify the address of an Prometheus instance, or if your Prometheus instance is not reachable via a public address you can specify a namespace, label selector, container and port running inside your cluster',
+                'You can specify the address of a Prometheus instance, or if your Prometheus instance is not reachable via a public address you can specify a namespace, label selector, container and port running inside your cluster',
               ),
             ),
             Padding(
@@ -163,6 +168,34 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
                   border: OutlineInputBorder(),
                   labelText: 'Address',
                 ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+              ),
+              child: Row(
+                children: [
+                  const Expanded(
+                    child: Divider(
+                      height: 0,
+                      thickness: 1.0,
+                    ),
+                  ),
+                  Text(
+                    'In-Cluster Configuration',
+                    style: secondaryTextStyle(
+                      context,
+                    ),
+                  ),
+                  const Expanded(
+                    child: Divider(
+                      height: 0,
+                      thickness: 1.0,
+                    ),
+                  ),
+                ],
               ),
             ),
             Padding(
@@ -228,6 +261,50 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
                   labelText: 'Port',
                 ),
                 validator: _portValidator,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: TextFormField(
+                controller: _pathController,
+                keyboardType: TextInputType.text,
+                autocorrect: false,
+                enableSuggestions: false,
+                maxLines: 1,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Path',
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+              ),
+              child: Row(
+                children: [
+                  const Expanded(
+                    child: Divider(
+                      height: 0,
+                      thickness: 1.0,
+                    ),
+                  ),
+                  Text(
+                    'Credentials',
+                    style: secondaryTextStyle(
+                      context,
+                    ),
+                  ),
+                  const Expanded(
+                    child: Divider(
+                      height: 0,
+                      thickness: 1.0,
+                    ),
+                  ),
+                ],
               ),
             ),
             Padding(

--- a/pkg/shared/prometheus.go
+++ b/pkg/shared/prometheus.go
@@ -33,6 +33,7 @@ type prometheus struct {
 	LabelSelector string `json:"labelSelector"`
 	Container     string `json:"container"`
 	Port          int64  `json:"port"`
+	Path          string `json:"path"`
 	Username      string `json:"username"`
 	Password      string `json:"password"`
 	Token         string `json:"token"`
@@ -77,7 +78,7 @@ func PrometheusGetData(restConfig *rest.Config, clientset *kubernetes.Clientset,
 			}
 		}()
 
-		requestData.Prometheus.Address = fmt.Sprintf("http://localhost:%d", pf.LocalPort)
+		requestData.Prometheus.Address = fmt.Sprintf("http://localhost:%d%s", pf.LocalPort, requestData.Prometheus.Path)
 	}
 
 	// Create a Prometheus client with the user specified credentials. As address for the Prometheus instance we are


### PR DESCRIPTION
Until now it was not possible to specify the path of a Prometheus instance, when the in-cluster configuration was used. This caused some problems with Prometheus compatible APIs like VictoriaMetrics, where the Prometheus API is exposed under a prefix (e.g. "/select/0/prometheus").

With the new path option, it is now possible to use such APIs. By default the path is set to an empty string, which is the same behaviour like before without the path option.