### PR TITLE
Fix Corners of Modal Bottom Sheet for Terminals

### DIFF
--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -74,6 +74,7 @@ class AppTerminalsWidget extends StatelessWidget {
             MediaQuery.of(context).size.height * (isKeyboardVisible ? 0.75 : 1),
         color: Colors.transparent,
         child: Scaffold(
+          backgroundColor: Colors.transparent,
           body: Container(
             padding: const EdgeInsets.only(
               left: Constants.spacingMiddle,


### PR DESCRIPTION
The corners of the modal bottom sheet for terminals and logs weren't rounded, becaus we didn't apply a transparent background color to the used Scaffold widget. This is now fixed, so that ther modal bottom sheet for terminals and logs looks exactly like the other modal bottom sheets.