### PR TITLE
Add Support for Streaming Logs

### DIFF
--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -93,6 +93,7 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
             TerminalType.exec,
             _container,
             null,
+            null,
             TerminalBackend(channel),
           );
           setState(() {

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -238,36 +238,52 @@ class AppTerminalsWidget extends StatelessWidget {
                                             ),
                                           )
                                         : Container()
-                                    : SingleChildScrollView(
-                                        physics: const ClampingScrollPhysics(),
-                                        child: Container(
-                                          padding: const EdgeInsets.all(
-                                            Constants.spacingSmall,
-                                          ),
-                                          color: const Color(0xff2E3440),
-                                          child: Wrap(
-                                            children: terminal.value.logs ==
-                                                    null
-                                                ? []
-                                                : terminal.value.logs!
-                                                    .asMap()
-                                                    .entries
-                                                    .map(
-                                                      (e) => SelectableText(
-                                                        e.value.join('\n\n'),
-                                                        style: TextStyle(
-                                                          color:
-                                                              getColor(e.key),
-                                                          fontSize: 14,
-                                                          fontFamily:
-                                                              getMonospaceFontFamily(),
-                                                        ),
-                                                      ),
-                                                    )
-                                                    .toList(),
-                                          ),
-                                        ),
-                                      );
+                                    : terminal.value.type ==
+                                            TerminalType.logstream
+                                        ? terminal.value.logstream != null
+                                            ? xtermui.TerminalView(
+                                                terminal
+                                                    .value.logstream!.terminal,
+                                                theme: terminalTheme,
+                                                textStyle: xterm.TerminalStyle(
+                                                  fontSize: 14,
+                                                  fontFamily:
+                                                      getMonospaceFontFamily(),
+                                                ),
+                                              )
+                                            : Container()
+                                        : SingleChildScrollView(
+                                            physics:
+                                                const ClampingScrollPhysics(),
+                                            child: Container(
+                                              padding: const EdgeInsets.all(
+                                                Constants.spacingSmall,
+                                              ),
+                                              color: const Color(0xff2E3440),
+                                              child: Wrap(
+                                                children: terminal.value.logs ==
+                                                        null
+                                                    ? []
+                                                    : terminal.value.logs!
+                                                        .asMap()
+                                                        .entries
+                                                        .map(
+                                                          (e) => SelectableText(
+                                                            e.value
+                                                                .join('\n\n'),
+                                                            style: TextStyle(
+                                                              color: getColor(
+                                                                  e.key),
+                                                              fontSize: 14,
+                                                              fontFamily:
+                                                                  getMonospaceFontFamily(),
+                                                            ),
+                                                          ),
+                                                        )
+                                                        .toList(),
+                                              ),
+                                            ),
+                                          );
                               },
                             ).toList(),
                           ),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ func Start(kubeClient kube.Client) {
 	router.HandleFunc("/health", middleware.Cors(s.healthHandler))
 	router.HandleFunc("/portforwarding", middleware.Cors(s.portForwardingHandler))
 	router.HandleFunc("/terminal", middleware.Cors(s.terminalHandler))
+	router.HandleFunc("/logs", middleware.Cors(s.logsHandler))
 
 	if err := http.ListenAndServe(":14122", router); err != nil {
 		return

--- a/pkg/server/streamlogs/streamlogs.go
+++ b/pkg/server/streamlogs/streamlogs.go
@@ -1,0 +1,55 @@
+package streamlogs
+
+import (
+	"bufio"
+	"context"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// StreamLogs opens a log stream for the provided container and writes the stream to the provided WebSocket connection.
+func StreamLogs(ctx context.Context, clientset *kubernetes.Clientset, conn *websocket.Conn, namespace, name, container string, since int64) error {
+	options := &corev1.PodLogOptions{
+		Container:    container,
+		SinceSeconds: &since,
+		Follow:       true,
+	}
+
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, options).Stream(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer stream.Close()
+	reader := bufio.NewReaderSize(stream, 16)
+	lastLine := ""
+
+	for {
+		data, isPrefix, err := reader.ReadLine()
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(string(data), "\r")
+		length := len(lines)
+
+		if len(lastLine) > 0 {
+			lines[0] = lastLine + lines[0]
+			lastLine = ""
+		}
+
+		if isPrefix {
+			lastLine = lines[length-1]
+			lines = lines[:(length - 1)]
+		}
+
+		for _, line := range lines {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(line)); err != nil {
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
It is now possible to listen on a stream of logs for a Pod / Container. For this we had added a new route to the http server, which can be used to create a WebSocket connection to stream the logs.

We have keept the original logs implementation, because when the user just wants to see the logs without following them we can still use this implementation, which has the advantage that we do not have to start a http server.