### PR TITLE
Use Background Threads on iOS

### DIFF
--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -5,10 +5,8 @@ import Kubenav
 
 public class KubenavPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    // Note: In release 2.10, the Task Queue API is only available on the master channel for iOS.
-    // let taskQueue = registrar.messenger.makeBackgroundTaskQueue()
-    // let channel = FlutterMethodChannel(name: "kubenav.io", binaryMessenger: registrar.messenger(), codec: FlutterStandardMethodCodec.sharedInstance, taskQueue: taskQueue)
-    let channel = FlutterMethodChannel(name: "kubenav.io", binaryMessenger: registrar.messenger())
+    let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
+    let channel = FlutterMethodChannel(name: "kubenav.io", binaryMessenger: registrar.messenger(), codec: FlutterStandardMethodCodec.sharedInstance(), taskQueue: taskQueue)
     let instance = KubenavPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }


### PR DESCRIPTION
For the Kubernetes API calls and for the different cloud providers we are using Go which is called via platform channels in Flutter. In the Android implementation we already executed the called native handlers in background threads and this commit adds the same functionality to our iOS implementation. This wasn't done earlier, because we run in the issue mentioned in https://github.com/flutter/flutter/issues/118832, which was fixed and included in Flutter v3.19.0.