### PR TITLE
Add Support for Multiple AWS SSO Accounts

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -145,6 +145,17 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       } else {
         awsGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, accessToken, accessTokenExpire, result)
       }
+    } else if (call.method == "awsGetSSOAccounts") {
+      val ssoRegion = call.argument<String>("ssoRegion")
+      val ssoClientID = call.argument<String>("ssoClientID")
+      val ssoClientSecret = call.argument<String>("ssoClientSecret")
+      val ssoDeviceCode = call.argument<String>("ssoDeviceCode")
+
+      if (ssoRegion == null || ssoClientID == null || ssoClientSecret == null || ssoDeviceCode == null) {
+        result.error("BAD_ARGUMENTS", null, null)
+      } else {
+        awsGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, result)
+      }
     } else if (call.method == "helmListCharts") {
       val clusterServer = call.argument<String>("clusterServer")
       val clusterCertificateAuthorityData = call.argument<String>("clusterCertificateAuthorityData")
@@ -357,6 +368,15 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       result.success(data)
     } catch (e: Exception) {
       result.error("AWS_GET_SSO_TOKEN_FAILED", e.localizedMessage, null)
+    }
+  }
+
+  private fun awsGetSSOAccounts(ssoRegion: String, ssoClientID: String, ssoClientSecret: String, ssoDeviceCode: String, result: MethodChannel.Result) {
+    try {
+      val data: String = Kubenav.awsGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode)
+      result.success(data)
+    } catch (e: Exception) {
+      result.error("AWS_GET_SSO_ACCOUNTS_FAILED", e.localizedMessage, null)
     }
   }
 

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -136,6 +136,17 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
+    } else if call.method == "awsGetSSOAccounts" {
+      if let args = call.arguments as? Dictionary<String, Any>,
+        let ssoRegion = args["ssoRegion"] as? String,
+        let ssoClientID = args["ssoClientID"] as? String,
+        let ssoClientSecret = args["ssoClientSecret"] as? String,
+        let ssoDeviceCode = args["ssoDeviceCode"] as? String
+      {
+        awsGetSSOAccounts(ssoRegion: ssoRegion, ssoClientID: ssoClientID, ssoClientSecret: ssoClientSecret, ssoDeviceCode: ssoDeviceCode, result: result)
+      } else {
+        result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
+      }
     } else if call.method == "helmListCharts" {
       if let args = call.arguments as? Dictionary<String, Any>,
         let clusterServer = args["clusterServer"] as? String,
@@ -363,6 +374,17 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     let data = KubenavAWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, accessToken, accessTokenExpire, &error)
     if error != nil {
       result(FlutterError(code: "AWS_GET_SSO_TOKEN_FAILED", message: error?.localizedDescription ?? "", details: nil))
+    } else {
+      result(data)
+    }
+  }
+
+  private func awsGetSSOAccounts(ssoRegion: String, ssoClientID: String, ssoClientSecret: String, ssoDeviceCode: String, result: FlutterResult) {
+    var error: NSError?
+
+    let data = KubenavAWSGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, &error)
+    if error != nil {
+      result(FlutterError(code: "AWS_GET_SSO_ACCOUNTS_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
       result(data)
     }

--- a/lib/widgets/resources/details/pod_details_item.dart
+++ b/lib/widgets/resources/details/pod_details_item.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:kubenav/utils/navigate.dart';
-import 'package:kubenav/widgets/resources/resource_details.dart';
 
 import 'package:provider/provider.dart';
 
@@ -15,11 +13,13 @@ import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/services/kubernetes_service.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/resources/pods.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/resources/details/details_containers.dart';
 import 'package:kubenav/widgets/resources/details/details_item.dart';
 import 'package:kubenav/widgets/resources/details/details_resources_preview.dart';
+import 'package:kubenav/widgets/resources/resource_details.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 class PodDetailsItem extends StatefulWidget implements IDetailsItemWidget {

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -238,7 +238,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
                 },
                 title: Text(
                   Characters(
-                    'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+                    'aws_${widget.provider.awssso?.region}_${_clusters[index].name}',
                   )
                       .replaceAll(Characters(''), Characters('\u{200B}'))
                       .toString(),

--- a/lib/widgets/settings/clusters/settings_reuse_provider_config_actions.dart
+++ b/lib/widgets/settings/clusters/settings_reuse_provider_config_actions.dart
@@ -16,6 +16,7 @@ import 'package:kubenav/widgets/settings/clusters/settings_add_cluster_manual.da
 import 'package:kubenav/widgets/settings/clusters/settings_add_cluster_oidc.dart';
 import 'package:kubenav/widgets/settings/clusters/settings_add_cluster_rancher.dart';
 import 'package:kubenav/widgets/settings/providers/settings_aws_provider_config.dart';
+import 'package:kubenav/widgets/settings/providers/settings_awssso_multiple_providers_config.dart';
 import 'package:kubenav/widgets/settings/providers/settings_awssso_provider_config.dart';
 import 'package:kubenav/widgets/settings/providers/settings_azure_provider_config.dart';
 import 'package:kubenav/widgets/settings/providers/settings_digitalocean_provider_config.dart';
@@ -149,6 +150,23 @@ class SettingsReuseProviderActions extends StatelessWidget {
         },
       ),
     );
