### PR TITLE
Get Logs for Deployment, DaemonSet and StatefulSet

### DIFF
--- a/lib/widgets/resources/details/details_get_logs.dart
+++ b/lib/widgets/resources/details/details_get_logs.dart
@@ -34,12 +34,12 @@ Map<String, int> sinceOptions = {
 class DetailsGetLogs extends StatefulWidget {
   const DetailsGetLogs({
     super.key,
-    required this.name,
+    required this.names,
     required this.namespace,
     required this.item,
   });
 
-  final String name;
+  final String names;
   final String namespace;
   final dynamic item;
 
@@ -90,8 +90,8 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
           proxy: appRepository.settings.proxy,
           timeout: appRepository.settings.timeout,
         ).getLogs(
-          widget.item['metadata']['name'],
-          widget.item['metadata']['namespace'],
+          widget.names,
+          widget.namespace,
           _container,
           sinceOptions[_since]!,
           _filterController.text,
@@ -172,7 +172,7 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
   Widget build(BuildContext context) {
     return AppBottomSheetWidget(
       title: 'Logs',
-      subtitle: widget.name,
+      subtitle: widget.names,
       icon: Icons.subject,
       closePressed: () {
         Navigator.pop(context);

--- a/lib/widgets/resources/details/details_get_logs_pods.dart
+++ b/lib/widgets/resources/details/details_get_logs_pods.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/cluster_provider.dart';
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_pod.dart';
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_pod_list.dart';
+import 'package:kubenav/models/kubernetes/io_k8s_apimachinery_pkg_apis_meta_v1_label_selector.dart';
+import 'package:kubenav/models/resource.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/resources/general.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/details/details_get_logs.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+import 'package:kubenav/widgets/shared/app_error_widget.dart';
+
+/// The [DetailsGetLogsPods] widget can be used to get a list of all Pods for a
+/// Deployment, DaemonSet or StatefulSet, where the user can then select the
+/// Pods for which he wants to view the logs.
+class DetailsGetLogsPods extends StatefulWidget {
+  const DetailsGetLogsPods({
+    Key? key,
+    required this.name,
+    required this.namespace,
+    required this.item,
+  }) : super(key: key);
+
+  final String name;
+  final String namespace;
+  final dynamic item;
+
+  @override
+  State<DetailsGetLogsPods> createState() => _DetailsGetLogsPodsState();
+}
+
+class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
+  bool _isLoading = false;
+  String _error = '';
+  List<IoK8sApiCoreV1Pod> _pods = <IoK8sApiCoreV1Pod>[];
+  List<IoK8sApiCoreV1Pod> _selectedPods = <IoK8sApiCoreV1Pod>[];
+  dynamic _podSpec;
+
+  /// [_getPods] gets all Pods for the provided Deployment, DaemonSet or
+  /// StatefulSet.
+  Future<void> _getPods() async {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+
+    setState(() {
+      _isLoading = true;
+      _error = '';
+    });
+
+    try {
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+
+      final result = await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).getRequest(
+        '/api/v1/namespaces/${widget.namespace}/pods?${getSelector(IoK8sApimachineryPkgApisMetaV1LabelSelector.fromJson(widget.item['spec']['selector']))}',
+      );
+
+      setState(() {
+        _isLoading = false;
+        _pods = IoK8sApiCoreV1PodList.fromJson(result)!.items;
+        if (result['items'].isNotEmpty) {
+          _podSpec = result['items'][0];
+        }
+      });
+    } catch (err) {
+      Logger.log(
+        'DetailsGetLogsPods _getPods',
+        'Could not get clusters',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+        _error = err.toString();
+      });
+    }
+  }
+
+  /// [_buildContent] shows a loading indicator, when we execute the API call to
+  /// get the clusters. When the API call returns an error we display an error
+  /// widget. If the API returns a list of clusters, we show a list of clusters,
+  /// which can be selected by the user to add them to the app.
+  Widget _buildContent() {
+    if (_isLoading) {
+      return Flex(
+        direction: Axis.vertical,
+        children: [
+          Expanded(
+            child: Wrap(
+              children: [
+                CircularProgressIndicator(
+                  color: theme(context).colorPrimary,
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (_error != '') {
+      return Flex(
+        direction: Axis.vertical,
+        children: [
+          Expanded(
+            child: Wrap(
+              children: [
+                AppErrorWidget(
+                  message: 'Could not load clusters',
+                  details: _error,
+                  icon: ClusterProviderType.google.icon(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    return ListView(
+      children: [
+        ...List.generate(
+          _pods.length,
+          (index) {
+            return Container(
+              margin: const EdgeInsets.only(
+                top: Constants.spacingSmall,
+                bottom: Constants.spacingSmall,
+                left: Constants.spacingExtraSmall,
+                right: Constants.spacingExtraSmall,
+              ),
+              decoration: BoxDecoration(
+                boxShadow: [
+                  BoxShadow(
+                    color: theme(context).colorShadow,
+                    blurRadius: Constants.sizeBorderBlurRadius,
+                    spreadRadius: Constants.sizeBorderSpreadRadius,
+                    offset: const Offset(0.0, 0.0),
+                  ),
+                ],
+                color: theme(context).colorCard,
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(Constants.sizeBorderRadius),
+                ),
+              ),
+              child: CheckboxListTile(
+                checkColor: Colors.white,
+                activeColor: theme(context).colorPrimary,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: _selectedPods
+                        .where((p) =>
+                            p.metadata?.name == _pods[index].metadata?.name)
+                        .toList()
+                        .length ==
+                    1,
+                onChanged: (bool? value) {
+                  if (value == true) {
+                    setState(() {
+                      _selectedPods.add(_pods[index]);
+                    });
+                  }
+                  if (value == false) {
+                    setState(() {
+                      _selectedPods = _selectedPods
+                          .where((p) =>
+                              p.metadata?.name == _pods[index].metadata?.name)
+                          .toList();
+                    });
+                  }
+                },
+                title: Text(
+                  Characters(
+                    _pods[index].metadata?.name ?? '',
+                  )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  style: noramlTextStyle(
+                    context,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getPods();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Select Pods',
+      subtitle: '${widget.name}/${widget.namespace}',
+      icon: 'assets/resources/${Resources.map['pods']?.resource}.svg',
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Get Logs',
+      actionPressed: () {
+        Navigator.pop(context);
+        if (_selectedPods.isNotEmpty && _podSpec != null) {
+          showModal(
+            context,
+            DetailsGetLogs(
+              names: _selectedPods
+                  .map((e) => e.metadata?.name ?? '')
+                  .toList()
+                  .join(','),
+              namespace: widget.namespace,
+              item: _podSpec,
+            ),
+          );
+        }
+      },
+      actionIsLoading: _isLoading,
+      child: _buildContent(),
+    );
+  }
+}

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -15,6 +15,7 @@ import 'package:kubenav/widgets/resources/details/details_create_job.dart';
 import 'package:kubenav/widgets/resources/details/details_delete_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_edit_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_get_logs.dart';
+import 'package:kubenav/widgets/resources/details/details_get_logs_pods.dart';
 import 'package:kubenav/widgets/resources/details/details_item_additional_printer_columns.dart';
 import 'package:kubenav/widgets/resources/details/details_item_conditions.dart';
 import 'package:kubenav/widgets/resources/details/details_item_metadata.dart';
@@ -226,6 +227,30 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
             showModal(
               context,
               DetailsGetLogs(
+                names: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if ((Resources.map['deployments']!.resource == resource &&
+            Resources.map['deployments']!.path == path) ||
+        (Resources.map['statefulsets']!.resource == resource &&
+            Resources.map['statefulsets']!.path == path) ||
+        (Resources.map['daemonsets']!.resource == resource &&
+            Resources.map['daemonsets']!.path == path)) {
+      additionalActions.add(
+        AppActionsHeaderModel(
+          title: 'Logs',
+          icon: Icons.subject,
+          onTap: () {
+            showModal(
+              context,
+              DetailsGetLogsPods(
                 name: name,
                 namespace: namespace ?? '',
                 item: item,


### PR DESCRIPTION
It is now possible to view the logs for a Deployment, DaemonSet and StatefulSet. For this the details view of these resources contains a new logs action, which will open a modal, where the user can select the Pods for which he wants to view the logs. Once the user made a selection the already known logs modal is opened where the user can specify the other settings to get the logs (e.g. container name).

Closes #365