### PR TITLE
Fix Tab Alignment

### DIFF
--- a/lib/widgets/resources/details/details_live_metrics.dart
+++ b/lib/widgets/resources/details/details_live_metrics.dart
@@ -239,26 +239,26 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
         length: 2,
         child: Column(
           children: [
-            ClipRRect(
-              borderRadius: const BorderRadius.all(
-                Radius.circular(Constants.sizeBorderRadius),
-              ),
-              child: SizedBox(
-                height: 32,
-                child: TabBar(
-                  isScrollable: false,
-                  labelColor: theme(context).onPrimary,
-                  unselectedLabelColor: theme(context).primary,
-                  labelPadding: EdgeInsets.zero,
-                  indicatorSize: TabBarIndicatorSize.tab,
-                  indicator: BoxDecoration(
-                    color: theme(context).primary,
+            SizedBox(
+              height: 32,
+              child: TabBar(
+                isScrollable: false,
+                tabAlignment: TabAlignment.fill,
+                labelColor: theme(context).onPrimary,
+                unselectedLabelColor: theme(context).primary,
+                labelPadding: EdgeInsets.zero,
+                indicatorPadding: const EdgeInsets.symmetric(horizontal: 5),
+                indicatorSize: TabBarIndicatorSize.tab,
+                indicator: BoxDecoration(
+                  borderRadius: BorderRadius.circular(
+                    Constants.sizeBorderRadius,
                   ),
-                  tabs: const [
-                    Tab(text: 'CPU'),
-                    Tab(text: 'Memory'),
-                  ],
+                  color: theme(context).primary,
                 ),
+                tabs: const [
+                  Tab(text: 'CPU'),
+                  Tab(text: 'Memory'),
+                ],
               ),
             ),
             const SizedBox(height: Constants.spacingMiddle),

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -123,44 +123,42 @@ class AppTerminalsWidget extends StatelessWidget {
                   length: terminalRepository.terminals.length,
                   child: Column(
                     children: [
-                      ClipRRect(
-                        borderRadius: const BorderRadius.all(
-                          Radius.circular(Constants.sizeBorderRadius),
-                        ),
-                        child: SizedBox(
-                          height: 32,
-                          child: TabBar(
-                            isScrollable: true,
-                            labelColor: theme(context).onPrimary,
-                            unselectedLabelColor: theme(context).primary,
-                            indicatorSize: TabBarIndicatorSize.tab,
-                            indicator: BoxDecoration(
-                              color: theme(context).primary,
+                      SizedBox(
+                        height: 32,
+                        child: TabBar(
+                          isScrollable: true,
+                          tabAlignment: TabAlignment.center,
+                          labelColor: theme(context).onPrimary,
+                          unselectedLabelColor: theme(context).primary,
+                          indicatorPadding:
+                              const EdgeInsets.symmetric(horizontal: 5),
+                          indicatorSize: TabBarIndicatorSize.tab,
+                          indicator: BoxDecoration(
+                            borderRadius: BorderRadius.circular(
+                              Constants.sizeBorderRadius,
                             ),
-                            tabs: terminalRepository.terminals
-                                .asMap()
-                                .entries
-                                .map(
-                              (terminal) {
-                                return Tab(
-                                  child: GestureDetector(
-                                    onDoubleTap: () {
-                                      terminalRepository.deleteTerminal(
-                                        terminal.key,
-                                      );
-                                      if (terminalRepository
-                                          .terminals.isEmpty) {
-                                        Navigator.pop(context);
-                                      }
-                                    },
-                                    child: Text(
-                                      terminal.value.name,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ).toList(),
+                            color: theme(context).primary,
                           ),
+                          tabs:
+                              terminalRepository.terminals.asMap().entries.map(
+                            (terminal) {
+                              return Tab(
+                                child: GestureDetector(
+                                  onDoubleTap: () {
+                                    terminalRepository.deleteTerminal(
+                                      terminal.key,
+                                    );
+                                    if (terminalRepository.terminals.isEmpty) {
+                                      Navigator.pop(context);
+                                    }
+                                  },
+                                  child: Text(
+                                    terminal.value.name,
+                                  ),
+                                ),
+                              );
+                            },
+                          ).toList(),
                         ),
                       ),
                       const SizedBox(height: Constants.spacingMiddle),
@@ -203,7 +201,9 @@ class AppTerminalsWidget extends StatelessWidget {
                                             padding: const EdgeInsets.all(
                                               Constants.spacingSmall,
                                             ),
-                                            color: theme(context).background,
+                                            color: theme(context)
+                                                .terminalTheme
+                                                .background,
                                             child: Wrap(
                                               children: terminal.value.logs ==
                                                       null


### PR DESCRIPTION
After we enable the `useMaterial3` option in #530, we have to add the `tabAlignment` option to our `TabBar` components, so that they are aligned correctly.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
