### PR TITLE
Allow Sponsoring via In-App Purchases

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -263,6 +263,8 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       } else {
         prometheusGetData(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout, request, result)
       }
+    } else if (call.method == "verifyIAP") {
+      result.notImplemented()
     } else {
       result.notImplemented()
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,7 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
+  pod 'TPInAppReceipt'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - ASN1Swift (1.2.3)
   - file_picker (0.0.1):
     - Flutter
   - Flutter (1.0.0)
@@ -6,6 +7,9 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - in_app_purchase_storekit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - local_auth_ios (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -14,6 +18,10 @@ PODS:
     - Flutter
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - TPInAppReceipt (3.3.4):
+    - TPInAppReceipt/Core (= 3.3.4)
+  - TPInAppReceipt/Core (3.3.4):
+    - ASN1Swift (~> 1.2.3)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -22,11 +30,18 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - in_app_purchase_storekit (from `.symlinks/plugins/in_app_purchase_storekit/ios`)
   - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - TPInAppReceipt
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+
+SPEC REPOS:
+  trunk:
+    - ASN1Swift
+    - TPInAppReceipt
 
 EXTERNAL SOURCES:
   file_picker:
@@ -37,6 +52,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  in_app_purchase_storekit:
+    :path: ".symlinks/plugins/in_app_purchase_storekit/ios"
   local_auth_ios:
     :path: ".symlinks/plugins/local_auth_ios/ios"
   package_info_plus:
@@ -49,16 +66,19 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  ASN1Swift: 73ba94f1d97c1c1d059d180708ad42845aeac4f9
   file_picker: de36ba292d3aa84e0b930a7643e8fd4586e24b21
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
+  in_app_purchase_storekit: 6b297e2b5eab9fa3251a492d57301722e4132a71
   local_auth_ios: 0d333dde7780f669e66f19d2ff6005f3ea84008d
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  TPInAppReceipt: 75ff97f2484a463cf46c172fe7f94225612aeda1
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
-PODFILE CHECKSUM: 4edb9fe21ef782edabd91e17f4b0817ee2c836b0
+PODFILE CHECKSUM: 5940ec6229ee284fb278e545e561ade0256fc5eb
 
 COCOAPODS: 1.11.3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		5520950029744B3100C0B38A /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552094FF29744B3100C0B38A /* StoreKit.framework */; };
 		55430D6127DCF9DF00E69423 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55430D6027DCF9DF00E69423 /* DispatchQueue.swift */; };
 		559DC63327C8D7020018E78E /* Kubenav.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559DC63127C8D6D50018E78E /* Kubenav.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
 		55C4E37827C952630039D04B /* KubenavPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C4E37727C952630039D04B /* KubenavPlugin.swift */; };
@@ -23,6 +24,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		552094FF29744B3100C0B38A /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		55430D6027DCF9DF00E69423 /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
 		559DC63127C8D6D50018E78E /* Kubenav.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Kubenav.xcframework; sourceTree = "<group>"; };
 		55C4E37727C952630039D04B /* KubenavPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubenavPlugin.swift; sourceTree = "<group>"; };
@@ -47,6 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5520950029744B3100C0B38A /* StoreKit.framework in Frameworks */,
 				559DC63327C8D7020018E78E /* Kubenav.xcframework in Frameworks */,
 				57B7696AAFE673571F3BDBEA /* Pods_Runner.framework in Frameworks */,
 			);
@@ -76,6 +79,7 @@
 		76CEC9B19E329A0DB6462407 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				552094FF29744B3100C0B38A /* StoreKit.framework */,
 				6F980B2BF4402CFBF648A1A8 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -1,4 +1,5 @@
 import UIKit
+import TPInAppReceipt
 import Flutter
 import Kubenav
 
@@ -253,6 +254,8 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
+    } else if call.method == "verifyIAP" {
+      verifyIAP(result: result)
     } else {
       result(FlutterMethodNotImplemented)
     }
@@ -438,6 +441,22 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
       result(FlutterError(code: "PROMETHEUS_GET_DATA_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
       result(data)
+    }
+  }
+
+  private func verifyIAP(result: FlutterResult) {
+    do {
+      let receipt = try InAppReceipt.localReceipt()
+      try receipt.validate()
+
+      let activePurchases: [InAppPurchase] = receipt.activeAutoRenewableSubscriptionPurchases
+      if activePurchases.isEmpty {
+        result("false")
+      } else {
+        result("true")
+      }
+    } catch {
+      result(FlutterError(code: "VERIFY_IAP_FAILED", message: error.localizedDescription, details: nil))
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/bookmarks_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/portforwarding_repository.dart';
+import 'package:kubenav/repositories/sponsor_repository.dart';
 import 'package:kubenav/repositories/terminal_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/services/kubenav_desktop.dart';
@@ -59,6 +60,7 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => SponsorRepository()),
         ChangeNotifierProvider(create: (_) => ThemeRepository()),
         ChangeNotifierProvider(create: (_) => AppRepository()),
         ChangeNotifierProvider(create: (_) => ClustersRepository()),

--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -315,6 +315,16 @@ class AppRepository with ChangeNotifier {
       notifyListeners();
     } catch (_) {}
   }
