### PR TITLE
Fix Pod Selection for Logs

### DIFF
--- a/lib/widgets/resources/details/details_get_logs_pods.dart
+++ b/lib/widgets/resources/details/details_get_logs_pods.dart
@@ -184,7 +184,7 @@ class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
                       _selectedPods = _selectedPods
                           .where(
                             (p) =>
-                                p.metadata?.name == _pods[index].metadata?.name,
+                                p.metadata?.name != _pods[index].metadata?.name,
                           )
                           .toList();
                     });


### PR DESCRIPTION
The selection of Pods for the logs of a Deployment, StatefulSet, etc. wasn't working correctly, because the filter to remove a selected Pod from the list was wrong. This is now fixed.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
