### PR TITLE
Fix several Problems with Provider Configuration

### DIFF
--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -32,8 +32,8 @@ class ClusterProvider {
     return ClusterProvider(
       id: data.containsKey('id') ? data['id'] : null,
       name: data.containsKey('name') ? data['name'] : null,
-      type: data.containsKey('provider')
-          ? getClusterProviderType(data['provider'])
+      type: data.containsKey('type')
+          ? getClusterProviderType(data['type'])
           : null,
       aws: data.containsKey('aws') && data['aws'] != null
           ? ClusterProviderAWS.fromJson(data['aws'])

--- a/lib/services/providers/aws_service.dart
+++ b/lib/services/providers/aws_service.dart
@@ -5,6 +5,35 @@ import 'package:flutter/services.dart';
 
 import 'package:kubenav/utils/logger.dart';
 
+/// [awsRegions] is a list of all available AWS regions. If AWS adds a new
+/// region it must be added to this list, so that a user can use the new region.
+const awsRegions = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+  'af-south-1',
+  'ap-east-1',
+  'ap-south-1',
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-northeast-3',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-southeast-3',
+  'ca-central-1',
+  'cn-north-1',
+  'cn-northwest-1',
+  'eu-central-1',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'eu-south-1',
+  'eu-north-1',
+  'me-south-1',
+  'sa-east-1',
+];
+
 /// [AWSCluster] is the format of a single cluster in the list of AWS clusters.
 /// Each cluster contains a [endpoint], a [name] and the [certificateAuthority].
 class AWSCluster {

--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -118,6 +118,7 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
               clusterServer: selectedCluster.endpoint ?? '',
               clusterCertificateAuthorityData:
                   selectedCluster.certificateAuthority?.data ?? '',
+              namespace: 'default',
             ),
           );
         }

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -122,6 +122,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
               userTokenExpireTimestamp:
                   widget.provider.awssso!.ssoCredentials?.accessTokenExpire ??
                       0,
+              namespace: 'default',
             ),
           );
         }

--- a/lib/widgets/settings/clusters/settings_add_cluster_google.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_google.dart
@@ -108,7 +108,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
             id: const Uuid().v4(),
             name: selectedCluster.name!,
             clusterProviderType: ClusterProviderType.google,
-            clusterProviderId: widget.provider.name ?? '',
+            clusterProviderId: widget.provider.id ?? '',
             clusterServer: 'https://${selectedCluster.endpoint!}',
             clusterCertificateAuthorityData:
                 selectedCluster.masterAuth?.clusterCaCertificate ?? '',
@@ -118,6 +118,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
             userClientKeyData: selectedCluster.masterAuth?.clientKey ?? '',
             userUsername: selectedCluster.masterAuth?.username ?? '',
             userPassword: selectedCluster.masterAuth?.password ?? '',
+            namespace: 'default',
           ),
         );
       }

--- a/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_awssso_provider_config.dart
+++ b/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_awssso_provider_config.dart
@@ -202,7 +202,7 @@ class _SettingsReauthenticateAWSSSOState
                 ),
               ),
             ),
-            onPressed: _verifyDevice,
+            onPressed: _awsSSOConfig == null ? null : _verifyDevice,
             child: Text(
               'Verify',
               style: primaryTextStyle(
@@ -229,7 +229,8 @@ class _SettingsReauthenticateAWSSSOState
                 ),
               ),
             ),
-            onPressed: _getSSOCredentials,
+            onPressed:
+                _awsSSOConfig == null || !_verified ? null : _getSSOCredentials,
             child: Text(
               'Get Credentials',
               style: primaryTextStyle(

--- a/lib/widgets/settings/providers/settings_aws_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_aws_provider_config.dart
@@ -6,6 +6,7 @@ import 'package:uuid/uuid.dart';
 import 'package:kubenav/models/cluster_provider.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/services/providers/aws_service.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/settings/clusters/settings_add_cluster_aws.dart';
@@ -220,31 +221,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
                         _region = newValue ?? '';
                       });
                     },
