### PR TITLE
Fix "theme" Function

### DIFF
--- a/lib/repositories/theme_repository.dart
+++ b/lib/repositories/theme_repository.dart
@@ -8,10 +8,13 @@ import 'package:kubenav/utils/storage.dart';
 
 /// [theme] is a helper function which returns the [ThemeSettings] for the users
 /// currently selected team.
+///
+/// NOTE: WE CAN NOT LISTEN TO CHANGES HERE, THIS WILL BREAK ALL OUR CHARTS AND
+/// SOME OTHER ACTIONS LIKE DELETING RESOURCES.
 ThemeSettings theme(BuildContext context) {
   return Provider.of<ThemeRepository>(
     context,
-    listen: true,
+    listen: false,
   ).theme;
 }
 


### PR DESCRIPTION
We can not listen to changes in the ThemeRepository in the theme function, because this breaks our charts and some other actions like deleting resources.