### PR TITLE
Enlarge Modal Bottom Sheet when Keyboard is shown

### DIFF
--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -90,9 +90,12 @@ class AppBottomSheetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom == 0;
+
     return SafeArea(
       child: Container(
-        height: MediaQuery.of(context).size.height * 0.75,
+        height:
+            MediaQuery.of(context).size.height * (isKeyboardVisible ? 0.75 : 1),
         color: Colors.transparent,
         child: Scaffold(
           backgroundColor: Colors.transparent,

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -66,9 +66,12 @@ class AppTerminalsWidget extends StatelessWidget {
       listen: true,
     );
 
+    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom == 0;
+
     return SafeArea(
       child: Container(
-        height: MediaQuery.of(context).size.height * 0.75,
+        height:
+            MediaQuery.of(context).size.height * (isKeyboardVisible ? 0.75 : 1),
         color: Colors.transparent,
         child: Scaffold(
           body: Container(


### PR DESCRIPTION
When we display a modal bottom sheet and the keyboard is visible the height of the modal bottom sheet is adjusted, to fill the complete screen.