### PR TITLE
Fix Restart of Deployments

### DIFF
--- a/lib/widgets/resources/details/details_restart_resource.dart
+++ b/lib/widgets/resources/details/details_restart_resource.dart
@@ -64,12 +64,12 @@ class _DetailsRestartResourceState extends State<DetailsRestartResource> {
       final String body = widget.item['spec'] != null &&
               widget.item['spec']['template'] != null &&
               widget.item['spec']['template']['metadata'] != null &&
-              widget.item['spec']['template']['metadata']['annotations'] !=
-                  null &&
-              widget.item['spec']['template']['metadata']['annotations']
+              widget.item['spec']['template']['metadata']['annotations'] != null
+          ? widget.item['spec']['template']['metadata']['annotations']
                       ['kubenav.io/restartedAt'] !=
                   null
-          ? '[{"op": "replace", "path": "/spec/template/metadata/annotations/kubenav.io~1restartedAt", "value": "$now"}]'
+              ? '[{"op": "replace", "path": "/spec/template/metadata/annotations/kubenav.io~1restartedAt", "value": "$now"}]'
+              : '[{"op": "add", "path": "/spec/template/metadata/annotations/kubenav.io~1restartedAt", "value": "$now"}]'
           : '[{"op": "add", "path": "/spec/template/metadata/annotations", "value": {"kubenav.io/restartedAt": "$now"}}]';
 
       final cluster = await clustersRepository.getClusterWithCredentials(


### PR DESCRIPTION
Under some circumstances it could happen that the restart action for Deployments, StatefulSets and DaemonSets deleted all existing annotations from "spec.template.metadata.annotations". This should now be fixed by checking if there are already other annotations besides the annotation we have to add. If this is the case we now apply another JSON patch to add our annotation.

Fixes #540