### PR TITLE
Sort Helm Revisions

### DIFF
--- a/cmd/kubenav/helm.go
+++ b/cmd/kubenav/helm.go
@@ -431,6 +431,10 @@ func HelmGetHistory(clusterServer, clusterCertificateAuthorityData string, clust
 		releases = append(releases, release)
 	}
 
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].Version < releases[j].Version
+	})
+
 	releasesBytes, err := json.Marshal(releases)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Instead of directly returning the revisions of a Helm chart, we are now sorting the revisions by the version field.

Closes #579