### PR TITLE
Improve List of Manual Maintained Namespaces

### DIFF
--- a/lib/models/help.dart
+++ b/lib/models/help.dart
@@ -324,6 +324,8 @@ On the namespaces page select the **Plus** icon in the op right corner.
 Then provide the **Name** of the namespace and click **Add Namespace**
 
 ![Add a Namespace](resource:assets/help/namespaces-add-namespace-3.png)
+
+You can also use the **star icon** on the details page for a namespace, to add / remove the namespace from the list of namespaces.
           ''',
         ),
         HelpItem(

--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -195,15 +195,21 @@ class AppRepository with ChangeNotifier {
   /// [addNamespace] adds the provided [value] to the list of the users favorite
   /// namespaces.
   Future<void> addNamespace(String value) async {
-    _settings.namespaces.add(value);
-    await _save();
-    notifyListeners();
+    if (_settings.namespaces.where((e) => e == value).toList().isEmpty) {
+      _settings.namespaces.add(value);
+      await _save();
+      notifyListeners();
+    }
   }
 
-  /// [deleteNamespace] deletes the namespace with the provided [index] from the
+  /// [deleteNamespace] deletes the namespace with the provided [value] from the
   /// list of the users favorite namespaces.
-  Future<void> deleteNamespace(int index) async {
-    _settings.namespaces.removeAt(index);
+  Future<void> deleteNamespace(String value) async {
+    _settings.namespaces = _settings.namespaces
+        .where(
+          (e) => e != value,
+        )
+        .toList();
     await _save();
     notifyListeners();
   }

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -139,6 +139,11 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
     String? namespace,
     dynamic item,
   ) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
     final List<AppActionsHeaderModel> additionalActions = [];
 
     if ((Resources.map['deployments']!.resource == resource &&
@@ -271,6 +276,31 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
       );
     }
 
+    if (Resources.map['namespaces']!.resource == resource &&
+        Resources.map['namespaces']!.path == path) {
+      additionalActions.add(
+        AppActionsHeaderModel(
+          title: 'Favorite',
+          icon: appRepository.settings.namespaces
+                  .where((e) => e == name)
+                  .toList()
+                  .isEmpty
+              ? Icons.star_outline
+              : Icons.star,
+          onTap: () {
+            if (appRepository.settings.namespaces
+                .where((e) => e == name)
+                .toList()
+                .isEmpty) {
+              appRepository.addNamespace(name);
+            } else {
+              appRepository.deleteNamespace(name);
+            }
+          },
+        ),
+      );
+    }
+
     return additionalActions;
   }
 
@@ -285,10 +315,6 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
   @override
   Widget build(BuildContext context) {
     Provider.of<ThemeRepository>(
-      context,
-      listen: true,
-    );
-    AppRepository appRepository = Provider.of<AppRepository>(
       context,
       listen: true,
     );
@@ -378,6 +404,10 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
                       );
                     }
 
+                    AppRepository appRepository = Provider.of<AppRepository>(
+                      context,
+                      listen: true,
+                    );
                     BookmarksRepository bookmarksRepository =
                         Provider.of<BookmarksRepository>(
                       context,

--- a/lib/widgets/settings/namespaces/settings_delete_namespace.dart
+++ b/lib/widgets/settings/namespaces/settings_delete_namespace.dart
@@ -12,10 +12,10 @@ import 'package:kubenav/widgets/shared/app_actions_widget.dart';
 class SettingsDeleteNamespace extends StatelessWidget {
   const SettingsDeleteNamespace({
     Key? key,
-    required this.index,
+    required this.namespace,
   }) : super(key: key);
 
-  final int index;
+  final String namespace;
 
   @override
   Widget build(BuildContext context) {
@@ -30,8 +30,7 @@ class SettingsDeleteNamespace extends StatelessWidget {
           title: 'Delete',
           color: theme(context).colorDanger,
           onTap: () {
-            final namespace = appRepository.settings.namespaces[index];
-            appRepository.deleteNamespace(index);
+            appRepository.deleteNamespace(namespace);
             showSnackbar(
               context,
               'Namespace deleted',

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -47,7 +47,7 @@ class SettingsNamespaces extends StatelessWidget {
     );
 
     return Container(
-      key: Key('$index'),
+      key: Key(appRepository.settings.namespaces[index]),
       margin: const EdgeInsets.only(
         top: Constants.spacingSmall,
         bottom: Constants.spacingSmall,
@@ -73,7 +73,9 @@ class SettingsNamespaces extends StatelessWidget {
         onTap: () {
           showActions(
             context,
-            SettingsDeleteNamespace(index: index),
+            SettingsDeleteNamespace(
+              namespace: appRepository.settings.namespaces[index],
+            ),
           );
         },
         child: Row(


### PR DESCRIPTION
It is possible to maintain a manuall list of namespaces within the app, to have quick access to your favorite/most used namespaces. This commit adds the following improvements for this feature:

- The list of namespaces is now unique, this means it is not possible to add a namespace twice. If a user tries to add an already existing namespace to the list of namespaces, the namespace will silently not be added.
- Namespaces can now also be added to the list of namespaces, from the details page of a namespace in the resources details via the "star icon". If the namespace is already in the list of namespaces it can also be removed via this icon. Similar to the bookmarks icon the start icon is outlined when the namespace is not in the list and filled when it is in the list.
- Since the list of namespaces now only contains unique entries, we use the namespace as key in the ReorderableListView widget instead of the index.