### PR TITLE
Fix AWS Role ARN is not Persisted

### DIFF
--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -107,6 +107,7 @@ class ClusterProviderAWS {
       'secretKey': secretKey,
       'region': region,
       'sessionToken': sessionToken,
+      'roleArn': roleArn,
     };
   }
 }


### PR DESCRIPTION
The "roleArn" field was forgotten in the "toJson" method of the AWS cluster provider configuration, so that the proeprty was not persisted and a user had to set it again after the app was restarted.

Fixes #471