### PR TITLE
Fix Sidebar in Classic Mode

### DIFF
--- a/lib/widgets/shared/app_drawer.dart
+++ b/lib/widgets/shared/app_drawer.dart
@@ -224,7 +224,7 @@ class AppDrawer extends StatelessWidget {
                 buildDivider(context, 'Discovery and Load Balancing'),
                 ...getResourceItems(
                   context,
-                  resource_model.ResourceType.workload,
+                  resource_model.ResourceType.discoveryandloadbalancing,
                 ),
                 buildDivider(context, 'Config and Storage'),
                 ...getResourceItems(


### PR DESCRIPTION
The sidebar in the classic mode displayed the wrong items in the "Discovery and Load Balancing" section, which is now fixed.

Fixes #528 