+
+    /// If a user selected the AWS SSO provider we also have to add an option,
+    /// where the user can load all the account ids and roles he has access to,
+    /// so that he haven't to specify them manually in the provider
+    /// configuration.
+    if (providerType == ClusterProviderType.awssso) {
+      actions.add(
+        AppActionsWidgetAction(
+          title: 'Add Multiple Providers',
+          color: theme(context).colorPrimary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(context, const SettingsAWSSSOMultipleProviders());
+          },
+        ),
+      );
+    }
 
     return AppActionsWidget(
       actions: actions,

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+
+import 'package:kubenav/models/cluster_provider.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/services/providers/aws_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/settings/providers/settings_awssso_multiple_providers_select.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+class SettingsAWSSSOMultipleProviders extends StatefulWidget {
+  const SettingsAWSSSOMultipleProviders({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<SettingsAWSSSOMultipleProviders> createState() =>
+      _SettingsAWSSSOMultipleProvidersState();
+}
+
+class _SettingsAWSSSOMultipleProvidersState
+    extends State<SettingsAWSSSOMultipleProviders> {
+  final _providerConfigFormKey = GlobalKey<FormState>();
+  final _startURLController = TextEditingController();
+  String _ssoRegion = 'us-east-1';
+  AWSSSOConfig? _awsSSOConfig;
+  bool _isLoading = false;
+
+  /// [_validator] is used to validate all the required fields. If they are
+  /// missing the validation of the form will fail.
+  String? _validator(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'This field is required';
+    }
+
+    return null;
+  }
+
+  Future<void> _startSSOFlow() async {
+    try {
+      final ssoConfig = await AWSService().getSSOConfig(
+        _ssoRegion,
+        _startURLController.text,
+      );
+
+      Logger.log(
+        'SettingsAWSSSOMultipleProviders _startSSOFlow',
+        'SSO config was returned',
+        ssoConfig,
+      );
+      setState(() {
+        _awsSSOConfig = ssoConfig;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Sing in completed',
+          'You can now click on the verify button',
+        );
+      }
+    } catch (err) {
+      Logger.log(
+        'SettingsAWSSSOMultipleProviders _startSSOFlow',
+        'Could not get SSO configuration',
+        err,
+      );
+      showSnackbar(
+        context,
+        'Could not get SSO configuration',
+        err.toString(),
+      );
+    }
+  }
+
+  Future<void> _verifyDevice() async {
+    try {
+      await openUrl(_awsSSOConfig!.device!.verificationUriComplete!);
+    } catch (err) {
+      Logger.log(
+        'SettingsAWSSSOMultipleProviders _verifyDevice',
+        'Could not verify device',
+        err,
+      );
+      showSnackbar(
+        context,
+        'Could not verify device',
+        err.toString(),
+      );
+    }
+  }
+
+  /// [_loadAccounts] loads all the AWS SSO accounts a user has access to
+  /// including there roles. If we are able to get these information we show
+  /// the [SettingsAWSSSOMultipleProvidersSelect] widget in the next step, where
+  /// the user can select the accounts and roles he wants to add to the app.
+  Future<void> _loadAccounts(BuildContext context) async {
+    try {
+      if (_providerConfigFormKey.currentState != null &&
+          _providerConfigFormKey.currentState!.validate()) {
+        setState(() {
+          _isLoading = true;
+        });
+        final accounts = await AWSService().getSSOAccounts(
+          _ssoRegion,
+          _awsSSOConfig!.client!.clientId!,
+          _awsSSOConfig!.client!.clientSecret!,
+          _awsSSOConfig!.device!.deviceCode!,
+        );
+
+        setState(() {
+          _isLoading = false;
+        });
+        if (mounted) {
+          Navigator.pop(context);
+          showModal(
+            context,
+            SettingsAWSSSOMultipleProvidersSelect(
+              startURL: _startURLController.text,
+              ssoRegion: _ssoRegion,
+              ssoConfig: _awsSSOConfig!,
+              accounts: accounts,
+            ),
+          );
+        }
+      }
+    } catch (err) {
+      setState(() {
+        _isLoading = false;
+      });
+      showSnackbar(
+        context,
+        'Could not load accounts and roles',
+        err.toString(),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _startURLController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: ClusterProviderType.awssso.title(),
+      subtitle: ClusterProviderType.awssso.subtitle(),
+      icon: ClusterProviderType.awssso.icon(),
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Load Accounts and Roles',
+      actionPressed: () {
+        _loadAccounts(context);
+      },
+      actionIsLoading: _isLoading,
+      child: Form(
+        key: _providerConfigFormKey,
+        child: ListView(
+          shrinkWrap: false,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: TextFormField(
+                controller: _startURLController,
+                keyboardType: TextInputType.text,
+                autocorrect: false,
+                enableSuggestions: false,
+                maxLines: 1,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Start URL',
+                ),
+                validator: _validator,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const Text('SSO Region'),
+                  DropdownButton(
+                    value: _ssoRegion,
+                    underline: Container(
+                      height: 2,
+                      color: theme(context).colorPrimary,
+                    ),
+                    onChanged: (String? newValue) {
+                      setState(() {
+                        _ssoRegion = newValue ?? '';
+                      });
+                    },
+                    items: awsRegions.map((value) {
+                      return DropdownMenuItem(
+                        value: value,
+                        child: Text(
+                          value,
+                          style: TextStyle(
+                            color: theme(context).colorTextPrimary,
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: theme(context).colorPrimary,
+                  foregroundColor: Colors.white,
+                  minimumSize: const Size.fromHeight(40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(
+                      Constants.sizeBorderRadius,
+                    ),
+                  ),
+                ),
+                onPressed: _startSSOFlow,
+                child: Text(
+                  'Sign In',
+                  style: primaryTextStyle(
+                    context,
+                    color: Colors.white,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: theme(context).colorPrimary,
+                  foregroundColor: Colors.white,
+                  minimumSize: const Size.fromHeight(40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(
+                      Constants.sizeBorderRadius,
+                    ),
+                  ),
+                ),
+                onPressed: _awsSSOConfig == null ? null : _verifyDevice,
+                child: Text(
+                  'Verify',
+                  style: primaryTextStyle(
+                    context,
+                    color: Colors.white,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:kubenav/models/cluster_provider.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/repositories/theme_repository.dart';
+import 'package:kubenav/services/providers/aws_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/settings/clusters/settings_reuse_provider_config_actions.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [SelectedAWSSSOAccount] model is used for the selected accounts and
+/// roles of an user. It contains the same information as the [AWSSSOAccount]
+/// model, but only contains one role, so that we can identify the selected
+/// roles in the [SettingsAWSSSOMultipleProvidersSelect] widget.
+class SelectedAWSSSOAccount {
+  String? accountId;
+  String? accountName;
+  String? role;
+  String? accessToken;
+  int? accessTokenExpire;
+
+  SelectedAWSSSOAccount({
+    required this.accountId,
+    required this.accountName,
+    required this.role,
+    required this.accessToken,
+    required this.accessTokenExpire,
+  });
+}
+
+/// The [SettingsAWSSSOMultipleProvidersSelect] widget allows a user to select
+/// a list of AWS SSO accounts and roles, which should be added to the app.
+class SettingsAWSSSOMultipleProvidersSelect extends StatefulWidget {
+  const SettingsAWSSSOMultipleProvidersSelect({
+    Key? key,
+    required this.startURL,
+    required this.ssoRegion,
+    required this.ssoConfig,
+    required this.accounts,
+  }) : super(key: key);
+
+  final String startURL;
+  final String ssoRegion;
+  final AWSSSOConfig ssoConfig;
+  final List<AWSSSOAccount> accounts;
+
+  @override
+  State<SettingsAWSSSOMultipleProvidersSelect> createState() =>
+      _SettingsAWSSSOMultipleProvidersSelectState();
+}
+
+class _SettingsAWSSSOMultipleProvidersSelectState
+    extends State<SettingsAWSSSOMultipleProvidersSelect> {
+  List<SelectedAWSSSOAccount> _selectedAccounts = [];
+  bool _isLoading = false;
+
+  /// [_addProviders] adds the users [_selectedAccounts] to our internal list of
+  /// cluster providers. Before each account is added we also have to get the
+  /// sso credentials for this account, so that we can use the account to get a
+  /// the list of Kubernetes clusters from the AWS API.
+  Future<void> _addProviders(BuildContext context) async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+      for (final account in _selectedAccounts) {
+        final ssoCredentials = await AWSService().getSSOToken(
+          account.accountId ?? '',
+          account.role ?? '',
+          widget.ssoRegion,
+          widget.ssoConfig.client!.clientId!,
+          widget.ssoConfig.client!.clientSecret!,
+          widget.ssoConfig.device!.deviceCode!,
+          account.accessToken ?? '',
+          account.accessTokenExpire ?? 0,
+        );
+
+        final provider = ClusterProvider(
+          id: const Uuid().v4(),
+          name:
+              '${account.accountName} (${account.accountId}) - ${account.role}',
+          type: ClusterProviderType.awssso,
+          awssso: ClusterProviderAWSSSO(
+            startURL: widget.startURL,
+            accountID: account.accountId,
+            roleName: account.role,
+            ssoRegion: widget.ssoRegion,
+            // NOTE: Currently we are using the provided SSO region also for the
+            // cluster region. This may not be perfect but regarding
+            // https://github.com/kubenav/kubenav/issues/490#issuecomment-1421430202
+            // this seems to be the most comman use case. The region can still
+            // be changed manually after the provider is added in the provider
+            // settings.
+            region: widget.ssoRegion,
+            ssoConfig: widget.ssoConfig,
+            ssoCredentials: ssoCredentials,
+          ),
+        );
+        await clustersRepository.addProvider(provider);
+      }
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        Navigator.pop(context);
+        showActions(
+          context,
+          const SettingsReuseProviderActions(
+            providerType: ClusterProviderType.awssso,
+          ),
+        );
+      }
+    } catch (err) {
+      setState(() {
+        _isLoading = false;
+      });
+      showSnackbar(
+        context,
+        'Could not add providers',
+        err.toString(),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: ClusterProviderType.awssso.title(),
+      subtitle: ClusterProviderType.awssso.subtitle(),
+      icon: ClusterProviderType.awssso.icon(),
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Add Providers',
+      actionPressed: () {
+        _addProviders(context);
+      },
+      actionIsLoading: _isLoading,
+      child: ListView(
+        children: [
+          ...List.generate(
+            widget.accounts.length,
+            (accountIndex) {
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      top: Constants.spacingSmall,
+                      bottom: Constants.spacingSmall,
+                      left: Constants.spacingExtraSmall,
+                      right: Constants.spacingExtraSmall,
+                    ),
+                    child: Text(
+                      '${widget.accounts[accountIndex].accountName} (${widget.accounts[accountIndex].accountId})',
+                      style: primaryTextStyle(context),
+                    ),
+                  ),
+                  ListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: [
+                      ...List.generate(
+                        widget.accounts[accountIndex].roles?.length ?? 0,
+                        (roleIndex) {
+                          return Container(
+                            margin: const EdgeInsets.only(
+                              top: Constants.spacingSmall,
+                              bottom: Constants.spacingSmall,
+                              left: Constants.spacingExtraSmall,
+                              right: Constants.spacingExtraSmall,
+                            ),
+                            decoration: BoxDecoration(
+                              boxShadow: [
+                                BoxShadow(
+                                  color: theme(context).colorShadow,
+                                  blurRadius: Constants.sizeBorderBlurRadius,
+                                  spreadRadius:
+                                      Constants.sizeBorderSpreadRadius,
+                                  offset: const Offset(0.0, 0.0),
+                                ),
+                              ],
+                              color: theme(context).colorCard,
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(Constants.sizeBorderRadius),
+                              ),
+                            ),
+                            child: CheckboxListTile(
+                              checkColor: Colors.white,
+                              activeColor: theme(context).colorPrimary,
+                              controlAffinity: ListTileControlAffinity.leading,
+                              value: _selectedAccounts
+                                      .where((a) =>
+                                          a.accountId ==
+                                              widget.accounts[accountIndex]
+                                                  .accountId &&
+                                          a.role ==
+                                              widget.accounts[accountIndex]
+                                                  .roles![roleIndex])
+                                      .toList()
+                                      .length ==
+                                  1,
+                              onChanged: (bool? value) {
+                                if (value == true) {
+                                  setState(() {
+                                    _selectedAccounts.add(
+                                      SelectedAWSSSOAccount(
+                                        accountId: widget
+                                            .accounts[accountIndex].accountId,
+                                        accountName: widget
+                                            .accounts[accountIndex].accountName,
+                                        role: widget.accounts[accountIndex]
+                                            .roles![roleIndex],
+                                        accessToken: widget
+                                            .accounts[accountIndex].accessToken,
+                                        accessTokenExpire: widget
+                                            .accounts[accountIndex]
+                                            .accessTokenExpire,
+                                      ),
+                                    );
+                                  });
+                                }
+                                if (value == false) {
+                                  setState(() {
+                                    _selectedAccounts = _selectedAccounts
+                                        .where((a) => !(a.accountId ==
+                                                widget.accounts[accountIndex]
+                                                    .accountId &&
+                                            a.role ==
+                                                widget.accounts[accountIndex]
+                                                    .roles![roleIndex]))
+                                        .toList();
+                                  });
+                                }
+                              },
+                              title: Text(
+                                Characters(
+                                  widget
+                                      .accounts[accountIndex].roles![roleIndex],
+                                )
+                                    .replaceAll(
+                                        Characters(''), Characters('\u{200B}'))
+                                    .toString(),
+                                style: noramlTextStyle(
+                                  context,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
It is now possible to add multiple AWS SSO Accounts and Roles at once, by only specifing the AWS SSO start url and region. We then automatically load all the accounts and the roles, so that a user can select which accounts and roles should be added to the app. Each selected account/role will be added as a new AWS SSO provider, so that we can use the already existing flow to add the clusters and to handle the authentication against the Kubernetes API of the added clusters.

Closes #490