### PR TITLE
Fix "Classic Mode" when User doesn't have any Clusters

### DIFF
--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -223,6 +223,10 @@ class ClustersRepository with ChangeNotifier {
   /// refresh the token and save the refreshed provider and cluster.
   Future<Cluster?> getClusterWithCredentials(String clusterId) async {
     try {
+      if (_clusters.isEmpty) {
+        throw 'No clusters were found';
+      }
+
       final cluster = _clusters
           .where(
             (cluster) => cluster.id == clusterId,

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -90,8 +90,8 @@ List<AppResourceActionsModel> resourceListActions(
                 clustersRepository
                     .getCluster(
                       clustersRepository.activeClusterId,
-                    )!
-                    .namespace,
+                    )
+                    ?.namespace,
               ) >
               -1
           ? 'Remove Bookmark'
@@ -107,8 +107,8 @@ List<AppResourceActionsModel> resourceListActions(
                 clustersRepository
                     .getCluster(
                       clustersRepository.activeClusterId,
-                    )!
-                    .namespace,
+                    )
+                    ?.namespace,
               ) >
               -1
           ? Icons.bookmark
@@ -125,8 +125,8 @@ List<AppResourceActionsModel> resourceListActions(
           clustersRepository
               .getCluster(
                 clustersRepository.activeClusterId,
-              )!
-              .namespace,
+              )
+              ?.namespace,
         );
         if (bookmarkIndex > -1) {
           bookmarksRepository.removeBookmark(bookmarkIndex);
@@ -143,8 +143,8 @@ List<AppResourceActionsModel> resourceListActions(
             clustersRepository
                 .getCluster(
                   clustersRepository.activeClusterId,
-                )!
-                .namespace,
+                )
+                ?.namespace,
           );
         }
       },
@@ -382,16 +382,17 @@ class _ResourcesListState extends State<ResourcesList> {
                     Characters(clustersRepository
                                         .getCluster(
                                           clustersRepository.activeClusterId,
-                                        )!
-                                        .namespace ==
+                                        )
+                                        ?.namespace ==
                                     '' ||
                                 (widget.scope == ResourceScope.cluster)
                             ? 'All Namespaces'
                             : clustersRepository
-                                .getCluster(
-                                  clustersRepository.activeClusterId,
-                                )!
-                                .namespace)
+                                    .getCluster(
+                                      clustersRepository.activeClusterId,
+                                    )
+                                    ?.namespace ??
+                                'All Namespaces')
                         .replaceAll(Characters(''), Characters('\u{200B}'))
                         .toString(),
                     textAlign: TextAlign.center,


### PR DESCRIPTION
When a user doesn't have any clusters configured and selects one of the resources from the sidebar in the "classic mode" the app crashes. This was caused, since we assumed that a user must have an active cluster when visiting the page, which is only true for the default layout but not for the "classic mode".

This is now fixed by adding conditional checks where required in the resources list widget and by throwing an error before making an API request when the list of clusters is empty.

Fixes #524