### PR TITLE
Upgrade Flutter Version to 3.7.2

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.0'
+          flutter-version: '3.7.2'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.0'
+          flutter-version: '3.7.2'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -214,7 +214,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.0'
+          flutter-version: '3.7.2'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,10 @@ kubenav uses [Flutter](https://flutter.dev) and [Go](https://go.dev), make sure 
 ```sh
 $ flutter --version
 
-Flutter 3.7.0 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision b06b8b2710 (5 days ago) • 2023-01-23 16:55:55 -0800
-Engine • revision b24591ed32
-Tools • Dart 2.19.0 • DevTools 2.20.1
+Flutter 3.7.2 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 32fb2f948e (6 hours ago) • 2023-02-08 07:30:10 -0800
+Engine • revision f40b73f8a4
+Tools • Dart 2.19.2 • DevTools 2.20.1
 
 
 $ go version


### PR DESCRIPTION
Update our current Flutter version 3.7.0 to the new Flutter version 3.7.2, which contains a lot of fixes.

See: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel#372-feb-8-2023