### PR TITLE
Make Sponsor Banner Less Annoying

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -406,6 +406,7 @@ class AppRepositorySettings {
       'editorFormat': editorFormat,
       'proxy': proxy,
       'timeout': timeout,
+      'sponsorReminder': sponsorReminder,
       'prometheus': prometheus.toJson(),
     };
   }

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
+import 'package:kubenav/repositories/sponsor_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
@@ -66,6 +69,86 @@ class _SettingsInfoState extends State<SettingsInfo> {
     }
   }
 
+  /// [buildAdditionalLinks] returns additional links for iOS which must be
+  /// present in the app so that the app is not rejected in the App Store
+  /// submission.
+  List<AppVertialListSimpleModel> buildAdditionalLinks(BuildContext context) {
+    if (Platform.isIOS) {
+      SponsorRepository sponsorRepository = Provider.of<SponsorRepository>(
+        context,
+        listen: false,
+      );
+
+      return [
+        AppVertialListSimpleModel(
+          onTap: () {
+            openUrl(
+              'https://www.apple.com/legal/internet-services/itunes/dev/stdeula/',
+            );
+          },
+          children: [
+            Icon(
+              Icons.policy,
+              color: theme(context).colorPrimary,
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              flex: 1,
+              child: Text(
+                'Terms of Use',
+                style: noramlTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
+              size: 16,
+            ),
+          ],
+        ),
+        AppVertialListSimpleModel(
+          onTap: () {
+            sponsorRepository.restorePurchases();
+            showSnackbar(
+              context,
+              'Restore Purchases',
+              'Your previous purchases were restored',
+            );
+          },
+          children: [
+            Icon(
+              Icons.favorite,
+              color: theme(context).colorPrimary,
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              flex: 1,
+              child: Text(
+                'Restore Purchases',
+                style: noramlTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
+              size: 16,
+            ),
+          ],
+        ),
+      ];
+    }
+
+    return [];
+  }
+
   @override
   void initState() {
     super.initState();
@@ -124,68 +207,6 @@ class _SettingsInfoState extends State<SettingsInfo> {
                 ),
                 textAlign: TextAlign.center,
               ),
-            ),
-          ],
-        ),
-        AppVertialListSimpleModel(
-          onTap: () {
-            showModal(
-              context,
-              AppBottomSheetWidget(
-                title: 'License',
-                subtitle: 'MIT License',
-                icon: CustomIcons.license,
-                closePressed: () {
-                  Navigator.pop(context);
-                },
-                actionText: 'Close',
-                actionPressed: () {
-                  Navigator.pop(context);
-                },
-                actionIsLoading: false,
-                child: Form(
-                  key: const Key('settings/license'),
-                  child: ListView(
-                    shrinkWrap: false,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: 8,
-                        ),
-                        child: Text(
-                          licenseText,
-                          style: TextStyle(
-                            color: theme(context).colorTextPrimary,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
-          children: [
-            Icon(
-              CustomIcons.license,
-              color: theme(context).colorPrimary,
-            ),
-            const SizedBox(width: Constants.spacingSmall),
-            Expanded(
-              flex: 1,
-              child: Text(
-                'License',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
-            ),
-            Icon(
-              Icons.arrow_forward_ios,
-              color: theme(context)
-                  .colorTextPrimary
-                  .withOpacity(Constants.opacityIcon),
-              size: 16,
             ),
           ],
         ),
@@ -273,6 +294,97 @@ class _SettingsInfoState extends State<SettingsInfo> {
             ),
           ],
         ),
+        AppVertialListSimpleModel(
+          onTap: () {
+            showModal(
+              context,
+              AppBottomSheetWidget(
+                title: 'License',
+                subtitle: 'MIT License',
+                icon: CustomIcons.license,
+                closePressed: () {
+                  Navigator.pop(context);
+                },
+                actionText: 'Close',
+                actionPressed: () {
+                  Navigator.pop(context);
+                },
+                actionIsLoading: false,
+                child: Form(
+                  key: const Key('settings/license'),
+                  child: ListView(
+                    shrinkWrap: false,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 8,
+                        ),
+                        child: Text(
+                          licenseText,
+                          style: TextStyle(
+                            color: theme(context).colorTextPrimary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+          children: [
+            Icon(
+              CustomIcons.license,
+              color: theme(context).colorPrimary,
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              flex: 1,
+              child: Text(
+                'License',
+                style: noramlTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
+              size: 16,
+            ),
+          ],
+        ),
+        AppVertialListSimpleModel(
+          onTap: () {
+            openUrl('https://kubenav.io/privacy.html');
+          },
+          children: [
+            Icon(
+              Icons.policy,
+              color: theme(context).colorPrimary,
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              flex: 1,
+              child: Text(
+                'Privacy Policy',
+                style: noramlTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: theme(context)
+                  .colorTextPrimary
+                  .withOpacity(Constants.opacityIcon),
+              size: 16,
+            ),
+          ],
+        ),
+        ...buildAdditionalLinks(context),
       ],
     );
   }

--- a/lib/widgets/settings/settings/settings_sponsor.dart
+++ b/lib/widgets/settings/settings/settings_sponsor.dart
@@ -104,7 +104,7 @@ class SettingsSponsor extends StatelessWidget {
                   Expanded(
                     flex: 1,
                     child: Text(
-                      e.title,
+                      titles.containsKey(e.id) ? titles[e.id]! : e.title,
                       style: noramlTextStyle(
                         context,
                       ),

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_actions.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_actions.dart
@@ -38,7 +38,7 @@ class SettingsSponsorActions extends StatelessWidget {
               ...sponsorRepository.products
                   .map(
                     (e) => AppActionsWidgetAction(
-                      title: e.title,
+                      title: titles.containsKey(e.id) ? titles[e.id]! : e.title,
                       color: theme(context).colorPrimary,
                       onTap: () {
                         Navigator.pop(context);
@@ -68,7 +68,7 @@ class SettingsSponsorActions extends StatelessWidget {
           : sponsorRepository.products
               .map(
                 (e) => AppActionsWidgetAction(
-                  title: e.title,
+                  title: titles.containsKey(e.id) ? titles[e.id]! : e.title,
                   color: theme(context).colorPrimary,
                   onTap: () {
                     Navigator.pop(context);

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
@@ -68,7 +68,9 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
   @override
   Widget build(BuildContext context) {
     return AppBottomSheetWidget(
-      title: widget.product.title,
+      title: titles.containsKey(widget.product.id)
+          ? titles[widget.product.id]!
+          : widget.product.title,
       subtitle:
           'Subscribe for ${widget.product.price} ${periods.containsKey(widget.product.id) ? periods[widget.product.id] : ''}',
       icon: Icons.favorite,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 4.0.0+74
+version: 4.0.0+76
 
 environment:
   sdk: '>=2.18.1 <3.0.0'


### PR DESCRIPTION
This commit fixes a bug with the sponsor banner in the settings screen. When the user clicks on the sponsor banner and wants to hide it via the "Not Now" button, it shouldn't be displayed for the next seven days, but I forgot to store this value in the settings, so that the sponsor banner was displayed with every app restart. This should now be fixed.

I also added a "Restore Purchases" button, which is required for the Apple AppStore. When the button is clicked we restore all previous purchases of the user, similar to how it is handled during the app start.