+
+  /// [setSponsorReminder] sets the sponsor reminder to the provided [value].
+  /// The value must be a unix timestamp in milliseconds which is in the future.
+  Future<void> setSponsorReminder(int value) async {
+    try {
+      _settings.sponsorReminder = value;
+      await _save();
+      notifyListeners();
+    } catch (_) {}
+  }
 }
 
 /// The [AppRepositorySettings] model represents all the app settings which can
@@ -326,6 +336,7 @@ class AppRepositorySettings {
   String editorFormat;
   String proxy;
   int timeout;
+  int sponsorReminder;
   AppRepositorySettingsPrometheus prometheus;
 
   AppRepositorySettings({
@@ -335,6 +346,7 @@ class AppRepositorySettings {
     required this.editorFormat,
     required this.proxy,
     required this.timeout,
+    required this.sponsorReminder,
     required this.prometheus,
   });
 
@@ -346,6 +358,7 @@ class AppRepositorySettings {
       editorFormat: 'yaml',
       proxy: '',
       timeout: 0,
+      sponsorReminder: 0,
       prometheus: AppRepositorySettingsPrometheus.fromDefault(),
     );
   }
@@ -373,6 +386,10 @@ class AppRepositorySettings {
       timeout: data.containsKey('timeout') && data['timeout'] != null
           ? data['timeout']
           : 0,
+      sponsorReminder:
+          data.containsKey('sponsorReminder') && data['sponsorReminder'] != null
+              ? data['sponsorReminder']
+              : 0,
       prometheus: data.containsKey('prometheus') && data['prometheus'] != null
           ? AppRepositorySettingsPrometheus.fromJson(data['prometheus'])
           : AppRepositorySettingsPrometheus.fromDefault(),

--- a/lib/repositories/sponsor_repository.dart
+++ b/lib/repositories/sponsor_repository.dart
@@ -1,0 +1,231 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'package:in_app_purchase/in_app_purchase.dart';
+
+import 'package:kubenav/services/kubenav_mobile.dart';
+import 'package:kubenav/utils/logger.dart';
+
+/// [productIDs] is a set of product ids which are configured in the Google Play
+/// Console and in App Store Connect. The set contains all the sponsoring levels
+/// which can be used by a user.
+const Set<String> productIDs = {'monthly_sponsor', 'yearly_sponsor'};
+
+/// [periods] contains the renew period for all configured [productIDs]. At the
+/// moment we are supporting a monthly and a yearly sponsorship.
+const Map<String, String> periods = {
+  'monthly_sponsor': 'per Month',
+  'yearly_sponsor': 'per Year',
+};
+
+/// The [SponsorRepositoryStatus] enum value contains all statuses for the
+/// [SponsorRepository]. The status can be [done] or [pending]. Normally the
+/// status is always [done] and only [pending] for the time between the user
+/// clicks on the subscribe button and finishes the payment.
+enum SponsorRepositoryStatus {
+  pending,
+  done,
+}
+
+/// The [SponsorRepository] handles the sponsoring of the project via In-App
+/// Purchases for iOS and Android. It is responsible for fetching all available
+/// products and for validating the purchase stream to check if the user has a
+/// valid subscription.
+///
+/// The repository shouldn't be used on desktop, because we do not have the
+/// required APIs there. Instead we should just display the links to the GitHub
+/// sponsoring dashboard and Paypal.
+///
+/// Some helpful links for handling In-App Purchase on Android and iOS:
+///   - https://help.apple.com/app-store-connect/#/devb57be10e7
+///   - https://github.com/flutter/plugins/blob/main/packages/in_app_purchase/in_app_purchase/example/README.md
+///   - https://medium.com/bosc-tech-labs-private-limited/how-to-implement-subscriptions-in-app-purchase-in-flutter-7ce8906e608a
+///   - https://fluffy.es/in-app-purchase-receipt-local/
+///   - https://qonversion.io/blog/the-ultimate-guide-to-subscription-testing-on-android/
+class SponsorRepository with ChangeNotifier {
+  SponsorRepository() {
+    if (Platform.isAndroid || Platform.isIOS) {
+      _init();
+    }
+  }
+
+  final InAppPurchase _iap = InAppPurchase.instance;
+
+  SponsorRepositoryStatus _status = SponsorRepositoryStatus.done;
+  bool _isAvailable = false;
+  bool _isSponsor = false;
+  List<ProductDetails> _products = [];
+  final List<PurchaseDetails> _purchases = [];
+
+  SponsorRepositoryStatus get status => _status;
+  bool get isAvailable => _isAvailable;
+  bool get isSponsor => _isSponsor;
+  List<ProductDetails> get products => _products;
+
+  /// [_init] initializes the repository, by listining to the purchase steam,
+  /// loading all products and restoring the users old purchases.
+  ///
+  /// While listining to the purchases stream we adjust the [_status] variable
+  /// and set it to `done` or `pending`, depending on the `PurchaseStatus`. If
+  /// the status is `PurchaseStatus.purchased` we set the [_isSponsor] to `true`
+  /// or if the `PurchaseStatus.restored` we also set the [_isSponsor] variable
+  /// to `true` when the corresponding verification succeeds (via [_verify]
+  /// function).
+  Future<void> _init() async {
+    try {
+      _isAvailable = await _iap.isAvailable();
+
+      if (_isAvailable) {
+        _iap.purchaseStream.listen((data) async {
+          Logger.log(
+            'SponsorRepository _init',
+            'Received purchase stream data',
+            data,
+          );
+
+          for (final purchaseDetails in data) {
+            Logger.log(
+              'SponsorRepository _init',
+              'Purchase details for received purchase stream data',
+              'ProductID: ${purchaseDetails.productID}, PurchaseID: ${purchaseDetails.purchaseID}, Status: ${purchaseDetails.status}, Error: ${purchaseDetails.error.toString()}',
+            );
+            try {
+              if (purchaseDetails.status == PurchaseStatus.pending) {
+                _status = SponsorRepositoryStatus.pending;
+                notifyListeners();
+              } else {
+                if (purchaseDetails.status == PurchaseStatus.error) {
+                  Logger.log(
+                    'SponsorRepository _init',
+                    'PurchaseDetails status is error',
+                    'Source: ${purchaseDetails.error?.source}, Code: ${purchaseDetails.error?.code}, Message: ${purchaseDetails.error?.message}, Details: ${purchaseDetails.error?.details}',
+                  );
+                  _status = SponsorRepositoryStatus.done;
+                  notifyListeners();
+                } else if (purchaseDetails.status == PurchaseStatus.purchased) {
+                  _isSponsor = true;
+                  _status = SponsorRepositoryStatus.done;
+                  notifyListeners();
+                } else if (purchaseDetails.status == PurchaseStatus.restored) {
+                  if (_isSponsor == false) {
+                    if (await _verify() == true) {
+                      _isSponsor = true;
+                    }
+                  }
+                  _status = SponsorRepositoryStatus.done;
+                  notifyListeners();
+                  break;
+                }
+
+                if (purchaseDetails.pendingCompletePurchase) {
+                  await _iap.completePurchase(purchaseDetails);
+                  _status = SponsorRepositoryStatus.done;
+                  notifyListeners();
+                }
+              }
+            } catch (err) {
+              Logger.log(
+                'SponsorRepository _init',
+                'An unknown error occured while listining to purchase stream',
+                err,
+              );
+            }
+          }
+
+          _purchases.addAll(data);
+          notifyListeners();
+        }, onDone: () {
+          Logger.log(
+            'SponsorRepository _init',
+            'Listen to purchase stream is done',
+          );
+        }, onError: (err) {
+          Logger.log(
+            'SponsorRepository _init',
+            'An error occured while listining to the purchase stream',
+            err,
+          );
+        });
+
+        await _getProducts();
+        await _iap.restorePurchases();
+      }
+    } catch (err) {
+      Logger.log(
+        'SponsorRepository _init',
+        'Could not initalize repository',
+        err,
+      );
+    }
+  }
+
+  /// [_getProducts] lists all products for the set of [productIDs]. The
+  /// retrieved products are then stored in the [_products] variable.
+  Future<void> _getProducts() async {
+    ProductDetailsResponse response = await _iap.queryProductDetails(
+      productIDs,
+    );
+    Logger.log(
+      'SponsorRepository _getProducts',
+      'Get products',
+      'Not Found IDs: ${response.notFoundIDs}, Products: ${response.productDetails}, Error: ${response.error.toString()}',
+    );
+    _products = response.productDetails;
+    notifyListeners();
+  }
+
+  /// [_verify] verifies that a user has a valid subscription.
+  ///
+  /// On iOS we are verify the purchase by using the
+  /// https://github.com/tikhop/TPInAppReceipt Swift package. We call the
+  /// required function via the [KubenavMobile] platform channels. If the
+  /// returned data is `true` the verification was successfull. If it is `false`
+  /// the verification failed.
+  ///
+  /// On Android we do not have to verify the returned purchases, since we only
+  /// receive purchase for an active subscription, so that we can always return
+  /// `true`.
+  Future<bool> _verify() async {
+    try {
+      if (Platform.isIOS) {
+        final result = await KubenavMobile().verifyIAP();
+        if (result == 'true') {
+          return true;
+        }
+        return false;
+      } else {
+        return true;
+      }
+    } catch (err) {
+      Logger.log(
+        'SponsorRepository _verify',
+        'Could not verify subscriptions',
+        err,
+      );
+    }
+
+    return true;
+  }
+
+  /// [subscribe] let a user subscribe to the provided [product]. This just
+  /// initializes the subscription process and we have to listen to the purchase
+  /// stream to check if the user completes the purchase or if he cancels the
+  /// subscription.
+  Future<void> subscribe(ProductDetails product) async {
+    try {
+      if (_isAvailable) {
+        final PurchaseParam purchaseParam =
+            PurchaseParam(productDetails: product);
+        await _iap.buyNonConsumable(purchaseParam: purchaseParam);
+      }
+    } catch (err) {
+      Logger.log(
+        'SponsorRepository subscribe',
+        'An error occured, while subscription was created',
+        err,
+      );
+      rethrow;
+    }
+  }
+}

--- a/lib/services/kubenav_mobile.dart
+++ b/lib/services/kubenav_mobile.dart
@@ -319,4 +319,23 @@ class KubenavMobile {
 
     return result;
   }
+
+  Future<String> verifyIAP() async {
+    Logger.log(
+      'KubenavMobile verifyIAP',
+      'Run verifyIAP function',
+    );
+
+    final String result = await platform.invokeMethod(
+      'verifyIAP',
+    );
+
+    Logger.log(
+      'KubenavMobile verifyIAP',
+      'Verify In-App Purchase was ok',
+      result,
+    );
+
+    return result;
+  }
 }

--- a/lib/widgets/home/home_overview.dart
+++ b/lib/widgets/home/home_overview.dart
@@ -6,17 +6,10 @@ import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
-import 'package:kubenav/utils/helpers.dart';
-import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/home/overview/overview_actions.dart';
 import 'package:kubenav/widgets/home/overview/overview_events.dart';
 import 'package:kubenav/widgets/home/overview/overview_metrics.dart';
-import 'package:kubenav/widgets/plugins/plugins.dart';
-import 'package:kubenav/widgets/resources/bookmarks/resources_bookmarks.dart';
-import 'package:kubenav/widgets/resources/resources.dart';
-import 'package:kubenav/widgets/settings/settings.dart';
-import 'package:kubenav/widgets/settings/settings_clusters.dart';
-import 'package:kubenav/widgets/shared/app_actions_header_widget.dart';
 import 'package:kubenav/widgets/shared/app_bottom_navigation_bar_widget.dart';
 import 'package:kubenav/widgets/shared/app_clusters_widget.dart';
 import 'package:kubenav/widgets/shared/app_floating_action_buttons_widget.dart';
@@ -39,72 +32,7 @@ class HomeOverview extends StatelessWidget {
     }
 
     return [
-      AppActionsHeaderWidget(
-        actions: [
-          AppActionsHeaderModel(
-            title: 'Resources',
-            icon: CustomIcons.kubernetes,
-            onTap: () {
-              navigate(
-                context,
-                const Resources(),
-                Constants.pageIndexResources,
-              );
-            },
-          ),
-          AppActionsHeaderModel(
-            title: 'Plugins',
-            icon: Icons.extension,
-            onTap: () {
-              navigate(
-                context,
-                const Plugins(),
-                Constants.pageIndexPlugins,
-              );
-            },
-          ),
-          AppActionsHeaderModel(
-            title: 'Settings',
-            icon: Icons.settings,
-            onTap: () {
-              navigate(
-                context,
-                const Settings(),
-                Constants.pageIndexSettings,
-              );
-            },
-          ),
-          AppActionsHeaderModel(
-            title: 'Clusters',
-            icon: CustomIcons.clusters,
-            onTap: () {
-              navigate(
-                context,
-                const SettingsClusters(),
-                Constants.pageIndexSettings,
-              );
-            },
-          ),
-          AppActionsHeaderModel(
-            title: 'Bookmarks',
-            icon: Icons.bookmark,
-            onTap: () {
-              navigate(
-                context,
-                const ResourcesBookmarks(),
-                Constants.pageIndexResources,
-              );
-            },
-          ),
-          AppActionsHeaderModel(
-            title: 'GitHub',
-            icon: CustomIcons.github,
-            onTap: () {
-              openUrl('https://github.com/kubenav/kubenav');
-            },
-          ),
-        ],
-      ),
+      const OverviewActions(),
       const OverviewMetrics(
         nodeName: null,
       ),

--- a/lib/widgets/home/overview/overview_actions.dart
+++ b/lib/widgets/home/overview/overview_actions.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/sponsor_repository.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/custom_icons.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/navigate.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/plugins/plugins.dart';
+import 'package:kubenav/widgets/resources/bookmarks/resources_bookmarks.dart';
+import 'package:kubenav/widgets/resources/resources.dart';
+import 'package:kubenav/widgets/settings/settings.dart';
+import 'package:kubenav/widgets/settings/settings/sponsor/settings_sponsor_actions.dart';
+import 'package:kubenav/widgets/settings/settings_clusters.dart';
+import 'package:kubenav/widgets/shared/app_actions_header_widget.dart';
+
+class OverviewActions extends StatelessWidget {
+  const OverviewActions({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+      context,
+      listen: true,
+    );
+
+    final sponsorAction = ((Platform.isAndroid || Platform.isIOS) &&
+            sponsorRepository.isAvailable &&
+            sponsorRepository.products.isNotEmpty &&
+            !sponsorRepository.isSponsor)
+        ? AppActionsHeaderModel(
+            title: 'Sponsor',
+            icon: Icons.favorite,
+            onTap: () {
+              showActions(
+                context,
+                const SettingsSponsorActions(
+                  showDismiss: false,
+                ),
+              );
+            },
+          )
+        : AppActionsHeaderModel(
+            title: 'GitHub',
+            icon: CustomIcons.github,
+            onTap: () {
+              openUrl('https://github.com/kubenav/kubenav');
+            },
+          );
+
+    return AppActionsHeaderWidget(
+      actions: [
+        AppActionsHeaderModel(
+          title: 'Resources',
+          icon: CustomIcons.kubernetes,
+          onTap: () {
+            navigate(
+              context,
+              const Resources(),
+              Constants.pageIndexResources,
+            );
+          },
+        ),
+        AppActionsHeaderModel(
+          title: 'Plugins',
+          icon: Icons.extension,
+          onTap: () {
+            navigate(
+              context,
+              const Plugins(),
+              Constants.pageIndexPlugins,
+            );
+          },
+        ),
+        AppActionsHeaderModel(
+          title: 'Settings',
+          icon: Icons.settings,
+          onTap: () {
+            navigate(
+              context,
+              const Settings(),
+              Constants.pageIndexSettings,
+            );
+          },
+        ),
+        AppActionsHeaderModel(
+          title: 'Clusters',
+          icon: CustomIcons.clusters,
+          onTap: () {
+            navigate(
+              context,
+              const SettingsClusters(),
+              Constants.pageIndexSettings,
+            );
+          },
+        ),
+        AppActionsHeaderModel(
+          title: 'Bookmarks',
+          icon: Icons.bookmark,
+          onTap: () {
+            navigate(
+              context,
+              const ResourcesBookmarks(),
+              Constants.pageIndexResources,
+            );
+          },
+        ),
+        sponsorAction,
+      ],
+    );
+  }
+}

--- a/lib/widgets/plugins/plugins.dart
+++ b/lib/widgets/plugins/plugins.dart
@@ -35,6 +35,7 @@ class Plugins extends StatelessWidget {
     }
 
     return [
+      const SizedBox(height: Constants.spacingSmall),
       AppVertialListSimpleWidget(
         title: 'Plugins',
         items: [

--- a/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
+++ b/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -18,6 +18,7 @@ import 'package:kubenav/widgets/settings/settings/settings_prometheus.dart';
 import 'package:kubenav/widgets/settings/settings/settings_proxy.dart';
 import 'package:kubenav/widgets/settings/settings/settings_sponsor.dart';
 import 'package:kubenav/widgets/settings/settings/settings_timeout.dart';
+import 'package:kubenav/widgets/settings/settings/sponsor/settings_sponsor_banner.dart';
 import 'package:kubenav/widgets/settings/settings_clusters.dart';
 import 'package:kubenav/widgets/settings/settings_help.dart';
 import 'package:kubenav/widgets/settings/settings_namespaces.dart';
@@ -619,15 +620,16 @@ class Settings extends StatelessWidget {
         child: Column(
           children: [
             const SizedBox(height: Constants.spacingSmall),
+            const SettingsSponsorBanner(),
             _buildViewAllClusters(context),
             _buildClusters(context),
             AppVertialListSimpleWidget(
               title: 'Settings',
               items: buildSettings(context),
             ),
+            const SettingsSponsor(),
             buildHelp(context),
             const SettingsInfo(),
-            const SettingsSponsor(),
             const SizedBox(height: Constants.spacingMiddle),
           ],
         ),

--- a/lib/widgets/settings/settings/settings_sponsor.dart
+++ b/lib/widgets/settings/settings/settings_sponsor.dart
@@ -4,19 +4,18 @@ import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
 
+import 'package:kubenav/repositories/sponsor_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
 import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 /// The [SettingsSponsor] widget displays a list with all available sponsor
-/// options. Currently these are GitHub Sponsors and Paypal.
-///
-/// On iOS the [SettingsSponsor] widget returns an empty container, because
-/// Apple doesn't like it when we do not use the In-App Purchase API.
-///
-/// See https://github.com/kubenav/kubenav/commit/6b4932a313a55366fa5b4674800a3cf40df23647
+/// options. For iOS and Android we are using In-App Purchase for sponsoring. On
+/// desktop we are just displaying a ling to GitHub Sponsors and Paypal.
 class SettingsSponsor extends StatelessWidget {
   const SettingsSponsor({
     Key? key,
@@ -24,15 +23,129 @@ class SettingsSponsor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+      context,
+      listen: true,
+    );
     Provider.of<ThemeRepository>(
       context,
       listen: true,
     );
 
-    if (Platform.isIOS) {
-      return Container();
+    /// On Android and iOS we are using In-App Purchases for sponsoring. If the
+    /// In-App Purchases API isn't available or when the user is already a
+    /// sponsor we just return an empty container.
+    if (Platform.isAndroid || Platform.isIOS) {
+      if (!sponsorRepository.isAvailable ||
+          sponsorRepository.products.isEmpty ||
+          sponsorRepository.isSponsor) {
+        return Container();
+      }
+
+      /// If a user clicked on the subscribe button in the
+      /// [SettingsSponsorSubscribe] widget to initialize the subscription
+      /// process we display a circular spinner while we didn't receive a
+      /// successful / canceled purchase.
+      if (sponsorRepository.status == SponsorRepositoryStatus.pending) {
+        return Wrap(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(Constants.spacingMiddle),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Sponsor',
+                      style: primaryTextStyle(context, size: 18),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+              ),
+              child: Center(
+                child: CircularProgressIndicator(
+                  color: theme(context).colorPrimary,
+                ),
+              ),
+            ),
+          ],
+        );
+      }
+
+      /// When a user isn't a sponsor we display all products we received from
+      /// the corresponding platform API. If the user clicks on one of these
+      /// products we open a [SettingsSponsorSubscribe] widget with this product
+      /// were a user can buy it.
+      return AppVertialListSimpleWidget(
+        title: 'Sponsor',
+        items: sponsorRepository.products
+            .map(
+              (e) => AppVertialListSimpleModel(
+                onTap: () {
+                  showModal(
+                    context,
+                    SettingsSponsorSubscribe(
+                      product: e,
+                    ),
+                  );
+                },
+                children: [
+                  Icon(
+                    Icons.favorite,
+                    color: theme(context).colorPrimary,
+                  ),
+                  const SizedBox(width: Constants.spacingSmall),
+                  Expanded(
+                    flex: 1,
+                    child: Text(
+                      e.title,
+                      style: noramlTextStyle(
+                        context,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.only(
+                      bottom: 2,
+                      top: 2,
+                      left: 6,
+                      right: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme(context).colorPrimary,
+                      borderRadius: const BorderRadius.all(
+                        Radius.circular(Constants.sizeBorderRadius),
+                      ),
+                    ),
+                    constraints: const BoxConstraints(
+                      minWidth: 16,
+                      minHeight: 16,
+                    ),
+                    child: Text(
+                      e.price,
+                      style: secondaryTextStyle(
+                        context,
+                        size: 14,
+                        color: Colors.white,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+            )
+            .toList(),
+      );
     }
 
+    /// On desktop we display a link to the GitHub Sponsors page and to Paypal
+    /// we are user has the chance to support the development.
     return AppVertialListSimpleWidget(
       title: 'Sponsor',
       items: [

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_actions.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_actions.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/sponsor_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart';
+import 'package:kubenav/widgets/shared/app_actions_widget.dart';
+
+/// The [SettingsSponsorActions] widget shows an action menu with all available
+/// sponsoring options (products). When the user clicks on one of the products
+/// the [SettingsSponsorSubscribe] will be opened like it is done in the
+/// settings screen.
+class SettingsSponsorActions extends StatelessWidget {
+  const SettingsSponsorActions({
+    Key? key,
+    required this.showDismiss,
+  }) : super(key: key);
+
+  final bool showDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: true,
+    );
+    SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+      context,
+      listen: true,
+    );
+
+    return AppActionsWidget(
+      actions: showDismiss
+          ? [
+              ...sponsorRepository.products
+                  .map(
+                    (e) => AppActionsWidgetAction(
+                      title: e.title,
+                      color: theme(context).colorPrimary,
+                      onTap: () {
+                        Navigator.pop(context);
+                        showModal(
+                          context,
+                          SettingsSponsorSubscribe(product: e),
+                        );
+                      },
+                    ),
+                  )
+                  .toList(),
+              AppActionsWidgetAction(
+                title: 'Not Now',
+                color: theme(context).colorDanger,
+                onTap: () {
+                  // For testing we can set the reminder to 1 minute, by default
+                  // it is set to 7 days.
+                  // final remindmeafter =
+                  //     DateTime.now().millisecondsSinceEpoch + 60000;
+                  final remindmeafter =
+                      DateTime.now().millisecondsSinceEpoch + 604800000;
+                  appRepository.setSponsorReminder(remindmeafter);
+                  Navigator.pop(context);
+                },
+              ),
+            ]
+          : sponsorRepository.products
+              .map(
+                (e) => AppActionsWidgetAction(
+                  title: e.title,
+                  color: theme(context).colorPrimary,
+                  onTap: () {
+                    Navigator.pop(context);
+                    showModal(
+                      context,
+                      SettingsSponsorSubscribe(product: e),
+                    );
+                  },
+                ),
+              )
+              .toList(),
+    );
+  }
+}

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_banner.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_banner.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/sponsor_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/settings/settings/sponsor/settings_sponsor_actions.dart';
+
+class SettingsSponsorBanner extends StatelessWidget {
+  const SettingsSponsorBanner({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Provider.of<ThemeRepository>(
+      context,
+      listen: true,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: true,
+    );
+    SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+      context,
+      listen: true,
+    );
+
+    if ((Platform.isAndroid || Platform.isIOS) &&
+        sponsorRepository.isAvailable &&
+        sponsorRepository.products.isNotEmpty &&
+        !sponsorRepository.isSponsor &&
+        DateTime.now().millisecondsSinceEpoch >
+            appRepository.settings.sponsorReminder) {
+      return Container(
+        padding: const EdgeInsets.only(
+          left: Constants.spacingMiddle,
+          right: Constants.spacingMiddle,
+        ),
+        child: Container(
+          margin: const EdgeInsets.only(
+            top: Constants.spacingSmall,
+            bottom: Constants.spacingSmall,
+          ),
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: theme(context).colorShadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
+              ),
+            ],
+            color: theme(context).colorCard,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: InkWell(
+            onTap: () {
+              showActions(
+                context,
+                const SettingsSponsorActions(
+                  showDismiss: true,
+                ),
+              );
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: theme(context).colorPrimary,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(Constants.sizeBorderRadius),
+                      topRight: Radius.circular(Constants.sizeBorderRadius),
+                    ),
+                  ),
+                  height: 140,
+                  width: MediaQuery.of(context).size.width,
+                  child: const Icon(
+                    Icons.favorite,
+                    color: Colors.white,
+                    size: 108,
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingSmall),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    left: Constants.spacingSmall,
+                  ),
+                  child: Text(
+                    'Sponsor',
+                    style: primaryTextStyle(
+                      context,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingExtraSmall),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    left: Constants.spacingSmall,
+                  ),
+                  child: Text(
+                    'Support the development of kubenav by becoming a sponsor.',
+                    style: secondaryTextStyle(
+                      context,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingSmall),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container();
+  }
+}

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/sponsor_repository.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [SettingsSponsorSubscribe] widget shows a modal bottom sheet for the
+/// provided [product], where a user can buy / subscribe to this product to
+/// support the development of the app. When the user clicks on the action
+/// button of the modal bottom sheet the sponsoring process is initialized and
+/// then completed via the platforms native screens.
+class SettingsSponsorSubscribe extends StatefulWidget {
+  const SettingsSponsorSubscribe({
+    Key? key,
+    required this.product,
+  }) : super(key: key);
+
+  final ProductDetails product;
+
+  @override
+  State<SettingsSponsorSubscribe> createState() =>
+      _SettingsSponsorSubscribeState();
+}
+
+class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
+  bool _isLoading = false;
+
+  /// [_subscribe] initializes the subscription process by calling the
+  /// `subscribe` function from our [SponsorRepository]. If we were able to
+  /// start the process the modal is closed and a native screen should be shown.
+  /// If we could not start the process we show the thrown exception in a
+  /// snackbar.
+  Future<void> _subscribe() async {
+    SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      await sponsorRepository.subscribe(widget.product);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      setState(() {
+        _isLoading = false;
+      });
+      showSnackbar(
+        context,
+        'An error occured',
+        err.toString(),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: widget.product.title,
+      subtitle:
+          'Subscribe for ${widget.product.price} ${periods.containsKey(widget.product.id) ? periods[widget.product.id] : ''}',
+      icon: Icons.favorite,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText:
+          'Subscribe for ${widget.product.price} ${periods.containsKey(widget.product.id) ? periods[widget.product.id] : ''}',
+      actionPressed: () {
+        _subscribe();
+      },
+      actionIsLoading: _isLoading,
+      child: Form(
+        child: ListView(
+          shrinkWrap: false,
+          children: const [
+            Padding(
+              padding: EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: Text(
+                'We believe in open source. This means that we will never put any features behind a paywall. You will always be able to use all features of kubenav for free.',
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: Text(
+                'With the monthly and yearly sponsoring you can remove the "Sponsor" banner in the settings screen and support the development of kubenav.',
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: Text(
+                'You can also support us by reporting bugs, submitting fixes, proposing new features or by becoming a maintainer. For more information you can have a look at the contributing guide in our GitHub repository. The repository is available at https://github.com/kubenav/kubenav.',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -12,7 +12,6 @@ import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/showmodal.dart';
-import 'package:kubenav/widgets/resources/list/list_item.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 import 'package:kubenav/widgets/shared/app_error_widget.dart';
 import 'package:kubenav/widgets/shared/app_list_item.dart';

--- a/lib/widgets/shared/app_prometheus_charts_widget.dart
+++ b/lib/widgets/shared/app_prometheus_charts_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import in_app_purchase_storekit
 import package_info_plus
 import path_provider_macos
 import screen_retriever
@@ -14,6 +15,7 @@ import window_manager
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,5 +1,8 @@
 PODS:
   - FlutterMacOS (1.0.0)
+  - in_app_purchase_storekit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_macos (0.0.1):
@@ -17,6 +20,7 @@ PODS:
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - in_app_purchase_storekit (from `Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
@@ -28,6 +32,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
+  in_app_purchase_storekit:
+    :path: Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_macos:
@@ -45,6 +51,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
+  in_app_purchase_storekit: 6b297e2b5eab9fa3251a492d57301722e4132a71
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,6 +263,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.6.0"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
+  in_app_purchase_android:
+    dependency: transitive
+    description:
+      name: in_app_purchase_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.3+9"
+  in_app_purchase_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_purchase_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
+  in_app_purchase_storekit:
+    dependency: transitive
+    description:
+      name: in_app_purchase_storekit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.4+1"
   intl:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 4.0.0+72
+version: 4.0.0+73
 
 environment:
   sdk: '>=2.18.1 <3.0.0'
@@ -50,6 +50,7 @@ dependencies:
   flutter_svg: ^1.1.6
   highlight: ^0.7.0
   http: ^0.13.4
+  in_app_purchase: ^3.1.1
   json_path: ^0.4.2
   jwt_decode: ^0.3.1
   local_auth: ^2.1.2


### PR DESCRIPTION
It is now possible to sponsor the development of kubenav via In-App Purchases on iOS and Android. When a user isn't a sponsor, we display a small sponsor icon in the actions menu on the home screen and a sponsor section in the settings. We also display a sponsor banner in the settings, which can be removed by a user and will only be displayed after 7 days.

If a user is a sponsor, all these references are removed.

Note: There are no features behind this sponsoring, besides that all the refrences to becomme a sponsor are removed from the app. I also do not plan to put anything behind a stupid paywall. This is just another way to support the development of the app. Besides that I also just wanted to try In-App Purchase to learn sth. new and hope that I found a good way to not disturb anyone with this change. If you feel annoyed by it please let me know, so that we can adjust the feature to become less annoying for everyone. Thanks for your understanding.