### PR TITLE
Use roleArn in AWSGetClusters

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -102,11 +102,12 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val secretKey = call.argument<String>("secretKey")
       val region = call.argument<String>("region")
       val sessionToken = call.argument<String>("sessionToken")
+      val roleArn = call.argument<String>("roleArn")
 
-      if (accessKeyID == null || secretKey == null || region == null || sessionToken == null) {
+      if (accessKeyID == null || secretKey == null || region == null || sessionToken == null || roleArn == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        awsGetClusters(accessKeyID, secretKey, region, sessionToken, result)
+        awsGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn, result)
       }
     } else if (call.method == "awsGetToken") {
       val accessKeyID = call.argument<String>("accessKeyID")
@@ -361,9 +362,9 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
-  private fun awsGetClusters(accessKeyID: String, secretKey: String, region: String, sessionToken: String, result: MethodChannel.Result) {
+  private fun awsGetClusters(accessKeyID: String, secretKey: String, region: String, sessionToken: String, roleArn: String, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.awsGetClusters(accessKeyID, secretKey, region, sessionToken)
+      val data: String = Kubenav.awsGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn)
       result.success(data)
     } catch (e: Exception) {
       result.error("AWS_GET_CLUSTERS_FAILED", e.localizedMessage, null)

--- a/cmd/mobile/aws.go
+++ b/cmd/mobile/aws.go
@@ -50,7 +50,7 @@ type AWSSSOAccount struct {
 }
 
 // AWSGetClusters returns all clusters which can be accessed with the given credentials.
-func AWSGetClusters(accessKeyID, secretKey, region, sessionToken string) (string, error) {
+func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string) (string, error) {
 	var clusters []*eks.Cluster
 	var names []*string
 	var nextToken *string
@@ -62,7 +62,11 @@ func AWSGetClusters(accessKeyID, secretKey, region, sessionToken string) (string
 		return "", err
 	}
 
-	eksClient := eks.New(sess)
+	if roleArn != "" {
+		cred = stscreds.NewCredentials(sess, roleArn)
+	}
+
+	eksClient := eks.New(sess, &aws.Config{Credentials: cred})
 
 	for {
 		c, err := eksClient.ListClusters(&eks.ListClustersInput{NextToken: nextToken})

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -94,8 +94,9 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let secretKey = args["secretKey"] as? String,
         let region = args["region"] as? String,
         let sessionToken = args["sessionToken"] as? String
+        let roleArn = args["roleArn"] as? String
       {
-        awsGetClusters(accessKeyID: accessKeyID, secretKey: secretKey, region: region, sessionToken: sessionToken, result: result)
+        awsGetClusters(accessKeyID: accessKeyID, secretKey: secretKey, region: region, sessionToken: sessionToken, roleArn: roleArn, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -361,10 +362,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func awsGetClusters(accessKeyID: String, secretKey: String, region: String, sessionToken: String, result: FlutterResult) {
+  private func awsGetClusters(accessKeyID: String, secretKey: String, region: String, sessionToken: String, roleArn: String, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavAWSGetClusters(accessKeyID, secretKey, region, sessionToken, &error)
+    let data = KubenavAWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn, &error)
     if error != nil {
       result(FlutterError(code: "AWS_GET_CLUSTERS_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {

--- a/lib/services/providers/aws_service.dart
+++ b/lib/services/providers/aws_service.dart
@@ -314,6 +314,7 @@ class AWSService {
     String secretKey,
     String region,
     String sessionToken,
+    String roleArn,
   ) async {
     try {
       final String result = await platform.invokeMethod(
@@ -323,6 +324,7 @@ class AWSService {
           'secretKey': secretKey,
           'region': region,
           'sessionToken': sessionToken,
+          'roleArn': roleArn,
         },
       );
 

--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -57,6 +57,7 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
           widget.provider.aws?.secretKey ?? '',
           widget.provider.aws?.region ?? '',
           widget.provider.aws?.sessionToken ?? '',
+          widget.provider.aws?.roleArn ?? '',
         );
 
         Logger.log(

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -57,6 +57,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
           widget.provider.awssso?.ssoCredentials?.secretAccessKey ?? '',
           widget.provider.awssso?.region ?? '',
           widget.provider.awssso?.ssoCredentials?.sessionToken ?? '',
+          ''
         );
 
         Logger.log(


### PR DESCRIPTION
Fixes https://github.com/kubenav/kubenav/issues/538
This PR uses the `roleArn` to perform the ListClusters for the AWS provider

I'm not a Flutter expert so I tried to make the smallest possible change but don't know if I changed everything in the flow. 
Also, I don't use the AWS SSO but I suppose there is no need for the role there