### PR TITLE
Fix AppNoClustersWidget Theming

### DIFF
--- a/lib/widgets/home/home.dart
+++ b/lib/widgets/home/home.dart
@@ -73,6 +73,10 @@ class _HomeState extends State<Home> {
       listen: true,
     );
 
+    if (!appRepository.isAuthenticated) {
+      return Container();
+    }
+
     if (appRepository.showClusters && clustersRepository.clusters.isNotEmpty) {
       return const HomeClusters();
     }

--- a/lib/widgets/shared/app_no_clusters_widget.dart
+++ b/lib/widgets/shared/app_no_clusters_widget.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
@@ -18,6 +20,11 @@ class AppNoClustersWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Provider.of<ThemeRepository>(
+      context,
+      listen: true,
+    );
+
     /// On Android and iOS we show a widget which can be used by the user to go
     /// the [SettingsClusters] page, where he can add a cluster via his
     /// Kubeconfig or one of our supported providers.


### PR DESCRIPTION
When the user hasn't added a cluster yet and the AppNoClustersWidget was shown in the setting and the user changed the theme the widget wasn't adjusted. This is now fix by listining to theme changes in the widget.

We also adjusted the Home widget, to show an empty container when the app is not initialized (isAuthenticated==false).