### PR TITLE
Fix Cluster Names for Google and AWS Provider

### DIFF
--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -239,7 +239,11 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
                   Expanded(
                     flex: 1,
                     child: Text(
-                      _clusters[index].name ?? '',
+                      Characters(
+                        'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
                       style: noramlTextStyle(
                         context,
                       ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -244,7 +244,11 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
                   Expanded(
                     flex: 1,
                     child: Text(
-                      _clusters[index].name ?? '',
+                      Characters(
+                        'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
                       style: noramlTextStyle(
                         context,
                       ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
@@ -229,7 +229,11 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
                   Expanded(
                     flex: 1,
                     child: Text(
-                      _clusters[index].name ?? '',
+                      Characters(
+                        _clusters[index].name ?? '',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
                       style: noramlTextStyle(
                         context,
                       ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
@@ -247,7 +247,11 @@ class _SettingsAddClusterDigitalOceanState
                   Expanded(
                     flex: 1,
                     child: Text(
-                      _clusters[index].name ?? '',
+                      Characters(
+                        _clusters[index].name ?? '',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
                       style: noramlTextStyle(
                         context,
                       ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_google.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_google.dart
@@ -106,7 +106,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
         await clustersRepository.addCluster(
           Cluster(
             id: const Uuid().v4(),
-            name: selectedCluster.name!,
+            name: 'gke_${selectedCluster.location}_${selectedCluster.name}',
             clusterProviderType: ClusterProviderType.google,
             clusterProviderId: widget.provider.id ?? '',
             clusterServer: 'https://${selectedCluster.endpoint!}',
@@ -238,7 +238,11 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
                   Expanded(
                     flex: 1,
                     child: Text(
-                      _clusters[index].name ?? '',
+                      Characters(
+                        'gke_${_clusters[index].location}_${_clusters[index].name}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
                       style: noramlTextStyle(
                         context,
                       ),


### PR DESCRIPTION
The cluster name shown in the list where a user could select the clusters he wants to add and the name of the then added clusters were not the same. This is now fixed by using the same naming schema in both places.

This commit also improves the presentation of clusters in the select clusters view with very long names, so that they are cutted of at any character now, to show as much as possible from the name.