### PR TITLE
Fix AppActionsWidget Widget for Long List of Actions

### DIFF
--- a/lib/widgets/shared/app_actions_widget.dart
+++ b/lib/widgets/shared/app_actions_widget.dart
@@ -64,28 +64,11 @@ class AppActionsWidget extends StatelessWidget {
           Radius.circular(Constants.sizeBorderRadius),
         ),
       ),
-      child: Wrap(
-        alignment: WrapAlignment.center,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: List.generate(actions.length, (index) {
-          if (index == actions.length - 1) {
-            return Wrap(
-              children: [
-                ListTile(
-                  onTap: actions[index].onTap,
-                  title: Text(
-                    actions[index].title,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: actions[index].color),
-                  ),
-                ),
-                const Divider(
-                  height: 0,
-                  thickness: 1.0,
-                ),
-              ],
-            );
-          } else {
+      child: SingleChildScrollView(
+        child: Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: List.generate(actions.length, (index) {
             return ListTile(
               onTap: actions[index].onTap,
               title: Text(
@@ -94,8 +77,8 @@ class AppActionsWidget extends StatelessWidget {
                 style: TextStyle(color: actions[index].color),
               ),
             );
-          }
-        }),
+          }),
+        ),
       ),
     );
   }


### PR DESCRIPTION
If the list of actions which should be displayed in the AppActionsWidget was very long, some actions were not displayed and could not selected. This is now fixed, so that the list of actions is scrollable and each actions can be selected.

Fixes #490