### PR TITLE
Fix Shell Selection in Terminal Widget

### DIFF
--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -233,7 +233,9 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
                       color: theme(context).colorPrimary,
                     ),
                     onChanged: (String? value) {
-                      _shell = value ?? 'sh';
+                      setState(() {
+                        _shell = value ?? 'sh';
+                      });
                     },
                     items: [
                       'sh',


### PR DESCRIPTION
The "DetailsTerminal" widget was missing a "setState" command in the "onChange" function for the shell selection, so that the selected shell was not updated. This is now fixed, so that the shell is changed on user selection.