### PR TITLE
Improve Reorder Handling

### DIFF
--- a/lib/models/help.dart
+++ b/lib/models/help.dart
@@ -94,7 +94,7 @@ There are multiple ways to switch between clusters:
           markdown: '''
 You can sort your clusters on the **Clusters** page (**Settings** -> **View all**), so that your the cluster which you have to access the most is always on the top.
 
-To sort the clusters you have to **press longer** on the cluster name and move it up or down.
+To sort the clusters you have to **press on the status icon** of the cluster and move it up or down.
           ''',
         ),
       ],
@@ -341,7 +341,7 @@ To delete a namespace go to **Settings** -> **Namespaces**. Then **click** on th
           markdown: '''
 To sort the list of namespaces go to **Settings** -> **Namespaces**.
 
-To sort the namespaces you have to **press longer** on the namespace name and move it up or down.
+To sort the namespaces you have to **press on the drag handle icon** of the namespace and move it up or down.
           ''',
         ),
       ],
@@ -383,7 +383,7 @@ You can also delete bookmarks by click on **View all** in the **Bookmarks** sect
           markdown: '''
 You can sort you bookmarks on the **Bookmarks** page.
 
-To sort the bookmarks you have to **press longer** on a bookmark and move it up or down.
+To sort the bookmarks you have to **press on the drag handle icon** of the bookmark and move it up or down.
           ''',
         ),
       ],

--- a/lib/widgets/resources/bookmarks/resources_bookmark_actions.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmark_actions.dart
@@ -31,11 +31,12 @@ class ResourcesBookmarkActions extends StatelessWidget {
           title: 'Delete',
           color: theme(context).colorDanger,
           onTap: () {
+            final title = bookmarksRepository.bookmarks[index].title;
             bookmarksRepository.removeBookmark(index);
             showSnackbar(
               context,
               'Bookmark deleted',
-              '',
+              'Bookmakr $title was deleted',
             );
             Navigator.pop(context);
           },

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -37,11 +35,8 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        final double animValue = Curves.easeInOut.transform(animation.value);
-        final double elevation = lerpDouble(0, 6, animValue)!;
         return Material(
-          elevation: elevation,
-          shadowColor: theme(context).colorShadow,
+          elevation: 0,
           child: child,
         );
       },
@@ -148,10 +143,6 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
               shrinkWrap: true,
               buildDefaultDragHandles: false,
               physics: const NeverScrollableScrollPhysics(),
-              padding: const EdgeInsets.only(
-                right: Constants.spacingMiddle,
-                left: Constants.spacingMiddle,
-              ),
               onReorder: (int start, int current) {
                 bookmarksRepository.reorder(start, current);
               },
@@ -167,130 +158,126 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                   bookmarksRepository.bookmarks[index].clusterId,
                 );
 
