### PR TITLE
Automatic Select Theme based on OS Settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,8 +73,30 @@ class App extends StatelessWidget {
   }
 }
 
-class AppMaterialApp extends StatelessWidget {
-  const AppMaterialApp({Key? key}) : super(key: key);
+class AppMaterialApp extends StatefulWidget {
+  const AppMaterialApp({super.key});
+
+  @override
+  State<AppMaterialApp> createState() => _AppMaterialAppState();
+}
+
+class _AppMaterialAppState extends State<AppMaterialApp> {
+  @override
+  void initState() {
+    super.initState();
+
+    /// Here we have to listen to OS changes to the users selected theme, so
+    /// that we can notify all listeners of the [ThemeRepository] when the OS
+    /// theme is changed and the user selected the "auto" theme option.
+    final window = WidgetsBinding.instance.window;
+
+    window.onPlatformBrightnessChanged = () {
+      Provider.of<ThemeRepository>(
+        context,
+        listen: false,
+      ).notify();
+    };
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/repositories/theme_repository.dart
+++ b/lib/repositories/theme_repository.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'package:provider/provider.dart';
 
@@ -10,7 +11,7 @@ import 'package:kubenav/utils/storage.dart';
 ThemeSettings theme(BuildContext context) {
   return Provider.of<ThemeRepository>(
     context,
-    listen: false,
+    listen: true,
   ).theme;
 }
 
@@ -18,6 +19,7 @@ ThemeSettings theme(BuildContext context) {
 /// All defined themes must also have a [ThemeSettings] object which is returned
 /// for the specified theme name in the [ThemeRepository.theme] getter.
 enum ThemeName {
+  auto,
   light,
   dark,
 }
@@ -40,7 +42,16 @@ ThemeName getThemeNameFromString(String? theme) {
     return ThemeName.dark;
   }
 
-  return ThemeName.light;
+  if (theme?.toLowerCase() == 'light') {
+    return ThemeName.light;
+  }
+
+  return ThemeName.auto;
+}
+
+bool isDarkTheme() {
+  return SchedulerBinding.instance.platformDispatcher.platformBrightness ==
+      Brightness.dark;
 }
 
 /// The [ThemeRepository] handles all theme related function of the app. A users
@@ -48,7 +59,7 @@ ThemeName getThemeNameFromString(String? theme) {
 /// responsible for returneing hte correct [ThemeSettings] for the users
 /// selected theme.
 class ThemeRepository with ChangeNotifier {
-  ThemeName _themeName = ThemeName.light;
+  ThemeName _themeName = isDarkTheme() ? ThemeName.dark : ThemeName.light;
 
   ThemeName get themeName => _themeName;
 
@@ -97,11 +108,19 @@ class ThemeRepository with ChangeNotifier {
   /// [theme] returns the correct [ThemeSettings] for the users selected
   /// [_themeName].
   ThemeSettings get theme {
+    if (_themeName == ThemeName.light) {
+      return _lightTheme;
+    }
+
     if (_themeName == ThemeName.dark) {
       return _darkTheme;
     }
 
-    return _lightTheme;
+    return isDarkTheme() ? _darkTheme : _lightTheme;
+  }
+
+  void notify() {
+    notifyListeners();
   }
 }
 


### PR DESCRIPTION
The theme is now automatically selected based on the users OS settings. The new logic is applied when a user selects the "auto" option in the app settings. For users which already selected the "light" or "dark" theme the logic is not applied and they have to opt in for the "auto" option.

See #489