### PR TITLE
Improve Bookmarks Handling

### DIFF
--- a/lib/repositories/bookmarks_repository.dart
+++ b/lib/repositories/bookmarks_repository.dart
@@ -77,6 +77,13 @@ class BookmarksRepository with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> removeBookmarksForCluster(String clusterId) async {
+    _bookmarks = _bookmarks.where((e) => e.clusterId != clusterId).toList();
+
+    await _save();
+    notifyListeners();
+  }
+
   /// [isBookmarked] returns the index of the bookmark which matches the given
   /// arguments or `-1` if no bookmark matches the given arguments.
   int isBookmarked(

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -128,6 +128,10 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
       context,
       listen: true,
     );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -159,6 +163,10 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                 context,
                 index,
               ) {
+                final cluster = clustersRepository.getCluster(
+                  bookmarksRepository.bookmarks[index].clusterId,
+                );
+
                 return ReorderableDragStartListener(
                   key: Key(
                     '${bookmarksRepository.bookmarks[index].type} ${bookmarksRepository.bookmarks[index].clusterId} ${bookmarksRepository.bookmarks[index].title} ${bookmarksRepository.bookmarks[index].resource} ${bookmarksRepository.bookmarks[index].path} ${bookmarksRepository.bookmarks[index].scope} ${bookmarksRepository.bookmarks[index].name} ${bookmarksRepository.bookmarks[index].namespace}',
@@ -225,7 +233,7 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                                         children: [
                                           Text(
                                             Characters(
-                                              'Cluster: ${bookmarksRepository.bookmarks[index].clusterId}',
+                                              'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
                                             )
                                                 .replaceAll(Characters(''),
                                                     Characters('\u{200B}'))

--- a/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
@@ -101,6 +101,10 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
       context,
       listen: true,
     );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
 
     if (bookmarksRepository.bookmarks.isEmpty) {
       return Container();
@@ -112,37 +116,43 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
         bookmarksRepository.bookmarks.length <= 10
             ? bookmarksRepository.bookmarks.length
             : 10,
-        (index) => AppHorizontalListCardsModel(
-          title: bookmarksRepository.bookmarks[index].title,
-          subtitle: bookmarksRepository.bookmarks[index].name == null
-              ? [
-                  'Cluster: ${bookmarksRepository.bookmarks[index].clusterId}',
-                  'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
-                ]
-              : [
-                  'Cluster: ${bookmarksRepository.bookmarks[index].clusterId}',
-                  'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
-                  'Name: ${bookmarksRepository.bookmarks[index].name}',
-                ],
-          image: resource_model.Resources.map.containsKey(
-                      bookmarksRepository.bookmarks[index].resource) &&
-                  resource_model
-                          .Resources
-                          .map[bookmarksRepository.bookmarks[index].resource]!
-                          .resource ==
-                      bookmarksRepository.bookmarks[index].resource &&
-                  resource_model
-                          .Resources
-                          .map[bookmarksRepository.bookmarks[index].resource]!
-                          .path ==
-                      bookmarksRepository.bookmarks[index].path
-              ? 'assets/resources/${bookmarksRepository.bookmarks[index].resource}.svg'
-              : 'assets/resources/customresourcedefinitions.svg',
-          imageFit: BoxFit.none,
-          onTap: () {
-            openBookmark(context, index);
-          },
-        ),
+        (index) {
+          final cluster = clustersRepository.getCluster(
+            bookmarksRepository.bookmarks[index].clusterId,
+          );
+
+          return AppHorizontalListCardsModel(
+            title: bookmarksRepository.bookmarks[index].title,
+            subtitle: bookmarksRepository.bookmarks[index].name == null
+                ? [
+                    'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
+                    'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
+                  ]
+                : [
+                    'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
+                    'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
+                    'Name: ${bookmarksRepository.bookmarks[index].name}',
+                  ],
+            image: resource_model.Resources.map.containsKey(
+                        bookmarksRepository.bookmarks[index].resource) &&
+                    resource_model
+                            .Resources
+                            .map[bookmarksRepository.bookmarks[index].resource]!
+                            .resource ==
+                        bookmarksRepository.bookmarks[index].resource &&
+                    resource_model
+                            .Resources
+                            .map[bookmarksRepository.bookmarks[index].resource]!
+                            .path ==
+                        bookmarksRepository.bookmarks[index].path
+                ? 'assets/resources/${bookmarksRepository.bookmarks[index].resource}.svg'
+                : 'assets/resources/customresourcedefinitions.svg',
+            imageFit: BoxFit.none,
+            onTap: () {
+              openBookmark(context, index);
+            },
+          );
+        },
       ),
       moreIcon: Icons.keyboard_arrow_right,
       moreText: 'View all',

--- a/lib/widgets/settings/clusters/settings_cluster_actions.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_actions.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/models/cluster.dart';
+import 'package:kubenav/repositories/bookmarks_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/showmodal.dart';
@@ -34,9 +35,14 @@ class _SettingsClusterActionsState extends State<SettingsClusterActions> {
       context,
       listen: false,
     );
+    BookmarksRepository bookmarksRepository = Provider.of<BookmarksRepository>(
+      context,
+      listen: false,
+    );
 
     try {
       await clustersRepository.deleteCluster(widget.cluster.id);
+      await bookmarksRepository.removeBookmarksForCluster(widget.cluster.id);
       if (mounted) {
         Navigator.pop(context);
         showSnackbar(

--- a/lib/widgets/settings/settings/settings_prometheus.dart
+++ b/lib/widgets/settings/settings/settings_prometheus.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:kubenav/utils/helpers.dart';
 
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 
 /// The [SettingsPrometheus] widget can be used to enable the Prometheus plugin,


### PR DESCRIPTION
Until now bookmarks for a cluser were not deleted, when the corresponding cluster was deleted, which broke the app when a user tried to open such a bookmark. This is now fixed by deleting all bookmarks with the cluster id of the deleted cluster.

We now show the name of the cluster instead of the cluster id in the bookmarks preview and the bookmarks list.