-                return ReorderableDragStartListener(
+                return Container(
                   key: Key(
                     '${bookmarksRepository.bookmarks[index].type} ${bookmarksRepository.bookmarks[index].clusterId} ${bookmarksRepository.bookmarks[index].title} ${bookmarksRepository.bookmarks[index].resource} ${bookmarksRepository.bookmarks[index].path} ${bookmarksRepository.bookmarks[index].scope} ${bookmarksRepository.bookmarks[index].name} ${bookmarksRepository.bookmarks[index].namespace}',
                   ),
-                  index: index,
                   child: Container(
-                    key: Key(
-                      '${bookmarksRepository.bookmarks[index].type} ${bookmarksRepository.bookmarks[index].clusterId} ${bookmarksRepository.bookmarks[index].title} ${bookmarksRepository.bookmarks[index].resource} ${bookmarksRepository.bookmarks[index].path} ${bookmarksRepository.bookmarks[index].scope} ${bookmarksRepository.bookmarks[index].name} ${bookmarksRepository.bookmarks[index].namespace}',
+                    margin: const EdgeInsets.only(
+                      top: Constants.spacingSmall,
+                      bottom: Constants.spacingSmall,
+                      left: Constants.spacingMiddle,
+                      right: Constants.spacingMiddle,
                     ),
-                    child: Container(
-                      margin: const EdgeInsets.only(
-                        bottom: Constants.spacingMiddle,
-                      ),
-                      padding: const EdgeInsets.all(12.0),
-                      decoration: BoxDecoration(
-                        boxShadow: [
-                          BoxShadow(
-                            color: theme(context).colorShadow,
-                            blurRadius: Constants.sizeBorderBlurRadius,
-                            spreadRadius: Constants.sizeBorderSpreadRadius,
-                            offset: const Offset(0.0, 0.0),
-                          ),
-                        ],
-                        color: theme(context).colorCard,
-                        borderRadius: const BorderRadius.all(
-                          Radius.circular(Constants.sizeBorderRadius),
+                    padding: const EdgeInsets.all(12.0),
+                    decoration: BoxDecoration(
+                      boxShadow: [
+                        BoxShadow(
+                          color: theme(context).colorShadow,
+                          blurRadius: Constants.sizeBorderBlurRadius,
+                          spreadRadius: Constants.sizeBorderSpreadRadius,
+                          offset: const Offset(0.0, 0.0),
                         ),
+                      ],
+                      color: theme(context).colorCard,
+                      borderRadius: const BorderRadius.all(
+                        Radius.circular(Constants.sizeBorderRadius),
                       ),
-                      child: InkWell(
-                        onTap: () {
-                          openBookmark(context, index);
-                        },
-                        onDoubleTap: () {
-                          showActions(
-                            context,
-                            ResourcesBookmarkActions(
-                              index: index,
-                            ),
-                          );
-                        },
-                        child: Column(
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Expanded(
-                                  child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        bookmarksRepository
-                                            .bookmarks[index].title,
-                                        style: primaryTextStyle(
-                                          context,
-                                        ),
+                    ),
+                    child: InkWell(
+                      onTap: () {
+                        openBookmark(context, index);
+                      },
+                      onDoubleTap: () {
+                        showActions(
+                          context,
+                          ResourcesBookmarkActions(
+                            index: index,
+                          ),
+                        );
+                      },
+                      child: Column(
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      bookmarksRepository
+                                          .bookmarks[index].title,
+                                      style: primaryTextStyle(
+                                        context,
                                       ),
-                                      Column(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.start,
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            Characters(
-                                              'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
-                                            )
-                                                .replaceAll(Characters(''),
-                                                    Characters('\u{200B}'))
-                                                .toString(),
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
+                                    ),
+                                    Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          Characters(
+                                            'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
+                                          )
+                                              .replaceAll(Characters(''),
+                                                  Characters('\u{200B}'))
+                                              .toString(),
+                                          style: secondaryTextStyle(
+                                            context,
                                           ),
-                                          Text(
-                                            Characters(
-                                              'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
-                                            )
-                                                .replaceAll(Characters(''),
-                                                    Characters('\u{200B}'))
-                                                .toString(),
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                        Text(
+                                          Characters(
+                                            'Namespace: ${bookmarksRepository.bookmarks[index].namespace}',
+                                          )
+                                              .replaceAll(Characters(''),
+                                                  Characters('\u{200B}'))
+                                              .toString(),
+                                          style: secondaryTextStyle(
+                                            context,
                                           ),
-                                          bookmarksRepository
-                                                      .bookmarks[index].name !=
-                                                  null
-                                              ? Text(
-                                                  Characters(
-                                                    'Name: ${bookmarksRepository.bookmarks[index].name}',
-                                                  )
-                                                      .replaceAll(
-                                                          Characters(''),
-                                                          Characters(
-                                                              '\u{200B}'))
-                                                      .toString(),
-                                                  style: secondaryTextStyle(
-                                                    context,
-                                                  ),
-                                                  maxLines: 1,
-                                                  overflow:
-                                                      TextOverflow.ellipsis,
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                        bookmarksRepository
+                                                    .bookmarks[index].name !=
+                                                null
+                                            ? Text(
+                                                Characters(
+                                                  'Name: ${bookmarksRepository.bookmarks[index].name}',
                                                 )
-                                              : Container(),
-                                        ],
-                                      )
-                                    ],
-                                  ),
+                                                    .replaceAll(Characters(''),
+                                                        Characters('\u{200B}'))
+                                                    .toString(),
+                                                style: secondaryTextStyle(
+                                                  context,
+                                                ),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              )
+                                            : Container(),
+                                      ],
+                                    )
+                                  ],
                                 ),
-                                Icon(
-                                  Icons.arrow_forward_ios,
+                              ),
+                              ReorderableDragStartListener(
+                                index: index,
+                                child: Icon(
+                                  Icons.drag_handle,
                                   color: Colors.grey[300],
                                   size: 24,
                                 ),
-                              ],
-                            ),
-                          ],
-                        ),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -18,12 +18,14 @@ import 'package:kubenav/utils/logger.dart';
 class SettingsClusterItem extends StatefulWidget {
   const SettingsClusterItem({
     Key? key,
+    required this.index,
     required this.cluster,
     required this.isActiveCluster,
     this.onTap,
     this.onDoubleTap,
   }) : super(key: key);
 
+  final int index;
   final Cluster cluster;
   final bool isActiveCluster;
   final void Function()? onTap;
@@ -90,7 +92,10 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.only(
-        bottom: Constants.spacingMiddle,
+        top: Constants.spacingSmall,
+        bottom: Constants.spacingSmall,
+        left: Constants.spacingMiddle,
+        right: Constants.spacingMiddle,
       ),
       padding: const EdgeInsets.all(12.0),
       decoration: BoxDecoration(
@@ -146,14 +151,17 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
                     ],
                   ),
                 ),
-                Icon(
-                  widget.isActiveCluster
-                      ? Icons.radio_button_checked
-                      : Icons.radio_button_unchecked,
-                  size: 24,
-                  color: statusOk
-                      ? theme(context).colorSuccess
-                      : theme(context).colorDanger,
+                ReorderableDragStartListener(
+                  index: widget.index,
+                  child: Icon(
+                    widget.isActiveCluster
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    size: 24,
+                    color: statusOk
+                        ? theme(context).colorSuccess
+                        : theme(context).colorDanger,
+                  ),
                 ),
               ],
             ),

--- a/lib/widgets/settings/settings_clusters.dart
+++ b/lib/widgets/settings/settings_clusters.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
@@ -37,11 +36,8 @@ class SettingsClusters extends StatelessWidget {
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        final double animValue = Curves.easeInOut.transform(animation.value);
-        final double elevation = lerpDouble(0, 6, animValue)!;
         return Material(
-          elevation: elevation,
-          shadowColor: theme(context).colorShadow,
+          elevation: 0,
           child: child,
         );
       },
@@ -162,10 +158,6 @@ class SettingsClusters extends StatelessWidget {
               shrinkWrap: true,
               buildDefaultDragHandles: false,
               physics: const NeverScrollableScrollPhysics(),
-              padding: const EdgeInsets.only(
-                right: Constants.spacingMiddle,
-                left: Constants.spacingMiddle,
-              ),
               onReorder: (int start, int current) {
                 clustersRepository.reorderClusters(start, current);
               },
@@ -177,34 +169,29 @@ class SettingsClusters extends StatelessWidget {
                 context,
                 index,
               ) {
-                return ReorderableDragStartListener(
+                return Container(
                   key: Key(
                     clustersRepository.clusters[index].id,
                   ),
-                  index: index,
-                  child: Container(
-                    key: Key(
-                      clustersRepository.clusters[index].id,
-                    ),
-                    child: SettingsClusterItem(
-                      key: Key(clustersRepository.clusters[index].id),
-                      cluster: clustersRepository.clusters[index],
-                      isActiveCluster: clustersRepository.clusters[index].id ==
-                          clustersRepository.activeClusterId,
-                      onTap: () {
-                        clustersRepository.setActiveCluster(
-                          clustersRepository.clusters[index].id,
-                        );
-                      },
-                      onDoubleTap: () {
-                        showActions(
-                          context,
-                          SettingsClusterActions(
-                            cluster: clustersRepository.clusters[index],
-                          ),
-                        );
-                      },
-                    ),
+                  child: SettingsClusterItem(
+                    key: Key(clustersRepository.clusters[index].id),
+                    index: index,
+                    cluster: clustersRepository.clusters[index],
+                    isActiveCluster: clustersRepository.clusters[index].id ==
+                        clustersRepository.activeClusterId,
+                    onTap: () {
+                      clustersRepository.setActiveCluster(
+                        clustersRepository.clusters[index].id,
+                      );
+                    },
+                    onDoubleTap: () {
+                      showActions(
+                        context,
+                        SettingsClusterActions(
+                          cluster: clustersRepository.clusters[index],
+                        ),
+                      );
+                    },
                   ),
                 );
               },

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -22,18 +20,15 @@ import 'package:kubenav/widgets/shared/app_floating_action_buttons_widget.dart';
 class SettingsNamespaces extends StatelessWidget {
   const SettingsNamespaces({Key? key}) : super(key: key);
 
-  /// [_proxyDecorator] is used to highlight the cluster which is currently
+  /// [_proxyDecorator] is used to highlight the bookmark which is currently
   /// draged by the user.
   Widget _proxyDecorator(BuildContext context, Widget child, int index,
       Animation<double> animation) {
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        final double animValue = Curves.easeInOut.transform(animation.value);
-        final double elevation = lerpDouble(0, 6, animValue)!;
         return Material(
-          elevation: elevation,
-          shadowColor: theme(context).colorShadow,
+          elevation: 0,
           child: child,
         );
       },
@@ -54,7 +49,10 @@ class SettingsNamespaces extends StatelessWidget {
     return Container(
       key: Key('$index'),
       margin: const EdgeInsets.only(
-        bottom: Constants.spacingMiddle,
+        top: Constants.spacingSmall,
+        bottom: Constants.spacingSmall,
+        left: Constants.spacingMiddle,
+        right: Constants.spacingMiddle,
       ),
       padding: const EdgeInsets.all(12.0),
       decoration: BoxDecoration(
@@ -96,6 +94,13 @@ class SettingsNamespaces extends StatelessWidget {
                 ],
               ),
             ),
+            ReorderableDragStartListener(
+              index: index,
+              child: Icon(
+                Icons.drag_handle,
+                color: Colors.grey[300],
+              ),
+            ),
           ],
         ),
       ),
@@ -135,36 +140,23 @@ class SettingsNamespaces extends StatelessWidget {
         child: Column(
           children: [
             const SizedBox(height: Constants.spacingLarge),
-            Padding(
-              padding: const EdgeInsets.only(
-                left: Constants.spacingMiddle,
-                right: Constants.spacingMiddle,
-              ),
-              child: ReorderableListView.builder(
-                shrinkWrap: true,
-                buildDefaultDragHandles: false,
-                physics: const NeverScrollableScrollPhysics(),
-                onReorder: (int start, int current) {
-                  appRepository.reorderNamespaces(start, current);
-                },
-                proxyDecorator: (
-                  Widget child,
-                  int index,
-                  Animation<double> animation,
-                ) =>
-                    _proxyDecorator(context, child, index, animation),
-                itemCount: appRepository.settings.namespaces.length,
-                itemBuilder: (
-                  context,
-                  index,
-                ) {
-                  return ReorderableDragStartListener(
-                    key: Key('$index'),
-                    index: index,
-                    child: buildNamespace(context, index),
-                  );
-                },
-              ),
+            ReorderableListView.builder(
+              shrinkWrap: true,
+              buildDefaultDragHandles: false,
+              physics: const NeverScrollableScrollPhysics(),
+              onReorder: (int start, int current) {
+                appRepository.reorderNamespaces(start, current);
+              },
+              proxyDecorator:
+                  (Widget child, int index, Animation<double> animation) =>
+                      _proxyDecorator(context, child, index, animation),
+              itemCount: appRepository.settings.namespaces.length,
+              itemBuilder: (
+                context,
+                index,
+              ) {
+                return buildNamespace(context, index);
+              },
             ),
             const SizedBox(height: Constants.spacingSmall),
           ],


### PR DESCRIPTION
This commit improves the reorder handling of clusters, namespaces and bookmarks. Until now it was difficult to scroll in the clusters, namespaces or bookmarks list, because this automatically triggered the reordering. This is now fixed by adding dedicated drag handles to these lists, which can be used to reorder them.

Note: The drag handle icon in the clusters list is the status indicator icon. We decided to reuse this icon, so that we do not have to add two different icons to the list.