### PR TITLE
Add Flutter Implementation for AWS Role ARN

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -113,12 +113,13 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val secretKey = call.argument<String>("secretKey")
       val region = call.argument<String>("region")
       val sessionToken = call.argument<String>("sessionToken")
+      val roleArn = call.argument<String>("roleArn")
       val clusterID = call.argument<String>("clusterID")
 
-      if (accessKeyID == null || secretKey == null || region == null || sessionToken == null || clusterID == null) {
+      if (accessKeyID == null || secretKey == null || region == null || sessionToken == null || roleArn == null || clusterID == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        awsGetToken(accessKeyID, secretKey, region, sessionToken, clusterID, result)
+        awsGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID, result)
       }
     } else if (call.method == "awsGetSSOConfig") {
       val ssoRegion = call.argument<String>("ssoRegion")
@@ -332,9 +333,9 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
-  private fun awsGetToken(accessKeyID: String, secretKey: String, region: String, sessionToken: String, clusterID: String, result: MethodChannel.Result) {
+  private fun awsGetToken(accessKeyID: String, secretKey: String, region: String, sessionToken: String, roleArn: String, clusterID: String, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.awsGetToken(accessKeyID, secretKey, region, sessionToken, clusterID)
+      val data: String = Kubenav.awsGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID)
       result.success(data)
     } catch (e: Exception) {
       result.error("AWS_GET_TOKEN_FAILED", e.localizedMessage, null)

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -105,9 +105,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let secretKey = args["secretKey"] as? String,
         let region = args["region"] as? String,
         let sessionToken = args["sessionToken"] as? String,
+        let roleArn = args["roleArn"] as? String,
         let clusterID = args["clusterID"] as? String
       {
-        awsGetToken(accessKeyID: accessKeyID, secretKey: secretKey, region: region, sessionToken: sessionToken, clusterID: clusterID, result: result)
+        awsGetToken(accessKeyID: accessKeyID, secretKey: secretKey, region: region, sessionToken: sessionToken, roleArn: roleArn, clusterID: clusterID, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -334,10 +335,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func awsGetToken(accessKeyID: String, secretKey: String, region: String, sessionToken: String, clusterID: String, result: FlutterResult) {
+  private func awsGetToken(accessKeyID: String, secretKey: String, region: String, sessionToken: String, roleArn: String, clusterID: String, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavAWSGetToken(accessKeyID, secretKey, region, sessionToken, clusterID, &error)
+    let data = KubenavAWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID, &error)
     if error != nil {
       result(FlutterError(code: "AWS_GET_TOKEN_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {

--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -80,12 +80,14 @@ class ClusterProviderAWS {
   String? secretKey;
   String? region;
   String? sessionToken;
+  String? roleArn;
 
   ClusterProviderAWS({
     required this.accessKeyID,
     required this.secretKey,
     required this.region,
     required this.sessionToken,
+    required this.roleArn,
   });
 
   factory ClusterProviderAWS.fromJson(Map<String, dynamic> data) {
@@ -95,6 +97,7 @@ class ClusterProviderAWS {
       region: data.containsKey('region') ? data['region'] : null,
       sessionToken:
           data.containsKey('sessionToken') ? data['sessionToken'] : null,
+      roleArn: data.containsKey('roleArn') ? data['roleArn'] : null,
     );
   }
 

--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -253,10 +253,11 @@ class ClustersRepository with ChangeNotifier {
           final provider = getProvider(cluster.clusterProviderId);
           if (provider != null && provider.aws != null) {
             final token = await AWSService().getToken(
-              provider.aws!.accessKeyID!,
-              provider.aws!.secretKey!,
-              provider.aws!.region!,
-              provider.aws!.sessionToken!,
+              provider.aws?.accessKeyID ?? '',
+              provider.aws?.secretKey ?? '',
+              provider.aws?.region ?? '',
+              provider.aws?.sessionToken ?? '',
+              provider.aws?.roleArn ?? '',
               cluster.clusterProviderInternal,
             );
             cluster.userToken = token;
@@ -294,24 +295,25 @@ class ClustersRepository with ChangeNotifier {
             }
 
             final credentials = await AWSService().getSSOToken(
-              provider.awssso!.accountID!,
-              provider.awssso!.roleName!,
-              provider.awssso!.ssoRegion!,
-              provider.awssso!.ssoConfig!.client!.clientId!,
-              provider.awssso!.ssoConfig!.client!.clientSecret!,
-              provider.awssso!.ssoConfig!.device!.deviceCode!,
-              provider.awssso!.ssoCredentials!.accessToken!,
-              provider.awssso!.ssoCredentials!.accessTokenExpire!,
+              provider.awssso?.accountID ?? '',
+              provider.awssso?.roleName ?? '',
+              provider.awssso?.ssoRegion ?? '',
+              provider.awssso?.ssoConfig?.client?.clientId ?? '',
+              provider.awssso?.ssoConfig?.client?.clientSecret ?? '',
+              provider.awssso?.ssoConfig?.device?.deviceCode ?? '',
+              provider.awssso?.ssoCredentials?.accessToken ?? '',
+              provider.awssso?.ssoCredentials?.accessTokenExpire ?? 0,
             );
 
             provider.awssso!.ssoCredentials = credentials;
             await editProviderWithoutNotify(provider);
 
             final token = await AWSService().getToken(
-              credentials.accessKeyId!,
-              credentials.secretAccessKey!,
-              provider.awssso!.region!,
-              credentials.sessionToken!,
+              credentials.accessKeyId ?? '',
+              credentials.secretAccessKey ?? '',
+              provider.awssso?.region ?? '',
+              credentials.sessionToken ?? '',
+              '',
               cluster.clusterProviderInternal,
             );
 
@@ -339,27 +341,27 @@ class ClustersRepository with ChangeNotifier {
         final provider = getProvider(cluster.clusterProviderId);
 
         if (DateTime.fromMillisecondsSinceEpoch(
-          provider!.google!.accessTokenExpires!,
+          provider?.google?.accessTokenExpires ?? 0,
         ).isBefore(DateTime.now())) {
           final googleTokens = await GoogleService().getTokensFromRefreshToken(
-            provider.google!.clientID!,
-            provider.google!.clientSecret!,
-            provider.google!.refreshToken!,
+            provider?.google?.clientID ?? '',
+            provider?.google?.clientSecret ?? '',
+            provider?.google?.refreshToken ?? '',
           );
 
           final expires = DateTime.now().millisecondsSinceEpoch +
               googleTokens.expiresIn! * 1000;
-          provider.google!.accessToken = googleTokens.accessToken!;
-          provider.google!.accessTokenExpires = expires;
+          provider?.google?.accessToken = googleTokens.accessToken!;
+          provider?.google?.accessTokenExpires = expires;
 
-          cluster.userToken = provider.google!.accessToken!;
+          cluster.userToken = provider?.google?.accessToken ?? '';
 
-          await editProviderWithoutNotify(provider);
+          await editProviderWithoutNotify(provider!);
           await editClusterWithoutNotify(cluster);
           return cluster;
         } else {
-          if (cluster.userToken != provider.google!.accessToken) {
-            cluster.userToken = provider.google!.accessToken!;
+          if (cluster.userToken != provider?.google?.accessToken) {
+            cluster.userToken = provider?.google?.accessToken ?? '';
             await editClusterWithoutNotify(cluster);
           }
           return cluster;
@@ -375,36 +377,36 @@ class ClustersRepository with ChangeNotifier {
         /// the cluster configuration before we return the cluster.
         final provider = getProvider(cluster.clusterProviderId);
 
-        DateTime? expiryDate = Jwt.getExpiryDate(provider!.oidc!.idToken!);
+        DateTime? expiryDate = Jwt.getExpiryDate(provider?.oidc?.idToken ?? '');
 
         if (expiryDate != null && expiryDate.isBefore(DateTime.now())) {
           final oidcResponse = await OIDCService().getAccessToken(
-            provider.oidc!.discoveryURL!,
-            provider.oidc!.clientID!,
-            provider.oidc!.clientSecret!,
-            provider.oidc!.certificateAuthority!,
-            provider.oidc!.scopes!,
+            provider?.oidc?.discoveryURL ?? '',
+            provider?.oidc?.clientID ?? '',
+            provider?.oidc?.clientSecret ?? '',
+            provider?.oidc?.certificateAuthority ?? '',
+            provider?.oidc?.scopes ?? '',
             Constants.oidcRedirectURI,
-            provider.oidc!.refreshToken!,
+            provider?.oidc?.refreshToken ?? '',
           );
 
           if (oidcResponse.idToken != null) {
-            provider.oidc!.idToken = oidcResponse.idToken!;
+            provider?.oidc?.idToken = oidcResponse.idToken!;
           }
 
           if (oidcResponse.refreshToken != null &&
               oidcResponse.refreshToken != '') {
-            provider.oidc!.refreshToken = oidcResponse.refreshToken!;
+            provider?.oidc?.refreshToken = oidcResponse.refreshToken!;
           }
 
           cluster.userToken = oidcResponse.idToken!;
-          await editProviderWithoutNotify(provider);
+          await editProviderWithoutNotify(provider!);
           await editClusterWithoutNotify(cluster);
 
           return cluster;
         } else {
-          if (cluster.userToken != provider.oidc!.idToken) {
-            cluster.userToken = provider.oidc!.idToken!;
+          if (cluster.userToken != provider?.oidc?.idToken) {
+            cluster.userToken = provider?.oidc?.idToken ?? '';
             editClusterWithoutNotify(cluster);
           }
           return cluster;

--- a/lib/services/providers/aws_service.dart
+++ b/lib/services/providers/aws_service.dart
@@ -313,6 +313,7 @@ class AWSService {
     String secretKey,
     String region,
     String sessionToken,
+    String roleArn,
     String clusterID,
   ) async {
     try {
@@ -323,6 +324,7 @@ class AWSService {
           'secretKey': secretKey,
           'region': region,
           'sessionToken': sessionToken,
+          'roleArn': roleArn,
           'clusterID': clusterID,
         },
       );

--- a/lib/widgets/settings/providers/settings_aws_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_aws_provider_config.dart
@@ -31,6 +31,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
   final _secretKeyController = TextEditingController();
   String _region = 'us-east-1';
   final _sessionTokenController = TextEditingController();
+  final _roleArnController = TextEditingController();
   bool _isLoading = false;
 
   /// [_validator] is used to validate all the required fields. If they are
@@ -65,6 +66,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
               secretKey: _secretKeyController.text,
               region: _region,
               sessionToken: _sessionTokenController.text,
+              roleArn: _roleArnController.text,
             ),
           );
           await clustersRepository.addProvider(provider);
@@ -88,6 +90,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
           provider.aws!.secretKey = _secretKeyController.text;
           provider.aws!.region = _region;
           provider.aws!.sessionToken = _sessionTokenController.text;
+          provider.aws!.roleArn = _roleArnController.text;
           await clustersRepository.editProvider(provider);
 
           setState(() {
@@ -119,6 +122,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
       _secretKeyController.text = widget.provider!.aws!.secretKey ?? '';
       _region = widget.provider!.aws!.region ?? '';
       _sessionTokenController.text = widget.provider!.aws!.sessionToken ?? '';
+      _roleArnController.text = widget.provider!.aws!.roleArn ?? '';
     }
   }
 
@@ -128,6 +132,7 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
     _accessKeyIDController.dispose();
     _secretKeyController.dispose();
     _sessionTokenController.dispose();
+    _roleArnController.dispose();
     super.dispose();
   }
 
@@ -248,7 +253,23 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
                 maxLines: 1,
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
-                  labelText: 'Session Token',
+                  labelText: 'Session Token (optional)',
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: TextFormField(
+                controller: _roleArnController,
+                keyboardType: TextInputType.text,
+                autocorrect: false,
+                enableSuggestions: false,
+                maxLines: 1,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Role ARN (optional)',
                 ),
               ),
             ),


### PR DESCRIPTION
This is the Flutter implementation for the changes made in #456, so that a user can specify the Role ARN in the Flutter app, which is then passed to the corresponding Go code to get the token for an AWS cluster.