### PR TITLE
macOS: Add Homebrew to Path

### DIFF
--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -33,7 +33,7 @@
 	<key>LSEnvironment</key>
 	<dict>
 		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Add the Homebrew location to the path variable for the macOS app, so that authentication for Kubernetes clusters works, when a user has installed the cloud providers CLI via Homebrew.

Fixes #476