### PR TITLE
Map secondary and long taps to double tap action 

### DIFF
--- a/lib/widgets/shared/app_list_item.dart
+++ b/lib/widgets/shared/app_list_item.dart
@@ -38,6 +38,8 @@ class AppListItem extends StatelessWidget {
     return InkWell(
       onTap: onTap,
       onDoubleTap: onDoubleTap,
+      onLongPress: onDoubleTap,
+      onSecondaryTap: onDoubleTap,
       child: Container(
         padding: const EdgeInsets.all(Constants.spacingListItemContent),
         decoration: BoxDecoration(


### PR DESCRIPTION
Fixes https://github.com/kubenav/kubenav/issues/541

This will improve UX as double tap is not common to open a secondary menu. We are more used to long tap on touch screens and right click (called secondary tap in Flutter) on desktops.