### PR TITLE
windows desktop version still shows 1.0.0 although it's the latest release 

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -227,7 +227,7 @@ jobs:
       - name: Build
         run: |
           flutter config --enable-windows-desktop
-          flutter build windows --release
+          flutter build windows --release --build-name ${{ github.event.release.tag_name }}
 
       - name: Package
         run: |


### PR DESCRIPTION
sets flutter build-name github.release.tag_name