### PR TITLE
Add Actions for Resources in List View

### DIFF
--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -98,6 +98,7 @@ class _OverviewEventsState extends State<OverviewEvents> {
           Resources.map['events']!.additionalPrinterColumns,
       name: event.metadata.name ?? '',
       namespace: event.metadata.namespace,
+      item: null,
       info: info,
       status: event.type == 'Normal' ? Status.success : Status.warning,
     );

--- a/lib/widgets/resources/list/clusterrolebinding_list_item.dart
+++ b/lib/widgets/resources/list/clusterrolebinding_list_item.dart
@@ -45,6 +45,7 @@ class ClusterRoleBindingListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: clusterRoleBinding?.metadata?.name ?? '',
       namespace: null,
+      item: item,
       info: [
         'Role: $role',
         'Age: $age',

--- a/lib/widgets/resources/list/configmap_list_item.dart
+++ b/lib/widgets/resources/list/configmap_list_item.dart
@@ -43,6 +43,7 @@ class ConfigMapListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: configMap?.metadata?.name ?? '',
       namespace: configMap?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${configMap?.metadata?.namespace ?? '-'}',
         'Data: $data',

--- a/lib/widgets/resources/list/cronjob_list_item.dart
+++ b/lib/widgets/resources/list/cronjob_list_item.dart
@@ -46,6 +46,7 @@ class CronJobListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: cronJob?.metadata?.name ?? '',
       namespace: cronJob?.metadata?.namespace,
+      item: item,
       info: info,
       status: suspend == 'True' ? Status.warning : Status.success,
     );

--- a/lib/widgets/resources/list/daemonset_list_item.dart
+++ b/lib/widgets/resources/list/daemonset_list_item.dart
@@ -75,6 +75,7 @@ class DaemonSetListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: daemonSet?.metadata?.name ?? '',
       namespace: daemonSet?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${daemonSet?.metadata?.namespace ?? '-'}',
         'Desired: $desired',

--- a/lib/widgets/resources/list/default_list_item.dart
+++ b/lib/widgets/resources/list/default_list_item.dart
@@ -77,6 +77,7 @@ class DefaultListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: name,
       namespace: namespace,
+      item: item,
       info: _buildInfo(namespace, age),
     );
   }

--- a/lib/widgets/resources/list/deployment_list_item.dart
+++ b/lib/widgets/resources/list/deployment_list_item.dart
@@ -67,6 +67,7 @@ class DeploymentListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: deplyoment?.metadata?.name ?? '',
       namespace: deplyoment?.metadata?.namespace,
+      item: item,
       info: info,
       status: getStatus(
         replicas,

--- a/lib/widgets/resources/list/endpoint_list_item.dart
+++ b/lib/widgets/resources/list/endpoint_list_item.dart
@@ -46,6 +46,7 @@ class EndpointListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: endpoint?.metadata?.name ?? '',
       namespace: endpoint?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${endpoint?.metadata?.namespace ?? '-'}',
         'Endpoints: ${ips != null && ips.isNotEmpty ? ips.join(', ') : '-'}',

--- a/lib/widgets/resources/list/event_list_item.dart
+++ b/lib/widgets/resources/list/event_list_item.dart
@@ -43,6 +43,7 @@ class EventListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: event?.metadata.name ?? '',
       namespace: event?.metadata.namespace,
+      item: item,
       info: info,
       status: type == 'Normal' ? Status.success : Status.warning,
     );

--- a/lib/widgets/resources/list/horizontalpodautoscaler_list_item.dart
+++ b/lib/widgets/resources/list/horizontalpodautoscaler_list_item.dart
@@ -60,6 +60,7 @@ class HorizontalPodAutoscalerListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: hpa?.metadata?.name ?? '',
       namespace: hpa?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${hpa?.metadata?.namespace ?? '-'}',
         'Reference: $reference',

--- a/lib/widgets/resources/list/ingress_list_item.dart
+++ b/lib/widgets/resources/list/ingress_list_item.dart
@@ -47,6 +47,7 @@ class IngressListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: ingress?.metadata?.name ?? '',
       namespace: ingress?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${ingress?.metadata?.namespace ?? '-'}',
         'Hosts: ${hosts != null && hosts.isNotEmpty ? hosts.join(', ') : '-'}',

--- a/lib/widgets/resources/list/job_list_item.dart
+++ b/lib/widgets/resources/list/job_list_item.dart
@@ -44,6 +44,7 @@ class JobListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: job?.metadata?.name ?? '',
       namespace: job?.metadata?.namespace,
+      item: item,
       info: info,
       status: completions != 0 && completions != succeeded
           ? Status.danger

