### PR TITLE
Adjust Modal Bottom Sheets

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -326,17 +326,6 @@ class AppRepository with ChangeNotifier {
     } catch (_) {}
   }
 
-  /// [setFullHeightModals] enables or disables full height modals. When the
-  /// [value] is `true` full height modals will be enabled. If the [value] is
-  /// `false` the will be disabled.
-  Future<void> setFullHeightModals(bool value) async {
-    try {
-      _settings.fullHeightModals = value;
-      await _save();
-      notifyListeners();
-    } catch (_) {}
-  }
-
   /// [setClassicMode] enables or disables the classic navigation mode known
   /// from version 3. When the [value] is `true` classic mode will be enabled.
   /// If the [value] is `false` it will be disabled.
@@ -356,7 +345,6 @@ class AppRepositorySettings {
   bool isAuthenticationEnabled;
   bool isShowClustersOnStart;
   String editorFormat;
-  bool fullHeightModals;
   bool classicMode;
   String proxy;
   int timeout;
@@ -368,7 +356,6 @@ class AppRepositorySettings {
     required this.isAuthenticationEnabled,
     required this.isShowClustersOnStart,
     required this.editorFormat,
-    required this.fullHeightModals,
     required this.classicMode,
     required this.proxy,
     required this.timeout,
@@ -382,7 +369,6 @@ class AppRepositorySettings {
       isAuthenticationEnabled: false,
       isShowClustersOnStart: false,
       editorFormat: 'yaml',
-      fullHeightModals: false,
       classicMode: false,
       proxy: '',
       timeout: 0,
@@ -408,10 +394,6 @@ class AppRepositorySettings {
           data.containsKey('editorFormat') && data['editorFormat'] != null
               ? data['editorFormat']
               : 'yaml',
-      fullHeightModals: data.containsKey('fullHeightModals') &&
-              data['fullHeightModals'] != null
-          ? data['fullHeightModals']
-          : false,
       classicMode:
           data.containsKey('classicMode') && data['classicMode'] != null
               ? data['classicMode']
@@ -438,7 +420,6 @@ class AppRepositorySettings {
       'isAuthenticationEnabled': isAuthenticationEnabled,
       'isShowClustersOnStart': isShowClustersOnStart,
       'editorFormat': editorFormat,
-      'fullHeightModals': fullHeightModals,
       'classicMode': classicMode,
       'proxy': proxy,
       'timeout': timeout,

--- a/lib/utils/showmodal.dart
+++ b/lib/utils/showmodal.dart
@@ -9,6 +9,13 @@ void showModal(BuildContext context, Widget widget) {
     isScrollControlled: true,
     isDismissible: true,
     useSafeArea: true,
+    backgroundColor: Colors.transparent,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(Constants.spacingMiddle),
+      ),
+    ),
+    clipBehavior: Clip.antiAliasWithSaveLayer,
     builder: (BuildContext context) {
       return widget;
     },
@@ -18,11 +25,13 @@ void showModal(BuildContext context, Widget widget) {
 void showActions(BuildContext context, Widget widget) {
   showModalBottomSheet(
     context: context,
-    isScrollControlled: false,
+    isScrollControlled: true,
     isDismissible: true,
     useSafeArea: true,
+    elevation: 0,
     backgroundColor: Colors.transparent,
     builder: (BuildContext context) {
+      return widget;
       return Container(
         margin: const EdgeInsets.all(Constants.spacingMiddle),
         child: widget,

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -480,30 +480,6 @@ class Settings extends StatelessWidget {
                   AppVertialListSimpleModel(
                     children: [
                       Icon(
-                        Icons.code,
-                        color: theme(context).primary,
-                      ),
-                      const SizedBox(width: Constants.spacingSmall),
-                      Expanded(
-                        flex: 1,
-                        child: Text(
-                          'Full Height Modals',
-                          style: noramlTextStyle(
-                            context,
-                          ),
-                        ),
-                      ),
-                      Switch(
-                        activeColor: theme(context).primary,
-                        onChanged: (value) =>
-                            {appRepository.setFullHeightModals(value)},
-                        value: appRepository.settings.fullHeightModals,
-                      ),
-                    ],
-                  ),
-                  AppVertialListSimpleModel(
-                    children: [
-                      Icon(
                         Icons.dashboard,
                         color: theme(context).primary,
                       ),

--- a/lib/widgets/shared/app_actions_widget.dart
+++ b/lib/widgets/shared/app_actions_widget.dart
@@ -50,9 +50,8 @@ class AppActionsWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(
-        left: Constants.spacingMiddle,
-        right: Constants.spacingMiddle,
+      margin: const EdgeInsets.all(
+        Constants.spacingMiddle,
       ),
       padding: const EdgeInsets.only(
         left: Constants.spacingMiddle,

--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/svg.dart';
-import 'package:provider/provider.dart';
 
-import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
@@ -89,24 +87,9 @@ class AppBottomSheetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    AppRepository appRepository = Provider.of<AppRepository>(
-      context,
-      listen: false,
-    );
-
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
-
-    return Container(
-      height: MediaQuery.of(context).size.height *
-          (isKeyboardVisible
-              ? 1
-              : appRepository.settings.fullHeightModals
-                  ? 1
-                  : 0.75),
-      color: Colors.transparent,
-      child: Scaffold(
-        backgroundColor: Colors.transparent,
-        body: Container(
+    return Scaffold(
+      body: SafeArea(
+        child: Container(
           padding: const EdgeInsets.only(
             left: Constants.spacingMiddle,
             right: Constants.spacingMiddle,

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:xterm/ui.dart' as xtermui;
 import 'package:xterm/xterm.dart' as xterm;
 
-import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/terminal_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/utils/constants.dart';
@@ -21,28 +20,14 @@ class AppTerminalsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    AppRepository appRepository = Provider.of<AppRepository>(
-      context,
-      listen: false,
-    );
     TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
       context,
       listen: true,
     );
 
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom != 0;
-
-    return Container(
-      height: MediaQuery.of(context).size.height *
-          (isKeyboardVisible
-              ? 1
-              : appRepository.settings.fullHeightModals
-                  ? 1
-                  : 0.75),
-      color: Colors.transparent,
-      child: Scaffold(
-        backgroundColor: Colors.transparent,
-        body: Container(
+    return Scaffold(
+      body: SafeArea(
+        child: Container(
           padding: const EdgeInsets.only(
             left: Constants.spacingMiddle,
             right: Constants.spacingMiddle,


### PR DESCRIPTION
Adjust the modal bottom sheets to always use the full display height and to use the `SafeArea` widget for better positioning. With this change we also removed the user setting to select the height of the modal bottom sheets.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
