### PR TITLE
Improve Selection of Clusters

### DIFF
--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -208,49 +208,40 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: Row(
-                children: [
-                  Checkbox(
-                    checkColor: Colors.white,
-                    fillColor: MaterialStateProperty.all(
-                      theme(context).colorPrimary,
-                    ),
-                    value: _selectedClusters
-                            .where((c) => c.name == _clusters[index].name)
-                            .toList()
-                            .length ==
-                        1,
-                    onChanged: (bool? value) {
-                      if (value == true) {
-                        setState(() {
-                          _selectedClusters.add(_clusters[index]);
-                        });
-                      }
-                      if (value == false) {
-                        setState(() {
-                          _selectedClusters = _selectedClusters
-                              .where((c) => c.name != _clusters[index].name)
-                              .toList();
-                        });
-                      }
-                    },
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedClusters
+                        .where((c) => c.name == _clusters[index].name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedClusters.add(_clusters[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedClusters = _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
                   ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      Characters(
-                        'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             );
           },

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -213,49 +213,40 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: Row(
-                children: [
-                  Checkbox(
-                    checkColor: Colors.white,
-                    fillColor: MaterialStateProperty.all(
-                      theme(context).colorPrimary,
-                    ),
-                    value: _selectedClusters
-                            .where((c) => c.name == _clusters[index].name)
-                            .toList()
-                            .length ==
-                        1,
-                    onChanged: (bool? value) {
-                      if (value == true) {
-                        setState(() {
-                          _selectedClusters.add(_clusters[index]);
-                        });
-                      }
-                      if (value == false) {
-                        setState(() {
-                          _selectedClusters = _selectedClusters
-                              .where((c) => c.name != _clusters[index].name)
-                              .toList();
-                        });
-                      }
-                    },
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedClusters
+                        .where((c) => c.name == _clusters[index].name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedClusters.add(_clusters[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedClusters = _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
                   ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      Characters(
-                        'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             );
           },

--- a/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
@@ -198,49 +198,40 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: Row(
-                children: [
-                  Checkbox(
-                    checkColor: Colors.white,
-                    fillColor: MaterialStateProperty.all(
-                      theme(context).colorPrimary,
-                    ),
-                    value: _selectedClusters
-                            .where((c) => c.name == _clusters[index].name)
-                            .toList()
-                            .length ==
-                        1,
-                    onChanged: (bool? value) {
-                      if (value == true) {
-                        setState(() {
-                          _selectedClusters.add(_clusters[index]);
-                        });
-                      }
-                      if (value == false) {
-                        setState(() {
-                          _selectedClusters = _selectedClusters
-                              .where((c) => c.name != _clusters[index].name)
-                              .toList();
-                        });
-                      }
-                    },
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedClusters
+                        .where((c) => c.name == _clusters[index].name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedClusters.add(_clusters[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedClusters = _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    _clusters[index].name ?? '',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
                   ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      Characters(
-                        _clusters[index].name ?? '',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             );
           },

--- a/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
@@ -216,49 +216,40 @@ class _SettingsAddClusterDigitalOceanState
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: Row(
-                children: [
-                  Checkbox(
-                    checkColor: Colors.white,
-                    fillColor: MaterialStateProperty.all(
-                      theme(context).colorPrimary,
-                    ),
-                    value: _selectedClusters
-                            .where((c) => c.name == _clusters[index].name)
-                            .toList()
-                            .length ==
-                        1,
-                    onChanged: (bool? value) {
-                      if (value == true) {
-                        setState(() {
-                          _selectedClusters.add(_clusters[index]);
-                        });
-                      }
-                      if (value == false) {
-                        setState(() {
-                          _selectedClusters = _selectedClusters
-                              .where((c) => c.name != _clusters[index].name)
-                              .toList();
-                        });
-                      }
-                    },
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedClusters
+                        .where((c) => c.name == _clusters[index].name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedClusters.add(_clusters[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedClusters = _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    _clusters[index].name ?? '',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
                   ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      Characters(
-                        _clusters[index].name ?? '',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             );
           },

--- a/lib/widgets/settings/clusters/settings_add_cluster_google.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_google.dart
@@ -207,49 +207,40 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              child: Row(
-                children: [
-                  Checkbox(
-                    checkColor: Colors.white,
-                    fillColor: MaterialStateProperty.all(
-                      theme(context).colorPrimary,
-                    ),
-                    value: _selectedClusters
-                            .where((c) => c.name == _clusters[index].name)
-                            .toList()
-                            .length ==
-                        1,
-                    onChanged: (bool? value) {
-                      if (value == true) {
-                        setState(() {
-                          _selectedClusters.add(_clusters[index]);
-                        });
-                      }
-                      if (value == false) {
-                        setState(() {
-                          _selectedClusters = _selectedClusters
-                              .where((c) => c.name != _clusters[index].name)
-                              .toList();
-                        });
-                      }
-                    },
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedClusters
+                        .where((c) => c.name == _clusters[index].name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedClusters.add(_clusters[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedClusters = _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    'gke_${_clusters[index].location}_${_clusters[index].name}',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
                   ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      Characters(
-                        'gke_${_clusters[index].location}_${_clusters[index].name}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             );
           },


### PR DESCRIPTION
When a cluster is added via the Google, AWS or Azure provider it is now easier to select the clusters which should be added. Before this change it was only possible to select the clusters by clicking on the corresponding checkbox. Now it is also possible to select the cluster by clicking on the name. This is possible because we are using the "CheckboxListTile" now.