### PR TITLE
Fix Y-Axis Labels in Live Metrics

### DIFF
--- a/lib/widgets/resources/details/details_live_metrics.dart
+++ b/lib/widgets/resources/details/details_live_metrics.dart
@@ -333,10 +333,14 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
                                     sideTitles: SideTitles(
                                       showTitles: true,
                                       reservedSize: 42,
-                                      getTitlesWidget:
-                                          (double value, TitleMeta meta) {
+                                      getTitlesWidget: (
+                                        double value,
+                                        TitleMeta meta,
+                                      ) {
                                         return Text(
-                                          formatCpuMetric(value, 0),
+                                          value > 1000000000
+                                              ? formatCpuMetric(value)
+                                              : formatCpuMetric(value, 0),
                                           style: secondaryTextStyle(
                                             context,
                                           ),
@@ -490,10 +494,14 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
                                     sideTitles: SideTitles(
                                       showTitles: true,
                                       reservedSize: 42,
-                                      getTitlesWidget:
-                                          (double value, TitleMeta meta) {
+                                      getTitlesWidget: (
+                                        double value,
+                                        TitleMeta meta,
+                                      ) {
                                         return Text(
-                                          formatMemoryMetric(value, 0),
+                                          value > 1048576
+                                              ? formatMemoryMetric(value, 2)
+                                              : formatMemoryMetric(value, 0),
                                           style: secondaryTextStyle(
                                             context,
                                           ),


### PR DESCRIPTION
The y axis in the live metrics wasn't formatted that well, because we always rounded to full numbers the displayed labels were duplicated. This should now be fixed, because we are checking the value of the label before it is rendered. This means that we add 2 decimal places when the value of the label is very large (full cores for CPU or Gi for Memory).

Fixes #497