### PR TITLE
Add Full Height Modal Setting

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -327,6 +327,17 @@ class AppRepository with ChangeNotifier {
       notifyListeners();
     } catch (_) {}
   }
+
+  /// [setFullHeightModals] enables or disables full height modals. When the
+  /// [value] is `true` full height modals will be enabled. If the [value] is
+  /// `false` the will be disabled.
+  Future<void> setFullHeightModals(bool value) async {
+    try {
+      _settings.fullHeightModals = value;
+      await _save();
+      notifyListeners();
+    } catch (_) {}
+  }
 }
 
 /// The [AppRepositorySettings] model represents all the app settings which can
@@ -336,6 +347,7 @@ class AppRepositorySettings {
   bool isAuthenticationEnabled;
   bool isShowClustersOnStart;
   String editorFormat;
+  bool fullHeightModals;
   String proxy;
   int timeout;
   int sponsorReminder;
@@ -346,6 +358,7 @@ class AppRepositorySettings {
     required this.isAuthenticationEnabled,
     required this.isShowClustersOnStart,
     required this.editorFormat,
+    required this.fullHeightModals,
     required this.proxy,
     required this.timeout,
     required this.sponsorReminder,
@@ -358,6 +371,7 @@ class AppRepositorySettings {
       isAuthenticationEnabled: false,
       isShowClustersOnStart: false,
       editorFormat: 'yaml',
+      fullHeightModals: false,
       proxy: '',
       timeout: 0,
       sponsorReminder: 0,
@@ -382,6 +396,10 @@ class AppRepositorySettings {
           data.containsKey('editorFormat') && data['editorFormat'] != null
               ? data['editorFormat']
               : 'yaml',
+      fullHeightModals: data.containsKey('fullHeightModals') &&
+              data['fullHeightModals'] != null
+          ? data['fullHeightModals']
+          : false,
       proxy: data.containsKey('proxy') && data['proxy'] != null
           ? data['proxy']
           : '',
@@ -404,6 +422,7 @@ class AppRepositorySettings {
       'isAuthenticationEnabled': isAuthenticationEnabled,
       'isShowClustersOnStart': isShowClustersOnStart,
       'editorFormat': editorFormat,
+      'fullHeightModals': fullHeightModals,
       'proxy': proxy,
       'timeout': timeout,
       'sponsorReminder': sponsorReminder,

--- a/lib/widgets/resources/details/details_live_metrics.dart
+++ b/lib/widgets/resources/details/details_live_metrics.dart
@@ -243,19 +243,22 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
               borderRadius: const BorderRadius.all(
                 Radius.circular(Constants.sizeBorderRadius),
               ),
-              child: TabBar(
-                isScrollable: false,
-                labelColor: Colors.white,
-                unselectedLabelColor: theme(context).colorPrimary,
-                labelPadding: EdgeInsets.zero,
-                indicatorSize: TabBarIndicatorSize.tab,
-                indicator: BoxDecoration(
-                  color: theme(context).colorPrimary,
+              child: SizedBox(
+                height: 32,
+                child: TabBar(
+                  isScrollable: false,
+                  labelColor: Colors.white,
+                  unselectedLabelColor: theme(context).colorPrimary,
+                  labelPadding: EdgeInsets.zero,
+                  indicatorSize: TabBarIndicatorSize.tab,
+                  indicator: BoxDecoration(
+                    color: theme(context).colorPrimary,
+                  ),
+                  tabs: const [
+                    Tab(text: 'CPU'),
+                    Tab(text: 'Memory'),
+                  ],
                 ),
-                tabs: const [
-                  Tab(text: 'CPU'),
-                  Tab(text: 'Memory'),
-                ],
               ),
             ),
             const SizedBox(height: Constants.spacingMiddle),

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -412,6 +412,32 @@ class Settings extends StatelessWidget {
 
     items.add(
       AppVertialListSimpleModel(
+        children: [
+          Icon(
+            Icons.code,
+            color: theme(context).colorPrimary,
+          ),
+          const SizedBox(width: Constants.spacingSmall),
+          Expanded(
+            flex: 1,
+            child: Text(
+              'Full Height Modal',
+              style: noramlTextStyle(
+                context,
+              ),
+            ),
+          ),
+          Switch(
+            activeColor: theme(context).colorPrimary,
+            onChanged: (value) => {appRepository.setFullHeightModals(value)},
+            value: appRepository.settings.fullHeightModals,
+          ),
+        ],
+      ),
+    );
+
+    items.add(
+      AppVertialListSimpleModel(
         onTap: () {
           showModal(
             context,

--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
 
+import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
@@ -90,12 +92,21 @@ class AppBottomSheetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom == 0;
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
 
     return SafeArea(
       child: Container(
-        height:
-            MediaQuery.of(context).size.height * (isKeyboardVisible ? 0.75 : 1),
+        height: MediaQuery.of(context).size.height *
+            (isKeyboardVisible
+                ? 1
+                : appRepository.settings.fullHeightModals
+                    ? 1
+                    : 0.75),
         color: Colors.transparent,
         child: Scaffold(
           backgroundColor: Colors.transparent,

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:xterm/ui.dart' as xtermui;
 import 'package:xterm/xterm.dart' as xterm;
 
+import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/terminal_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
@@ -61,17 +62,25 @@ class AppTerminalsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
     TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
       context,
       listen: true,
     );
 
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom == 0;
+    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
 
     return SafeArea(
       child: Container(
-        height:
-            MediaQuery.of(context).size.height * (isKeyboardVisible ? 0.75 : 1),
+        height: MediaQuery.of(context).size.height *
+            (isKeyboardVisible
+                ? 1
+                : appRepository.settings.fullHeightModals
+                    ? 1
+                    : 0.75),
         color: Colors.transparent,
         child: Scaffold(
           backgroundColor: Colors.transparent,
@@ -173,37 +182,40 @@ class AppTerminalsWidget extends StatelessWidget {
                           borderRadius: const BorderRadius.all(
                             Radius.circular(Constants.sizeBorderRadius),
                           ),
-                          child: TabBar(
-                            isScrollable: true,
-                            labelColor: Colors.white,
-                            unselectedLabelColor: theme(context).colorPrimary,
-                            indicatorSize: TabBarIndicatorSize.tab,
-                            indicator: BoxDecoration(
-                              color: theme(context).colorPrimary,
-                            ),
-                            tabs: terminalRepository.terminals
-                                .asMap()
-                                .entries
-                                .map(
-                              (terminal) {
-                                return Tab(
-                                  child: GestureDetector(
-                                    onDoubleTap: () {
-                                      terminalRepository.deleteTerminal(
-                                        terminal.key,
-                                      );
-                                      if (terminalRepository
-                                          .terminals.isEmpty) {
-                                        Navigator.pop(context);
-                                      }
-                                    },
-                                    child: Text(
-                                      terminal.value.name,
+                          child: SizedBox(
+                            height: 32,
+                            child: TabBar(
+                              isScrollable: true,
+                              labelColor: Colors.white,
+                              unselectedLabelColor: theme(context).colorPrimary,
+                              indicatorSize: TabBarIndicatorSize.tab,
+                              indicator: BoxDecoration(
+                                color: theme(context).colorPrimary,
+                              ),
+                              tabs: terminalRepository.terminals
+                                  .asMap()
+                                  .entries
+                                  .map(
+                                (terminal) {
+                                  return Tab(
+                                    child: GestureDetector(
+                                      onDoubleTap: () {
+                                        terminalRepository.deleteTerminal(
+                                          terminal.key,
+                                        );
+                                        if (terminalRepository
+                                            .terminals.isEmpty) {
+                                          Navigator.pop(context);
+                                        }
+                                      },
+                                      child: Text(
+                                        terminal.value.name,
+                                      ),
                                     ),
-                                  ),
-                                );
-                              },
-                            ).toList(),
+                                  );
+                                },
+                              ).toList(),
+                            ),
                           ),
                         ),
                         const SizedBox(height: Constants.spacingMiddle),


### PR DESCRIPTION
This commit adds a new "fullHeightModals" setting in the app settings, which allows a user to enabled full height modals (modals which takes the entire screen size and not just 75%). This setting isn't enabled by default, because it also comes with the drawback that the modal header is moved behind the safe area.

Hopefully this should be fixed by the "safeArea" property for modal bottom sheets in Flutter 3.7.0 (currently we are not able to update because some dependencies are not working with the new version).

Fixes #467