### PR TITLE
Fix Show all Pods Running on Node

### DIFF
--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -89,7 +89,10 @@ class _ResourcesListState extends State<ResourcesList> {
         ? '${widget.path}/${widget.resource}?${widget.selector} ?? ' '}'
         : widget.namespace != null
             ? '${widget.path}/namespaces/${widget.namespace}/${widget.resource}?${widget.selector ?? ''}'
-            : '${widget.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource}?${widget.selector ?? ''}';
+            : widget.selector != null &&
+                    widget.selector!.startsWith('fieldSelector=spec.nodeName=')
+                ? '${widget.path}/${widget.resource}?${widget.selector ?? ''}'
+                : '${widget.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource}?${widget.selector ?? ''}';
 
     final resourcesList = await KubernetesService(
       cluster: cluster!,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 4.0.0+76
+version: 4.0.1+78
 
 environment:
   sdk: '>=2.18.1 <3.0.0'


### PR DESCRIPTION
In the node details view it is possible to view all pods which are running on the currently selected node. There was a bug which filtered the pods shown after clicking on "View all" by the currently selected namespace for the cluster. This should now be fixed by checking if the selector is used to select all pods for a node. If this is the case we are ignoring the current cluster namespace to get the pods.