-                    items: [
-                      'us-east-1',
-                      'us-east-2',
-                      'us-west-1',
-                      'us-west-2',
-                      'af-south-1',
-                      'ap-east-1',
-                      'ap-south-1',
-                      'ap-northeast-1',
-                      'ap-northeast-2',
-                      'ap-northeast-3',
-                      'ap-southeast-1',
-                      'ap-southeast-2',
-                      'ca-central-1',
-                      'cn-north-1',
-                      'cn-northwest-1',
-                      'eu-central-1',
-                      'eu-west-1',
-                      'eu-west-2',
-                      'eu-west-3',
-                      'eu-south-1',
-                      'eu-north-1',
-                      'me-south-1',
-                      'sa-east-1',
-                    ].map((value) {
+                    items: awsRegions.map((value) {
                       return DropdownMenuItem(
                         value: value,
                         child: Text(

--- a/lib/widgets/settings/providers/settings_awssso_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_provider_config.dart
@@ -88,7 +88,9 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
   Future<void> _verifyDevice() async {
     try {
       await openUrl(_awsSSOConfig!.device!.verificationUriComplete!);
-      _verified = true;
+      setState(() {
+        _verified = true;
+      });
     } catch (err) {
       Logger.log(
         'SettingsAWSSSOProvider _verifyDevice',
@@ -347,31 +349,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                         _ssoRegion = newValue ?? '';
                       });
                     },
-                    items: [
-                      'us-east-1',
-                      'us-east-2',
-                      'us-west-1',
-                      'us-west-2',
-                      'af-south-1',
-                      'ap-east-1',
-                      'ap-south-1',
-                      'ap-northeast-1',
-                      'ap-northeast-2',
-                      'ap-northeast-3',
-                      'ap-southeast-1',
-                      'ap-southeast-2',
-                      'ca-central-1',
-                      'cn-north-1',
-                      'cn-northwest-1',
-                      'eu-central-1',
-                      'eu-west-1',
-                      'eu-west-2',
-                      'eu-west-3',
-                      'eu-south-1',
-                      'eu-north-1',
-                      'me-south-1',
-                      'sa-east-1',
-                    ].map((value) {
+                    items: awsRegions.map((value) {
                       return DropdownMenuItem(
                         value: value,
                         child: Text(
@@ -406,31 +384,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                         _region = newValue ?? '';
                       });
                     },
-                    items: [
-                      'us-east-1',
-                      'us-east-2',
-                      'us-west-1',
-                      'us-west-2',
-                      'af-south-1',
-                      'ap-east-1',
-                      'ap-south-1',
-                      'ap-northeast-1',
-                      'ap-northeast-2',
-                      'ap-northeast-3',
-                      'ap-southeast-1',
-                      'ap-southeast-2',
-                      'ca-central-1',
-                      'cn-north-1',
-                      'cn-northwest-1',
-                      'eu-central-1',
-                      'eu-west-1',
-                      'eu-west-2',
-                      'eu-west-3',
-                      'eu-south-1',
-                      'eu-north-1',
-                      'me-south-1',
-                      'sa-east-1',
-                    ].map((value) {
+                    items: awsRegions.map((value) {
                       return DropdownMenuItem(
                         value: value,
                         child: Text(
@@ -486,7 +440,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                     ),
                   ),
                 ),
-                onPressed: _verifyDevice,
+                onPressed: _awsSSOConfig == null ? null : _verifyDevice,
                 child: Text(
                   'Verify',
                   style: primaryTextStyle(
@@ -512,7 +466,9 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                     ),
                   ),
                 ),
-                onPressed: _getSSOCredentials,
+                onPressed: _awsSSOConfig == null || !_verified
+                    ? null
+                    : _getSSOCredentials,
                 child: Text(
                   'Get Credentials',
                   style: primaryTextStyle(

--- a/lib/widgets/settings/providers/settings_google_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_google_provider_config.dart
@@ -47,7 +47,8 @@ class _SettingsGoogleProviderState extends State<SettingsGoogleProvider> {
   Future<void> _signIn() async {
     try {
       await openUrl(
-          'https://accounts.google.com/o/oauth2/v2/auth?client_id=${_clientIDController.text}&redirect_uri=${Constants.googleRedirectURI}&response_type=code&scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&include_granted_scopes=true');
+        'https://accounts.google.com/o/oauth2/v2/auth?client_id=${_clientIDController.text}&redirect_uri=${Constants.googleRedirectURI}&response_type=code&scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&include_granted_scopes=true&prompt=consent',
+      );
     } catch (err) {
       Logger.log(
         'SettingsGoogleProvider _signIn',
@@ -129,6 +130,23 @@ class _SettingsGoogleProviderState extends State<SettingsGoogleProvider> {
           if (mounted) {
             Navigator.pop(context);
           }
+        }
+      } else {
+        Logger.log(
+          'SettingsGoogleProvider _saveProvider',
+          'Could not get credentials',
+          'Access Token: ${googleTokens.accessToken}, Expires In: ${googleTokens.expiresIn}, Refresh Token: ${googleTokens.refreshToken}',
+        );
+        setState(() {
+          _isLoading = false;
+        });
+
+        if (mounted) {
+          showSnackbar(
+            context,
+            'Could not get credentials',
+            'Access Token: ${googleTokens.accessToken}, Expires In: ${googleTokens.expiresIn}, Refresh Token: ${googleTokens.refreshToken}',
+          );
         }
       }
     } catch (err) {


### PR DESCRIPTION
This commit contains several small fixes with the configuration of the cluster providers, the added fixes are listed below:

- Use global list for AWS regions: Until now the supported AWS regions where maintained in across several widgets. Now we are using a globally available variable "awsRegions" to maintain them, so that we only have to add new regions at one place.
- The json parsing of the providers when they were read from disk contained a bug, so that the providers doesn't contain the provider type after they were read. This is now fixed, so that the provider type is also available after the providers were read from our storage.
- The created clusters for the AWS and Google provider didn't contain the "default" namespace, so that automatically all namespaces where selected. This is now changed, so that the "default" namespace is used like for the other providers.
- The AWS SSO handling was improved, by disabling the buttons which can not be used until a required action was executed. This should help users to perform all actions in the correct order.
- The refresh token handling for the Google provider was fixed. Until now it was only possible to use the OAuth client one time, because the seconde time the provider was used the response from Google didn't contain a refresh token, so that we were not able to use the provider. To fix this issue we had to add the "prompt=consent" parameter to the login url.