### PR TITLE
Fix Theming of Icons

### DIFF
--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -17,8 +17,7 @@ class Constants {
 
   static const spacingIcon54x54 = 6.0;
 
-  static const opacityLight = 0.75;
-  static const opacityHeavy = 0.25;
+  static const opacityIcon = 0.25;
 
   static const pageIndexHome = 0;
   static const pageIndexResources = 1;

--- a/lib/widgets/plugins/plugins.dart
+++ b/lib/widgets/plugins/plugins.dart
@@ -88,7 +88,9 @@ class Plugins extends StatelessWidget {
               const SizedBox(width: Constants.spacingSmall),
               Icon(
                 Icons.arrow_forward_ios,
-                color: Colors.grey[300],
+                color: theme(context)
+                    .colorTextSecondary
+                    .withOpacity(Constants.opacityIcon),
                 size: 24,
               ),
             ],
@@ -138,7 +140,9 @@ class Plugins extends StatelessWidget {
               const SizedBox(width: Constants.spacingSmall),
               Icon(
                 Icons.arrow_forward_ios,
-                color: Colors.grey[300],
+                color: theme(context)
+                    .colorTextSecondary
+                    .withOpacity(Constants.opacityIcon),
                 size: 24,
               ),
             ],

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -271,7 +271,9 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                                 index: index,
                                 child: Icon(
                                   Icons.drag_handle,
-                                  color: Colors.grey[300],
+                                  color: theme(context)
+                                      .colorTextSecondary
+                                      .withOpacity(Constants.opacityIcon),
                                   size: 24,
                                 ),
                               ),

--- a/lib/widgets/resources/details/configmap_details_item.dart
+++ b/lib/widgets/resources/details/configmap_details_item.dart
@@ -135,7 +135,9 @@ class ConfigMapDetailsItem extends StatelessWidget
                     const SizedBox(width: Constants.spacingSmall),
                     Icon(
                       Icons.arrow_forward_ios,
-                      color: Colors.grey[300],
+                      color: theme(context)
+                          .colorTextSecondary
+                          .withOpacity(Constants.opacityIcon),
                       size: 24,
                     ),
                   ],

--- a/lib/widgets/resources/details/details_container.dart
+++ b/lib/widgets/resources/details/details_container.dart
@@ -265,7 +265,9 @@ class DetailsContainer extends StatelessWidget {
                       const SizedBox(width: Constants.spacingSmall),
                       Icon(
                         Icons.arrow_forward_ios,
-                        color: Colors.grey[300],
+                        color: theme(context)
+                            .colorTextSecondary
+                            .withOpacity(Constants.opacityIcon),
                         size: 24,
                       ),
                     ],
@@ -332,7 +334,9 @@ class DetailsContainer extends StatelessWidget {
                       const SizedBox(width: Constants.spacingSmall),
                       Icon(
                         Icons.arrow_forward_ios,
-                        color: Colors.grey[300],
+                        color: theme(context)
+                            .colorTextSecondary
+                            .withOpacity(Constants.opacityIcon),
                         size: 24,
                       ),
                     ],

--- a/lib/widgets/resources/details/secret_details_item.dart
+++ b/lib/widgets/resources/details/secret_details_item.dart
@@ -136,7 +136,9 @@ class SecretDetailsItem extends StatelessWidget implements IDetailsItemWidget {
                     const SizedBox(width: Constants.spacingSmall),
                     Icon(
                       Icons.arrow_forward_ios,
-                      color: Colors.grey[300],
+                      color: theme(context)
+                          .colorTextSecondary
+                          .withOpacity(Constants.opacityIcon),
                       size: 24,
                     ),
                   ],

--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -101,7 +101,9 @@ class Resources extends StatelessWidget {
                 const SizedBox(width: Constants.spacingSmall),
                 Icon(
                   Icons.arrow_forward_ios,
-                  color: Colors.grey[300],
+                  color: theme(context)
+                      .colorTextSecondary
+                      .withOpacity(Constants.opacityIcon),
                   size: 24,
                 ),
               ],

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -238,7 +238,9 @@ class Settings extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -271,7 +273,9 @@ class Settings extends StatelessWidget {
           ),
           Icon(
             Icons.arrow_forward_ios,
-            color: Colors.grey[300],
+            color: theme(context)
+                .colorTextPrimary
+                .withOpacity(Constants.opacityIcon),
             size: 16,
           ),
         ],
@@ -452,7 +456,9 @@ class Settings extends StatelessWidget {
           ),
           Icon(
             Icons.arrow_forward_ios,
-            color: Colors.grey[300],
+            color: theme(context)
+                .colorTextPrimary
+                .withOpacity(Constants.opacityIcon),
             size: 16,
           ),
         ],
@@ -486,7 +492,9 @@ class Settings extends StatelessWidget {
           ),
           Icon(
             Icons.arrow_forward_ios,
-            color: Colors.grey[300],
+            color: theme(context)
+                .colorTextPrimary
+                .withOpacity(Constants.opacityIcon),
             size: 16,
           ),
         ],
@@ -520,7 +528,9 @@ class Settings extends StatelessWidget {
           ),
           Icon(
             Icons.arrow_forward_ios,
-            color: Colors.grey[300],
+            color: theme(context)
+                .colorTextPrimary
+                .withOpacity(Constants.opacityIcon),
             size: 16,
           ),
         ],
@@ -561,7 +571,9 @@ class Settings extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -590,7 +602,9 @@ class Settings extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -182,7 +182,9 @@ class _SettingsInfoState extends State<SettingsInfo> {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -208,7 +210,9 @@ class _SettingsInfoState extends State<SettingsInfo> {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -234,7 +238,9 @@ class _SettingsInfoState extends State<SettingsInfo> {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -260,7 +266,9 @@ class _SettingsInfoState extends State<SettingsInfo> {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],

--- a/lib/widgets/settings/settings/settings_sponsor.dart
+++ b/lib/widgets/settings/settings/settings_sponsor.dart
@@ -57,7 +57,9 @@ class SettingsSponsor extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -83,7 +85,9 @@ class SettingsSponsor extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],

--- a/lib/widgets/settings/settings_help.dart
+++ b/lib/widgets/settings/settings_help.dart
@@ -80,7 +80,9 @@ class SettingsHelp extends StatelessWidget {
             ),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
               size: 16,
             ),
           ],

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -100,7 +100,9 @@ class SettingsNamespaces extends StatelessWidget {
               index: index,
               child: Icon(
                 Icons.drag_handle,
-                color: Colors.grey[300],
+                color: theme(context)
+                    .colorTextPrimary
+                    .withOpacity(Constants.opacityIcon),
               ),
             ),
           ],

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -107,7 +107,9 @@ class SettingsProviders extends StatelessWidget {
             const SizedBox(width: Constants.spacingSmall),
             Icon(
               Icons.arrow_forward_ios,
-              color: Colors.grey[300],
+              color: theme(context)
+                  .colorTextSecondary
+                  .withOpacity(Constants.opacityIcon),
               size: 24,
             ),
           ],


### PR DESCRIPTION
Some icons were still using a static color instead of a color from our theme. The color of the icons which were using "Colors.grey[300]" are now using the primary or secondary text color of the selected theme.

The icons are using the primary text color when the text uses the primary color. If the text uses the primary and secondary color the icons will use the secondary color.