### PR TITLE
Support Port-Forwarding via Services

### DIFF
--- a/lib/repositories/portforwarding_repository.dart
+++ b/lib/repositories/portforwarding_repository.dart
@@ -119,6 +119,10 @@ class PortForwardingRepository with ChangeNotifier {
   /// internal http server is running before we can create the session. The
   /// created session is then added to the [_sessions] list and can be viewed
   /// by a user via the corresponding floating action button.
+  ///
+  /// If the [container] is an empty string and [port] the port is 0 the
+  /// [serviceSelector] and [serviceTargetPort] must be provided to establish a
+  /// port forwading session via the a service.
   Future<void> createSession(
     Cluster cluster,
     String proxy,
@@ -127,6 +131,8 @@ class PortForwardingRepository with ChangeNotifier {
     String namespace,
     String container,
     int port,
+    String serviceSelector,
+    String serviceTargetPort,
   ) async {
     try {
       final isStarted = await KubernetesService(
@@ -144,17 +150,15 @@ class PortForwardingRepository with ChangeNotifier {
           cluster: cluster,
           proxy: proxy,
           timeout: timeout,
-        ).portForwarding(name, namespace, port);
-        _sessions.add(
-          PortForwardingSession(
-            id: result['sessionID'],
-            name: name,
-            namespace: namespace,
-            container: container,
-            remotePort: port,
-            localPort: result['localPort'],
-          ),
+        ).portForwarding(
+          name,
+          namespace,
+          port,
+          serviceSelector,
+          serviceTargetPort,
         );
+
+        _sessions.add(PortForwardingSession.fromJson(result));
         notifyListeners();
       }
     } catch (err) {

--- a/lib/services/kubernetes_service.dart
+++ b/lib/services/kubernetes_service.dart
@@ -344,7 +344,12 @@ class KubernetesService {
   /// of the given Pod name, by using the `portforwarding` endpoint of the
   /// internal http server.
   Future<Map<String, dynamic>> portForwarding(
-      String name, String namespace, int port) async {
+    String name,
+    String namespace,
+    int port,
+    String serviceSelector,
+    String serviceTargetPort,
+  ) async {
     try {
       final response = await http.post(
         Uri.parse('http://localhost:14122/portforwarding'),
@@ -367,6 +372,8 @@ class KubernetesService {
           'podName': name,
           'podNamespace': namespace,
           'podPort': port,
+          'serviceSelector': serviceSelector,
+          'serviceTargetPort': serviceTargetPort,
         }),
       );
 

--- a/lib/widgets/resources/details/pod_details_item.dart
+++ b/lib/widgets/resources/details/pod_details_item.dart
@@ -119,6 +119,8 @@ class _PodDetailsItemState extends State<PodDetailsItem> {
         pod.metadata!.namespace!,
         containerName,
         containerPort,
+        '',
+        '',
       );
 
       if (mounted) {

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getPodContainerAndPort(pod corev1.Pod, serviceTargetPort string) (string, int64) {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			parsedServiceTargetPort, err := strconv.ParseInt(serviceTargetPort, 10, 64)
+			if err == nil {
+				if parsedServiceTargetPort == int64(port.ContainerPort) {
+					return container.Name, int64(port.ContainerPort)
+				}
+			} else {
+				if serviceTargetPort == port.Name {
+					return container.Name, int64(port.ContainerPort)
+				}
+			}
+		}
+	}
+
+	return "", 0
+}

--- a/pkg/server/portforwarding/portforwarding.go
+++ b/pkg/server/portforwarding/portforwarding.go
@@ -34,6 +34,8 @@ type CreateRequest struct {
 	PodNamespace                    string `json:"podNamespace"`
 	PodContainer                    string `json:"podContainer"`
 	PodPort                         int64  `json:"podPort"`
+	ServiceSelector                 string `json:"serviceSelector"`
+	ServiceTargetPort               string `json:"serviceTargetPort"`
 }
 
 // DeleteRequest is the structure of a request to delete a port forwarding session, for that is just contains the


### PR DESCRIPTION
It is now possible to establish a port-forwarding session via a service. To do this a user can now click on a port in the service details view. We will then use the service selector to get the corresponding pods and will establish a port forwarding session to the first port.