--- a/lib/widgets/resources/list/list_item.dart
+++ b/lib/widgets/resources/list/list_item.dart
@@ -5,6 +5,8 @@ import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/navigate.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/list/list_item_actions.dart';
 import 'package:kubenav/widgets/resources/resource_details.dart';
 import 'package:kubenav/widgets/shared/app_list_item.dart';
 
@@ -43,6 +45,7 @@ class ListItemWidget extends StatelessWidget {
     required this.additionalPrinterColumns,
     required this.name,
     required this.namespace,
+    required this.item,
     required this.info,
     this.status = Status.undefined,
     this.onTap,
@@ -55,6 +58,7 @@ class ListItemWidget extends StatelessWidget {
   final List<AdditionalPrinterColumns> additionalPrinterColumns;
   final String name;
   final String? namespace;
+  final dynamic item;
   final List<String> info;
   final Status status;
   final void Function()? onTap;
@@ -122,6 +126,23 @@ class ListItemWidget extends StatelessWidget {
             ),
           );
         },
+        onDoubleTap: item == null
+            ? null
+            : () {
+                showActions(
+                  context,
+                  ListItemActions(
+                    title: title,
+                    resource: resource,
+                    path: path,
+                    scope: scope,
+                    additionalPrinterColumns: additionalPrinterColumns,
+                    name: name,
+                    namespace: namespace,
+                    item: item,
+                  ),
+                );
+              },
         child: Row(
           children: [
             Expanded(

--- a/lib/widgets/resources/list/list_item_actions.dart
+++ b/lib/widgets/resources/list/list_item_actions.dart
@@ -1,0 +1,378 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_pod.dart';
+import 'package:kubenav/models/resource.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/bookmarks_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/details/details_create_job.dart';
+import 'package:kubenav/widgets/resources/details/details_delete_resource.dart';
+import 'package:kubenav/widgets/resources/details/details_edit_resource.dart';
+import 'package:kubenav/widgets/resources/details/details_get_logs.dart';
+import 'package:kubenav/widgets/resources/details/details_get_logs_pods.dart';
+import 'package:kubenav/widgets/resources/details/details_live_metrics_containers.dart';
+import 'package:kubenav/widgets/resources/details/details_restart_resource.dart';
+import 'package:kubenav/widgets/resources/details/details_scale_resource.dart';
+import 'package:kubenav/widgets/resources/details/details_show_yaml.dart';
+import 'package:kubenav/widgets/resources/details/details_terminal.dart';
+import 'package:kubenav/widgets/shared/app_actions_widget.dart';
+
+/// The [ListItemActions] widget renders an actions menu, with the actions for
+/// a reesource. The actions are the same as defined in `resource_details.dart`
+/// file for the details view of a resource.
+class ListItemActions extends StatefulWidget {
+  const ListItemActions({
+    Key? key,
+    required this.title,
+    required this.resource,
+    required this.path,
+    required this.scope,
+    required this.additionalPrinterColumns,
+    required this.name,
+    required this.namespace,
+    required this.item,
+  }) : super(key: key);
+
+  final String title;
+  final String resource;
+  final String path;
+  final ResourceScope scope;
+  final List<AdditionalPrinterColumns> additionalPrinterColumns;
+  final String name;
+  final String? namespace;
+  final dynamic item;
+
+  @override
+  State<ListItemActions> createState() => _ListItemActionsState();
+}
+
+class _ListItemActionsState extends State<ListItemActions> {
+  List<AppActionsWidgetAction> buildAdditionalActions(
+    BuildContext context,
+    String resource,
+    String path,
+    String name,
+    String? namespace,
+    dynamic item,
+  ) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    final List<AppActionsWidgetAction> additionalActions = [];
+
+    if ((Resources.map['deployments']!.resource == resource &&
+            Resources.map['deployments']!.path == path) ||
+        (Resources.map['statefulsets']!.resource == resource &&
+            Resources.map['statefulsets']!.path == path)) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Scale',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsScaleResource(
+                resource: resource,
+                path: path,
+                name: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if ((Resources.map['deployments']!.resource == resource &&
+            Resources.map['deployments']!.path == path) ||
+        (Resources.map['statefulsets']!.resource == resource &&
+            Resources.map['statefulsets']!.path == path) ||
+        (Resources.map['daemonsets']!.resource == resource &&
+            Resources.map['daemonsets']!.path == path)) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Restart',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsRestartResource(
+                resource: resource,
+                path: path,
+                name: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (Resources.map['cronjobs']!.resource == resource &&
+        Resources.map['cronjobs']!.path == path) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Create Job',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsCreateJob(
+                name: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (Resources.map['pods']!.resource == resource &&
+        Resources.map['pods']!.path == path) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Logs',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsGetLogs(
+                names: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if ((Resources.map['deployments']!.resource == resource &&
+            Resources.map['deployments']!.path == path) ||
+        (Resources.map['statefulsets']!.resource == resource &&
+            Resources.map['statefulsets']!.path == path) ||
+        (Resources.map['daemonsets']!.resource == resource &&
+            Resources.map['daemonsets']!.path == path)) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Logs',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsGetLogsPods(
+                name: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (Resources.map['pods']!.resource == resource &&
+        Resources.map['pods']!.path == path) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Terminal',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsTerminal(
+                name: name,
+                namespace: namespace ?? '',
+                item: item,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (Resources.map['pods']!.resource == resource &&
+        Resources.map['pods']!.path == path) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: 'Live Metrics',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showActions(
+              context,
+              DetailsLiveMetricsContainers(
+                name: name,
+                namespace: namespace ?? '',
+                pod: IoK8sApiCoreV1Pod.fromJson(item)!,
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (Resources.map['namespaces']!.resource == resource &&
+        Resources.map['namespaces']!.path == path) {
+      additionalActions.add(
+        AppActionsWidgetAction(
+          title: appRepository.settings.namespaces
+                  .where((e) => e == name)
+                  .toList()
+                  .isEmpty
+              ? 'Add to Favorites'
+              : 'Remove from Favorites',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            if (appRepository.settings.namespaces
+                .where((e) => e == name)
+                .toList()
+                .isEmpty) {
+              appRepository.addNamespace(name);
+            } else {
+              appRepository.deleteNamespace(name);
+            }
+          },
+        ),
+      );
+    }
+
+    return additionalActions;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    BookmarksRepository bookmarksRepository = Provider.of<BookmarksRepository>(
+      context,
+      listen: false,
+    );
+
+    return AppActionsWidget(
+      actions: [
+        AppActionsWidgetAction(
+          title:
+              appRepository.settings.editorFormat == 'json' ? 'Json' : 'Yaml',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsShowYaml(
+                item: widget.item,
+              ),
+            );
+          },
+        ),
+        AppActionsWidgetAction(
+          title: 'Edit',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsEditResource(
+                resource: widget.resource,
+                path: widget.path,
+                name: widget.name,
+                namespace: widget.namespace,
+                item: widget.item,
+              ),
+            );
+          },
+        ),
+        AppActionsWidgetAction(
+          title: 'Delete',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              DetailsDeleteResource(
+                resource: widget.resource,
+                path: widget.path,
+                name: widget.name,
+                namespace: widget.namespace,
+              ),
+            );
+          },
+        ),
+        AppActionsWidgetAction(
+          title: bookmarksRepository.isBookmarked(
+                    BookmarkType.details,
+                    clustersRepository.activeClusterId,
+                    widget.title,
+                    widget.resource,
+                    widget.path,
+                    widget.scope,
+                    widget.name,
+                    widget.namespace,
+                  ) >
+                  -1
+              ? 'Remove from Bookmarks'
+              : 'Add to Bookmarks',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            final bookmarkIndex = bookmarksRepository.isBookmarked(
+              BookmarkType.details,
+              clustersRepository.activeClusterId,
+              widget.title,
+              widget.resource,
+              widget.path,
+              widget.scope,
+              widget.name,
+              widget.namespace,
+            );
+            if (bookmarkIndex > -1) {
+              bookmarksRepository.removeBookmark(bookmarkIndex);
+            } else {
+              bookmarksRepository.addBookmark(
+                BookmarkType.details,
+                clustersRepository.activeClusterId,
+                widget.title,
+                widget.resource,
+                widget.path,
+                widget.scope,
+                widget.additionalPrinterColumns,
+                widget.name,
+                widget.namespace,
+              );
+            }
+          },
+        ),
+        ...buildAdditionalActions(
+          context,
+          widget.resource,
+          widget.path,
+          widget.name,
+          widget.namespace,
+          widget.item,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/resources/list/namespace_list_item.dart
+++ b/lib/widgets/resources/list/namespace_list_item.dart
@@ -43,6 +43,7 @@ class NamespaceListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: namespace?.metadata?.name ?? '',
       namespace: null,
+      item: item,
       info: [
         'Status: $status',
         'Age: $age',

--- a/lib/widgets/resources/list/networkpolicy_list_item.dart
+++ b/lib/widgets/resources/list/networkpolicy_list_item.dart
@@ -45,6 +45,7 @@ class NetworkPolicyListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: np?.metadata?.name ?? '',
       namespace: np?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${np?.metadata?.namespace ?? '-'}',
         'Pod Selector: ${podSelector != null && podSelector.isNotEmpty ? podSelector.join(', ') : '-'}',

--- a/lib/widgets/resources/list/node_list_item.dart
+++ b/lib/widgets/resources/list/node_list_item.dart
@@ -65,6 +65,7 @@ class NodeListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: node?.metadata?.name ?? '',
       namespace: null,
+      item: item,
       info: info,
       status: status != null && status.where((e) => e == 'Ready').isNotEmpty
           ? Status.success

--- a/lib/widgets/resources/list/persistentvolume_list_item.dart
+++ b/lib/widgets/resources/list/persistentvolume_list_item.dart
@@ -54,6 +54,7 @@ class PersistentVolumeListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: pv?.metadata?.name ?? '',
       namespace: null,
+      item: item,
       info: [
         'Capacity: $capacity',
         'Access Modes: $accessMode',

--- a/lib/widgets/resources/list/persistentvolumeclaim_list_item.dart
+++ b/lib/widgets/resources/list/persistentvolumeclaim_list_item.dart
@@ -48,6 +48,7 @@ class PersistentVolumeClaimListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: pvc?.metadata?.name ?? '',
       namespace: pvc?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${pvc?.metadata?.namespace ?? '-'}',
         'Status: $status',

--- a/lib/widgets/resources/list/pod_list_item.dart
+++ b/lib/widgets/resources/list/pod_list_item.dart
@@ -54,6 +54,7 @@ class PodListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: pod?.metadata?.name ?? '',
       namespace: pod?.metadata?.namespace,
+      item: item,
       info: info,
       status: status,
     );

--- a/lib/widgets/resources/list/poddisruptionbudget_list_item.dart
+++ b/lib/widgets/resources/list/poddisruptionbudget_list_item.dart
@@ -63,6 +63,7 @@ class PodDisruptionBudgetListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: pdb?.metadata?.name ?? '',
       namespace: pdb?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${pdb?.metadata?.namespace ?? '-'}',
         'Min. Available: $minAvailable',

--- a/lib/widgets/resources/list/replicaset_list_item.dart
+++ b/lib/widgets/resources/list/replicaset_list_item.dart
@@ -61,6 +61,7 @@ class ReplicaSetListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: replicaSet?.metadata?.name ?? '',
       namespace: replicaSet?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${replicaSet?.metadata?.namespace ?? '-'}',
         'Desired: $desired',

--- a/lib/widgets/resources/list/rolebinding_list_item.dart
+++ b/lib/widgets/resources/list/rolebinding_list_item.dart
@@ -44,6 +44,7 @@ class RoleBindingListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: roleBinding?.metadata?.name ?? '',
       namespace: roleBinding?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${roleBinding?.metadata?.namespace ?? '-'}',
         'Role: $role',

--- a/lib/widgets/resources/list/secret_list_item.dart
+++ b/lib/widgets/resources/list/secret_list_item.dart
@@ -59,6 +59,7 @@ class SecretListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: secret?.metadata?.name ?? '',
       namespace: secret?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${secret?.metadata?.namespace ?? '-'}',
         'Type: $type',

--- a/lib/widgets/resources/list/service_list_item.dart
+++ b/lib/widgets/resources/list/service_list_item.dart
@@ -51,6 +51,7 @@ class ServiceListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: service?.metadata?.name ?? '',
       namespace: service?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${service?.metadata?.namespace ?? '-'}',
         'Type: $type',

--- a/lib/widgets/resources/list/serviceaccount_list_item.dart
+++ b/lib/widgets/resources/list/serviceaccount_list_item.dart
@@ -44,6 +44,7 @@ class ServiceAccountListItem extends StatelessWidget
       additionalPrinterColumns: additionalPrinterColumns,
       name: sa?.metadata?.name ?? '',
       namespace: sa?.metadata?.namespace,
+      item: item,
       info: [
         'Namespace: ${sa?.metadata?.namespace ?? '-'}',
         'Secrets: $secrets',

--- a/lib/widgets/resources/list/statefulset_list_item.dart
+++ b/lib/widgets/resources/list/statefulset_list_item.dart
@@ -65,6 +65,7 @@ class StatefulSetListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: sts?.metadata?.name ?? '',
       namespace: sts?.metadata?.namespace,
+      item: item,
       info: info,
       status: getStatus(
         replicas,

--- a/lib/widgets/resources/list/storageclass_list_item.dart
+++ b/lib/widgets/resources/list/storageclass_list_item.dart
@@ -49,6 +49,7 @@ class StorageClassListItem extends StatelessWidget implements IListItemWidget {
       additionalPrinterColumns: additionalPrinterColumns,
       name: sc?.metadata?.name ?? '',
       namespace: null,
+      item: item,
       info: [
         'Provisioner: $provisioner',
         'Reclaim Policy: $reclaimPolicy',


### PR DESCRIPTION
It is now possible to view the actions like gettings logs for a Pod, scaling a Deployment, etc. in the list view of the resources. The actions can be opened via a double tap on the resource. This allows users to use actions without going to the details page of a resource.