### PR TITLE
Filter List of Resources on Change

### DIFF
--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -370,7 +370,7 @@ class _ResourcesListState extends State<ResourcesList> {
                           ),
                           color: theme(context).colorPrimary,
                           child: TextField(
-                            onSubmitted: (value) {
+                            onChanged: (value) {
                               setState(() {
                                 _filter = value;
                               });

--- a/lib/widgets/resources/resources_list_crds.dart
+++ b/lib/widgets/resources/resources_list_crds.dart
@@ -282,7 +282,7 @@ class _ResourcesListCRDsState extends State<ResourcesListCRDs> {
                           ),
                           color: theme(context).colorPrimary,
                           child: TextField(
-                            onSubmitted: (value) {
+                            onChanged: (value) {
                               setState(() {
                                 _filter = value;
                               });


### PR DESCRIPTION
Instead of filtering the list of resources / list of CRDs when the user submits the filter text field we are now filtering the list as the user types, so that the list of resources is directly updated and the user does not have to presse enter anymore.