### PR TITLE
Use new "useSafeArea" Property for Modals

### DIFF
--- a/lib/utils/showmodal.dart
+++ b/lib/utils/showmodal.dart
@@ -8,6 +8,7 @@ void showModal(BuildContext context, Widget widget) {
     context: context,
     isScrollControlled: true,
     isDismissible: true,
+    useSafeArea: true,
     builder: (BuildContext context) {
       return widget;
     },
@@ -19,6 +20,7 @@ void showActions(BuildContext context, Widget widget) {
     context: context,
     isScrollControlled: false,
     isDismissible: true,
+    useSafeArea: true,
     backgroundColor: Colors.transparent,
     builder: (BuildContext context) {
       return Container(

--- a/lib/widgets/shared/app_actions_widget.dart
+++ b/lib/widgets/shared/app_actions_widget.dart
@@ -49,55 +49,53 @@ class AppActionsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Container(
-        margin: const EdgeInsets.only(
-          left: Constants.spacingMiddle,
-          right: Constants.spacingMiddle,
+    return Container(
+      margin: const EdgeInsets.only(
+        left: Constants.spacingMiddle,
+        right: Constants.spacingMiddle,
+      ),
+      padding: const EdgeInsets.only(
+        left: Constants.spacingMiddle,
+        right: Constants.spacingMiddle,
+      ),
+      decoration: BoxDecoration(
+        color: theme(context).colorCard,
+        borderRadius: const BorderRadius.all(
+          Radius.circular(Constants.sizeBorderRadius),
         ),
-        padding: const EdgeInsets.only(
-          left: Constants.spacingMiddle,
-          right: Constants.spacingMiddle,
-        ),
-        decoration: BoxDecoration(
-          color: theme(context).colorCard,
-          borderRadius: const BorderRadius.all(
-            Radius.circular(Constants.sizeBorderRadius),
-          ),
-        ),
-        child: Wrap(
-          alignment: WrapAlignment.center,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: List.generate(actions.length, (index) {
-            if (index == actions.length - 1) {
-              return Wrap(
-                children: [
-                  ListTile(
-                    onTap: actions[index].onTap,
-                    title: Text(
-                      actions[index].title,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(color: actions[index].color),
-                    ),
+      ),
+      child: Wrap(
+        alignment: WrapAlignment.center,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: List.generate(actions.length, (index) {
+          if (index == actions.length - 1) {
+            return Wrap(
+              children: [
+                ListTile(
+                  onTap: actions[index].onTap,
+                  title: Text(
+                    actions[index].title,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: actions[index].color),
                   ),
-                  const Divider(
-                    height: 0,
-                    thickness: 1.0,
-                  ),
-                ],
-              );
-            } else {
-              return ListTile(
-                onTap: actions[index].onTap,
-                title: Text(
-                  actions[index].title,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: actions[index].color),
                 ),
-              );
-            }
-          }),
-        ),
+                const Divider(
+                  height: 0,
+                  thickness: 1.0,
+                ),
+              ],
+            );
+          } else {
+            return ListTile(
+              onTap: actions[index].onTap,
+              title: Text(
+                actions[index].title,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: actions[index].color),
+              ),
+            );
+          }
+        }),
       ),
     );
   }

--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -99,126 +99,124 @@ class AppBottomSheetWidget extends StatelessWidget {
 
     final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
 
-    return SafeArea(
-      child: Container(
-        height: MediaQuery.of(context).size.height *
-            (isKeyboardVisible
-                ? 1
-                : appRepository.settings.fullHeightModals
-                    ? 1
-                    : 0.75),
-        color: Colors.transparent,
-        child: Scaffold(
-          backgroundColor: Colors.transparent,
-          body: Container(
-            padding: const EdgeInsets.only(
-              left: Constants.spacingMiddle,
-              right: Constants.spacingMiddle,
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Container(
-                  padding: const EdgeInsets.only(
-                    top: Constants.spacingMiddle,
-                    bottom: Constants.spacingMiddle,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Flexible(
-                        child: Row(
-                          children: [
-                            _buildIcon(context, icon),
-                            Flexible(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    title,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: primaryTextStyle(
-                                      context,
-                                      size: 18,
-                                    ),
+    return Container(
+      height: MediaQuery.of(context).size.height *
+          (isKeyboardVisible
+              ? 1
+              : appRepository.settings.fullHeightModals
+                  ? 1
+                  : 0.75),
+      color: Colors.transparent,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Container(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                  bottom: Constants.spacingMiddle,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      child: Row(
+                        children: [
+                          _buildIcon(context, icon),
+                          Flexible(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  title,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: primaryTextStyle(
+                                    context,
+                                    size: 18,
                                   ),
-                                  Text(
-                                    Characters(subtitle)
-                                        .replaceAll(Characters(''),
-                                            Characters('\u{200B}'))
-                                        .toString(),
-                                    overflow: TextOverflow.ellipsis,
-                                    style: secondaryTextStyle(
-                                      context,
-                                    ),
+                                ),
+                                Text(
+                                  Characters(subtitle)
+                                      .replaceAll(Characters(''),
+                                          Characters('\u{200B}'))
+                                      .toString(),
+                                  overflow: TextOverflow.ellipsis,
+                                  style: secondaryTextStyle(
+                                    context,
                                   ),
-                                ],
-                              ),
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
-                      ),
-                      IconButton(
-                        icon: Icon(
-                          Icons.close_outlined,
-                          color: theme(context).colorTextPrimary,
-                        ),
-                        onPressed: closePressed,
-                      ),
-                    ],
-                  ),
-                ),
-                const Divider(
-                  height: 0,
-                  thickness: 1.0,
-                ),
-                const SizedBox(height: Constants.spacingMiddle),
-                Flexible(
-                  child: child,
-                ),
-                const SizedBox(height: Constants.spacingMiddle),
-                const Divider(
-                  height: 0,
-                  thickness: 1.0,
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    top: Constants.spacingMiddle,
-                    bottom: Constants.spacingMiddle,
-                  ),
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme(context).colorPrimary,
-                      foregroundColor: Colors.white,
-                      minimumSize: const Size.fromHeight(40),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(
-                          Constants.sizeBorderRadius,
-                        ),
+                          ),
+                        ],
                       ),
                     ),
-                    onPressed: actionIsLoading ? null : actionPressed,
-                    child: actionIsLoading
-                        ? const SizedBox(
-                            height: 24,
-                            width: 24,
-                            child: CircularProgressIndicator(
-                              color: Colors.white,
-                            ),
-                          )
-                        : Text(
-                            actionText,
-                            style: primaryTextStyle(
-                              context,
-                              color: Colors.white,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                  ),
+                    IconButton(
+                      icon: Icon(
+                        Icons.close_outlined,
+                        color: theme(context).colorTextPrimary,
+                      ),
+                      onPressed: closePressed,
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+              const Divider(
+                height: 0,
+                thickness: 1.0,
+              ),
+              const SizedBox(height: Constants.spacingMiddle),
+              Flexible(
+                child: child,
+              ),
+              const SizedBox(height: Constants.spacingMiddle),
+              const Divider(
+                height: 0,
+                thickness: 1.0,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                  bottom: Constants.spacingMiddle,
+                ),
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme(context).colorPrimary,
+                    foregroundColor: Colors.white,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
+                    ),
+                  ),
+                  onPressed: actionIsLoading ? null : actionPressed,
+                  child: actionIsLoading
+                      ? const SizedBox(
+                          height: 24,
+                          width: 24,
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                          ),
+                        )
+                      : Text(
+                          actionText,
+                          style: primaryTextStyle(
+                            context,
+                            color: Colors.white,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -73,228 +73,223 @@ class AppTerminalsWidget extends StatelessWidget {
 
     final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
 
-    return SafeArea(
-      child: Container(
-        height: MediaQuery.of(context).size.height *
-            (isKeyboardVisible
-                ? 1
-                : appRepository.settings.fullHeightModals
-                    ? 1
-                    : 0.75),
-        color: Colors.transparent,
-        child: Scaffold(
-          backgroundColor: Colors.transparent,
-          body: Container(
-            padding: const EdgeInsets.only(
-              left: Constants.spacingMiddle,
-              right: Constants.spacingMiddle,
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Container(
-                  padding: const EdgeInsets.only(
-                    top: Constants.spacingMiddle,
-                    bottom: Constants.spacingMiddle,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Flexible(
-                        child: Row(
-                          children: [
-                            Container(
-                              margin: const EdgeInsets.only(
-                                right: Constants.spacingMiddle,
-                              ),
-                              padding: const EdgeInsets.all(
-                                Constants.spacingExtraSmall,
-                              ),
-                              decoration: BoxDecoration(
-                                color: theme(context).colorPrimary,
-                                borderRadius: const BorderRadius.all(
-                                  Radius.circular(
-                                    Constants.sizeBorderRadius,
-                                  ),
+    return Container(
+      height: MediaQuery.of(context).size.height *
+          (isKeyboardVisible
+              ? 1
+              : appRepository.settings.fullHeightModals
+                  ? 1
+                  : 0.75),
+      color: Colors.transparent,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Container(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                  bottom: Constants.spacingMiddle,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      child: Row(
+                        children: [
+                          Container(
+                            margin: const EdgeInsets.only(
+                              right: Constants.spacingMiddle,
+                            ),
+                            padding: const EdgeInsets.all(
+                              Constants.spacingExtraSmall,
+                            ),
+                            decoration: BoxDecoration(
+                              color: theme(context).colorPrimary,
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(
+                                  Constants.sizeBorderRadius,
                                 ),
                               ),
-                              height: 54,
-                              width: 54,
-                              child: const Icon(
-                                Icons.terminal,
-                                color: Colors.white,
-                                size: 36,
-                              ),
                             ),
-                            Flexible(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Terminals',
-                                    overflow: TextOverflow.ellipsis,
-                                    style: primaryTextStyle(
-                                      context,
-                                      size: 18,
-                                    ),
-                                  ),
-                                  Text(
-                                    Characters(
-                                      'You have ${terminalRepository.terminals.length} Terminals open',
-                                    )
-                                        .replaceAll(Characters(''),
-                                            Characters('\u{200B}'))
-                                        .toString(),
-                                    overflow: TextOverflow.ellipsis,
-                                    style: secondaryTextStyle(
-                                      context,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      IconButton(
-                        icon: const Icon(
-                          Icons.close_outlined,
-                        ),
-                        onPressed: () {
-                          Navigator.pop(context);
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-                const Divider(
-                  height: 0,
-                  thickness: 1.0,
-                ),
-                const SizedBox(height: Constants.spacingMiddle),
-                Flexible(
-                  child: DefaultTabController(
-                    length: terminalRepository.terminals.length,
-                    child: Column(
-                      children: [
-                        ClipRRect(
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(Constants.sizeBorderRadius),
-                          ),
-                          child: SizedBox(
-                            height: 32,
-                            child: TabBar(
-                              isScrollable: true,
-                              labelColor: Colors.white,
-                              unselectedLabelColor: theme(context).colorPrimary,
-                              indicatorSize: TabBarIndicatorSize.tab,
-                              indicator: BoxDecoration(
-                                color: theme(context).colorPrimary,
-                              ),
-                              tabs: terminalRepository.terminals
-                                  .asMap()
-                                  .entries
-                                  .map(
-                                (terminal) {
-                                  return Tab(
-                                    child: GestureDetector(
-                                      onDoubleTap: () {
-                                        terminalRepository.deleteTerminal(
-                                          terminal.key,
-                                        );
-                                        if (terminalRepository
-                                            .terminals.isEmpty) {
-                                          Navigator.pop(context);
-                                        }
-                                      },
-                                      child: Text(
-                                        terminal.value.name,
-                                      ),
-                                    ),
-                                  );
-                                },
-                              ).toList(),
+                            height: 54,
+                            width: 54,
+                            child: const Icon(
+                              Icons.terminal,
+                              color: Colors.white,
+                              size: 36,
                             ),
                           ),
+                          Flexible(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Terminals',
+                                  overflow: TextOverflow.ellipsis,
+                                  style: primaryTextStyle(
+                                    context,
+                                    size: 18,
+                                  ),
+                                ),
+                                Text(
+                                  Characters(
+                                    'You have ${terminalRepository.terminals.length} Terminals open',
+                                  )
+                                      .replaceAll(Characters(''),
+                                          Characters('\u{200B}'))
+                                      .toString(),
+                                  overflow: TextOverflow.ellipsis,
+                                  style: secondaryTextStyle(
+                                    context,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.close_outlined,
+                      ),
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              const Divider(
+                height: 0,
+                thickness: 1.0,
+              ),
+              const SizedBox(height: Constants.spacingMiddle),
+              Flexible(
+                child: DefaultTabController(
+                  length: terminalRepository.terminals.length,
+                  child: Column(
+                    children: [
+                      ClipRRect(
+                        borderRadius: const BorderRadius.all(
+                          Radius.circular(Constants.sizeBorderRadius),
                         ),
-                        const SizedBox(height: Constants.spacingMiddle),
-                        Expanded(
-                          child: TabBarView(
-                            children: terminalRepository.terminals
+                        child: SizedBox(
+                          height: 32,
+                          child: TabBar(
+                            isScrollable: true,
+                            labelColor: Colors.white,
+                            unselectedLabelColor: theme(context).colorPrimary,
+                            indicatorSize: TabBarIndicatorSize.tab,
+                            indicator: BoxDecoration(
+                              color: theme(context).colorPrimary,
+                            ),
+                            tabs: terminalRepository.terminals
                                 .asMap()
                                 .entries
                                 .map(
                               (terminal) {
-                                return terminal.value.type == TerminalType.exec
-                                    ? terminal.value.terminal != null
-                                        ? xtermui.TerminalView(
-                                            terminal.value.terminal!.terminal,
-                                            theme: terminalTheme,
-                                            textStyle: xterm.TerminalStyle(
-                                              fontSize: 14,
-                                              fontFamily:
-                                                  getMonospaceFontFamily(),
-                                            ),
-                                          )
-                                        : Container()
-                                    : terminal.value.type ==
-                                            TerminalType.logstream
-                                        ? terminal.value.logstream != null
-                                            ? xtermui.TerminalView(
-                                                terminal
-                                                    .value.logstream!.terminal,
-                                                theme: terminalTheme,
-                                                textStyle: xterm.TerminalStyle(
-                                                  fontSize: 14,
-                                                  fontFamily:
-                                                      getMonospaceFontFamily(),
-                                                ),
-                                              )
-                                            : Container()
-                                        : SingleChildScrollView(
-                                            physics:
-                                                const ClampingScrollPhysics(),
-                                            child: Container(
-                                              padding: const EdgeInsets.all(
-                                                Constants.spacingSmall,
-                                              ),
-                                              color: const Color(0xff2E3440),
-                                              child: Wrap(
-                                                children: terminal.value.logs ==
-                                                        null
-                                                    ? []
-                                                    : terminal.value.logs!
-                                                        .asMap()
-                                                        .entries
-                                                        .map(
-                                                          (e) => SelectableText(
-                                                            e.value
-                                                                .join('\n\n'),
-                                                            style: TextStyle(
-                                                              color: getColor(
-                                                                  e.key),
-                                                              fontSize: 14,
-                                                              fontFamily:
-                                                                  getMonospaceFontFamily(),
-                                                            ),
-                                                          ),
-                                                        )
-                                                        .toList(),
-                                              ),
-                                            ),
-                                          );
+                                return Tab(
+                                  child: GestureDetector(
+                                    onDoubleTap: () {
+                                      terminalRepository.deleteTerminal(
+                                        terminal.key,
+                                      );
+                                      if (terminalRepository
+                                          .terminals.isEmpty) {
+                                        Navigator.pop(context);
+                                      }
+                                    },
+                                    child: Text(
+                                      terminal.value.name,
+                                    ),
+                                  ),
+                                );
                               },
                             ).toList(),
                           ),
                         ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(height: Constants.spacingMiddle),
+                      Expanded(
+                        child: TabBarView(
+                          children:
+                              terminalRepository.terminals.asMap().entries.map(
+                            (terminal) {
+                              return terminal.value.type == TerminalType.exec
+                                  ? terminal.value.terminal != null
+                                      ? xtermui.TerminalView(
+                                          terminal.value.terminal!.terminal,
+                                          theme: terminalTheme,
+                                          textStyle: xterm.TerminalStyle(
+                                            fontSize: 14,
+                                            fontFamily:
+                                                getMonospaceFontFamily(),
+                                          ),
+                                        )
+                                      : Container()
+                                  : terminal.value.type ==
+                                          TerminalType.logstream
+                                      ? terminal.value.logstream != null
+                                          ? xtermui.TerminalView(
+                                              terminal
+                                                  .value.logstream!.terminal,
+                                              theme: terminalTheme,
+                                              textStyle: xterm.TerminalStyle(
+                                                fontSize: 14,
+                                                fontFamily:
+                                                    getMonospaceFontFamily(),
+                                              ),
+                                            )
+                                          : Container()
+                                      : SingleChildScrollView(
+                                          physics:
+                                              const ClampingScrollPhysics(),
+                                          child: Container(
+                                            padding: const EdgeInsets.all(
+                                              Constants.spacingSmall,
+                                            ),
+                                            color: const Color(0xff2E3440),
+                                            child: Wrap(
+                                              children: terminal.value.logs ==
+                                                      null
+                                                  ? []
+                                                  : terminal.value.logs!
+                                                      .asMap()
+                                                      .entries
+                                                      .map(
+                                                        (e) => SelectableText(
+                                                          e.value.join('\n\n'),
+                                                          style: TextStyle(
+                                                            color:
+                                                                getColor(e.key),
+                                                            fontSize: 14,
+                                                            fontFamily:
+                                                                getMonospaceFontFamily(),
+                                                          ),
+                                                        ),
+                                                      )
+                                                      .toList(),
+                                            ),
+                                          ),
+                                        );
+                            },
+                          ).toList(),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(height: Constants.spacingMiddle),
-              ],
-            ),
+              ),
+              const SizedBox(height: Constants.spacingMiddle),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
Instead of wrapping our modals in the "SafeArea" widget we are now using the "useSafeArea" property of the showModalBottomSheet function, which was introduced with the Flutter 3.7.0 update. This has the advantage that the safe area is really respected, which wasn't the case for the "SafeArea" widget.