### PR TITLE
Disable Navigation to Current Page

### DIFF
--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:provider/provider.dart';
 
@@ -177,7 +176,7 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
         child: ListView(
           shrinkWrap: false,
           children: [
-            Padding(
+            const Padding(
               padding: EdgeInsets.symmetric(
                 vertical: Constants.spacingSmall,
               ),
@@ -185,7 +184,7 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
                 'We believe in open source. This means that we will never put any features behind a paywall. You will always be able to use all features of kubenav for free.',
               ),
             ),
-            Padding(
+            const Padding(
               padding: EdgeInsets.symmetric(
                 vertical: Constants.spacingSmall,
               ),
@@ -193,7 +192,7 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
                 'With the monthly and yearly sponsoring you can remove the "Sponsor" banner in the settings screen and support the development of kubenav.',
               ),
             ),
-            Padding(
+            const Padding(
               padding: EdgeInsets.symmetric(
                 vertical: Constants.spacingSmall,
               ),

--- a/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
+++ b/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
@@ -52,19 +52,55 @@ class AppBottomNavigationBarWidget extends StatelessWidget {
       onTap: (value) {
         switch (value) {
           case 0:
-            navigate(context, const Home(), Constants.pageIndexHome);
+            if (Navigator.of(context).canPop() == true ||
+                appRepository.currentPageIndex != Constants.pageIndexHome) {
+              navigate(
+                context,
+                const Home(),
+                Constants.pageIndexHome,
+              );
+            }
             break;
           case 1:
-            navigate(context, const Resources(), Constants.pageIndexResources);
+            if (Navigator.of(context).canPop() == true ||
+                appRepository.currentPageIndex !=
+                    Constants.pageIndexResources) {
+              navigate(
+                context,
+                const Resources(),
+                Constants.pageIndexResources,
+              );
+            }
             break;
           case 2:
-            navigate(context, const Plugins(), Constants.pageIndexPlugins);
+            if (Navigator.of(context).canPop() == true ||
+                appRepository.currentPageIndex != Constants.pageIndexPlugins) {
+              navigate(
+                context,
+                const Plugins(),
+                Constants.pageIndexPlugins,
+              );
+            }
             break;
           case 3:
-            navigate(context, const Settings(), Constants.pageIndexSettings);
+            if (Navigator.of(context).canPop() == true ||
+                appRepository.currentPageIndex != Constants.pageIndexSettings) {
+              navigate(
+                context,
+                const Settings(),
+                Constants.pageIndexSettings,
+              );
+            }
             break;
           default:
-            navigate(context, const Home(), Constants.pageIndexHome);
+            if (Navigator.of(context).canPop() == true ||
+                appRepository.currentPageIndex != Constants.pageIndexHome) {
+              navigate(
+                context,
+                const Home(),
+                Constants.pageIndexHome,
+              );
+            }
             break;
         }
       },


### PR DESCRIPTION
Until now it was possible to navigate to the same page via the bottom navigation bar. This is not possible anymore. This was removed, because it was a bit confusing for users, e.g. a user was on the home page and clicked the home icon, the navigation animation was displayed, but the user was still on the same page.

This doesn't effect the behaviour that the bottom navigation bar can also be used to go back to the root page, e.g. a user views the details of a Kubernetes resource, he can still go back to the resources list by clicking on the resources icon in the navigation bar.