### PR TITLE
Add Show Clusters on Start Option

### DIFF
--- a/lib/widgets/home/home.dart
+++ b/lib/widgets/home/home.dart
@@ -7,6 +7,7 @@ import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/bookmarks_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/widgets/home/home_clusters.dart';
 import 'package:kubenav/widgets/home/home_overview.dart';
 
 /// The [Home] is the first widget which is displayed when a user opens the app.
@@ -59,6 +60,23 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
+    /// When a user selected the show clusters on start option in the settings
+    /// we will show the [HomeClusters] widget instead of the normal
+    /// [HomeOverview] widget on the home screen, to allow the user to select an
+    /// active cluster before he continues.
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: true,
+    );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
+
+    if (appRepository.showClusters && clustersRepository.clusters.isNotEmpty) {
+      return const HomeClusters();
+    }
+
     return const HomeOverview();
   }
 }

--- a/lib/widgets/home/home_clusters.dart
+++ b/lib/widgets/home/home_clusters.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+
+/// The [HomeClusters] can be used to display a list of clusters when the app
+/// is started and the user has selected the [isShowClustersOnStart] option
+/// in the settings. When the user selected a cluster, this screen is not shown
+/// again.
+class HomeClusters extends StatefulWidget {
+  const HomeClusters({Key? key}) : super(key: key);
+
+  @override
+  State<HomeClusters> createState() => _HomeClustersState();
+}
+
+class _HomeClustersState extends State<HomeClusters> {
+  /// [_setActiveCluster] sets the cluster with the provided [clusterId] as the
+  /// active cluster and disabled the [showClusters] option in the app
+  /// repository, to not show this screen again.
+  Future<void> _setActiveCluster(BuildContext context, String clusterId) async {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      await clustersRepository.setActiveCluster(clusterId);
+      await appRepository.disableShowClusters();
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Provider.of<ThemeRepository>(
+      context,
+      listen: true,
+    );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text('Select Cluster'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(Constants.spacingMiddle),
+        child: ListView(
+          children: List.generate(
+            clustersRepository.clusters.length,
+            (index) => Container(
+              margin: const EdgeInsets.only(
+                top: Constants.spacingSmall,
+                bottom: Constants.spacingSmall,
+                left: Constants.spacingExtraSmall,
+                right: Constants.spacingExtraSmall,
+              ),
+              padding: const EdgeInsets.all(12.0),
+              decoration: BoxDecoration(
+                boxShadow: [
+                  BoxShadow(
+                    color: theme(context).colorShadow,
+                    blurRadius: Constants.sizeBorderBlurRadius,
+                    spreadRadius: Constants.sizeBorderSpreadRadius,
+                    offset: const Offset(0.0, 0.0),
+                  ),
+                ],
+                color: theme(context).colorCard,
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(Constants.sizeBorderRadius),
+                ),
+              ),
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: () {
+                    _setActiveCluster(
+                      context,
+                      clustersRepository.clusters[index].id,
+                    );
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.radio_button_unchecked,
+                        size: 24,
+                        color: theme(context).colorPrimary,
+                      ),
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          clustersRepository.clusters[index].name,
+                          style: noramlTextStyle(
+                            context,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/home/home_overview.dart
+++ b/lib/widgets/home/home_overview.dart
@@ -25,7 +25,7 @@ import 'package:kubenav/widgets/shared/app_no_clusters_widget.dart';
 class HomeOverview extends StatelessWidget {
   const HomeOverview({Key? key}) : super(key: key);
 
-  List<Widget> buildContent(BuildContext context) {
+  List<Widget> _buildContent(BuildContext context) {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
@@ -174,7 +174,7 @@ class HomeOverview extends StatelessWidget {
       floatingActionButton: const AppFloatingActionButtonsWidget(),
       body: SingleChildScrollView(
         child: Column(
-          children: buildContent(context),
+          children: _buildContent(context),
         ),
       ),
     );

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -312,6 +312,36 @@ class Settings extends StatelessWidget {
       AppVertialListSimpleModel(
         children: [
           Icon(
+            CustomIcons.clusters,
+            color: theme(context).colorPrimary,
+          ),
+          const SizedBox(width: Constants.spacingSmall),
+          Expanded(
+            flex: 1,
+            child: Text(
+              'Show Cluster on Start',
+              style: noramlTextStyle(
+                context,
+              ),
+            ),
+          ),
+          Switch(
+            activeColor: theme(context).colorPrimary,
+            onChanged: (value) {
+              appRepository.setIsShowClustersOnStart(
+                !appRepository.settings.isShowClustersOnStart,
+              );
+            },
+            value: appRepository.settings.isShowClustersOnStart,
+          ),
+        ],
+      ),
+    );
+
+    items.add(
+      AppVertialListSimpleModel(
+        children: [
+          Icon(
             Icons.code,
             color: theme(context).colorPrimary,
           ),

--- a/lib/widgets/shared/app_clusters_widget.dart
+++ b/lib/widgets/shared/app_clusters_widget.dart
@@ -19,7 +19,7 @@ class AppClustersWidget extends StatefulWidget {
 }
 
 class _AppClustersWidgetState extends State<AppClustersWidget> {
-  Future<void> setActiveCluster(BuildContext context, String clusterId) async {
+  Future<void> _setActiveCluster(BuildContext context, String clusterId) async {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
@@ -82,7 +82,7 @@ class _AppClustersWidgetState extends State<AppClustersWidget> {
               cursor: SystemMouseCursors.click,
               child: GestureDetector(
                 onTap: () {
-                  setActiveCluster(
+                  _setActiveCluster(
                     context,
                     clustersRepository.clusters[index].id,
                   );


### PR DESCRIPTION
The new show clusters on start option can be used to show a list of clusters when the app is started. By default we will directly show the overview page when the app is started with the active cluster from the users last session. When the show clusters on start option is enabled we not show the overview page and instead show a list of all configured clusters, where a user can select the active cluster before he can continue.

The list of clusters is only shown when the corresponding option is enabled and the list of clusters is not empty.