### PR TITLE
Fix GHA for macOS Release

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -20,7 +20,7 @@ jobs:
       #   - https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
       #   - https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install the Apple Certificate
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'release' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -75,7 +75,7 @@ jobs:
           flutter build macos --release
 
       - name: Code Sign
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'release' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           codesign --deep --force --options runtime --sign "Developer ID Application: Rico Berger (75AP6HWLUD)" build/macos/Build/Products/Release/kubenav.app -v
 
@@ -91,7 +91,7 @@ jobs:
       # the following command can be used for debugging
       #   xcrun notarytool log <RANDOM-ID> --key AuthKey_${MACOS_ASC_API_KEY}.p8 --key-id $MACOS_ASC_API_KEY --issuer $MACOS_ACS_ISSUER
       - name: Upload to Notarization Service
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'release' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           MACOS_ASC_AUTH_KEY: ${{ secrets.MACOS_ASC_AUTH_KEY }}
           MACOS_ASC_API_KEY: ${{ secrets.MACOS_ASC_API_KEY }}


### PR DESCRIPTION
The change introduced in #483, caused a problem with the continuouse delivery action when a new release is published, because the signing steps are not executed. This should be fixed by running the necessary steps when:

- The event name which triggers the action is "release"
- The PR is created from a branch within the repository