### PR TITLE
Add Support for Self Signed Certificates in Prometheus Plugin

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -463,6 +463,7 @@ class AppRepositorySettingsPrometheus {
   String username;
   String password;
   String token;
+  String certificate;
 
   AppRepositorySettingsPrometheus({
     required this.enabled,
@@ -475,6 +476,7 @@ class AppRepositorySettingsPrometheus {
     required this.username,
     required this.password,
     required this.token,
+    required this.certificate,
   });
 
   factory AppRepositorySettingsPrometheus.fromDefault() {
@@ -489,6 +491,7 @@ class AppRepositorySettingsPrometheus {
       username: '',
       password: '',
       token: '',
+      certificate: '',
     );
   }
 
@@ -524,6 +527,10 @@ class AppRepositorySettingsPrometheus {
       token: data.containsKey('token') && data['token'] != null
           ? data['token']
           : '',
+      certificate:
+          data.containsKey('certificate') && data['certificate'] != null
+              ? data['certificate']
+              : '',
     );
   }
 
@@ -539,6 +546,7 @@ class AppRepositorySettingsPrometheus {
       'username': username,
       'password': password,
       'token': token,
+      'certificate': certificate,
     };
   }
 }

--- a/lib/widgets/settings/settings/settings_prometheus.dart
+++ b/lib/widgets/settings/settings/settings_prometheus.dart
@@ -35,6 +35,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   final _tokenController = TextEditingController();
+  final _certificateController = TextEditingController();
 
   /// [_portValidator] is used to validate the required field [_portController].
   /// If the value is empty or not a number the validation fails.
@@ -68,6 +69,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
     _usernameController.text = widget.currentPrometheus.username;
     _passwordController.text = widget.currentPrometheus.password;
     _tokenController.text = widget.currentPrometheus.token;
+    _certificateController.text = widget.currentPrometheus.certificate;
   }
 
   @override
@@ -81,6 +83,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
     _usernameController.dispose();
     _passwordController.dispose();
     _tokenController.dispose();
+    _certificateController.dispose();
     super.dispose();
   }
 
@@ -114,6 +117,7 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
               username: _usernameController.text,
               password: _passwordController.text,
               token: _tokenController.text,
+              certificate: _certificateController.text,
             ),
           );
           Navigator.pop(context);
@@ -352,6 +356,22 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
                   labelText: 'Token',
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: Constants.spacingSmall,
+              ),
+              child: TextFormField(
+                controller: _certificateController,
+                keyboardType: TextInputType.text,
+                autocorrect: false,
+                enableSuggestions: false,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Certificate',
                 ),
               ),
             ),

--- a/pkg/shared/helm.go
+++ b/pkg/shared/helm.go
@@ -101,9 +101,6 @@ type Chart struct {
 	// Files are miscellaneous files in a chart archive,
 	// e.g. README, LICENSE, etc.
 	Files []*File `json:"files"`
-
-	parent       *Chart
-	dependencies []*Chart
 }
 
 type File struct {
@@ -329,17 +326,11 @@ func HelmListCharts(clientset *kubernetes.Clientset, namespace string) (string, 
 		return "", err
 	}
 
-	var secrets map[string][]corev1.Secret
-	secrets = make(map[string][]corev1.Secret)
+	secrets := make(map[string][]corev1.Secret)
 
 	for _, secretItem := range secretList.Items {
 		key := secretItem.Namespace + "_" + secretItem.Labels["name"]
-
-		if _, ok := secrets[key]; ok {
-			secrets[key] = append(secrets[key], secretItem)
-		} else {
-			secrets[key] = []corev1.Secret{secretItem}
-		}
+		secrets[key] = append(secrets[key], secretItem)
 	}
 
 	for key := range secrets {


### PR DESCRIPTION
The Prometheus plugin supports self signed certificates now. For that the certificate can be provided in the Prometheus plugin configuration and will be used for every request against the configured Prometheus instance.

Closes #516