### PR TITLE
Change Page Transitions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -154,6 +154,15 @@ class _AppMaterialAppState extends State<AppMaterialApp> {
               borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
             ),
           ),
+          pageTransitionsTheme: const PageTransitionsTheme(
+            builders: {
+              TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+              TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+              TargetPlatform.linux: CupertinoPageTransitionsBuilder(),
+              TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+              TargetPlatform.windows: CupertinoPageTransitionsBuilder(),
+            },
+          ),
           highlightColor: Colors.transparent,
           splashColor: Colors.transparent,
         ),


### PR DESCRIPTION
Change the page transitions for Android, Linux and Windows to use the same animation as on iOS and macOS, which feels smoother then the default one on these platforms.

This means that we are now using "CupertinoPageTransitionsBuilder" everywhere instead of "CupertinoPageTransitionsBuilder" and "ZoomPageTransitionsBuilder".

Closes #522.