### PR TITLE
Improve Layout

### DIFF
--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 
 /// [Logger] is our custom log implementation, which allows us to log messages
@@ -28,20 +29,17 @@ class Logger extends StatelessWidget {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: Form(
-        key: const Key('settings/logs'),
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: SelectableText(
-                _Log.list.map((e) => e.toString()).join('\n\n'),
-              ),
-            ),
-          ],
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: SelectableText(
+            _Log.list.map((e) => e.toString()).join('\n\n'),
+          ),
         ),
       ),
     );

--- a/lib/widgets/home/home_overview.dart
+++ b/lib/widgets/home/home_overview.dart
@@ -25,8 +25,10 @@ class HomeOverview extends StatelessWidget {
 
     if (clustersRepository.clusters.isEmpty) {
       return [
-        const SizedBox(height: Constants.spacingSmall),
-        const AppNoClustersWidget(),
+        const Padding(
+          padding: EdgeInsets.all(Constants.spacingMiddle),
+          child: AppNoClustersWidget(),
+        ),
       ];
     }
 
@@ -37,7 +39,7 @@ class HomeOverview extends StatelessWidget {
       ),
       const SizedBox(height: Constants.spacingMiddle),
       const OverviewEvents(),
-      const SizedBox(height: Constants.spacingSmall),
+      const SizedBox(height: Constants.spacingMiddle),
     ];
   }
 

--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -121,6 +121,19 @@ class _OverviewEventsState extends State<OverviewEvents> {
 
     return Column(
       children: [
+        Padding(
+          padding: const EdgeInsets.all(Constants.spacingMiddle),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Warnings',
+                  style: primaryTextStyle(context, size: 18),
+                ),
+              ),
+            ],
+          ),
+        ),
         FutureBuilder(
           future: _futureFetchEvents,
           builder: (
@@ -135,7 +148,10 @@ class _OverviewEventsState extends State<OverviewEvents> {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Padding(
-                      padding: const EdgeInsets.all(Constants.spacingMiddle),
+                      padding: const EdgeInsets.only(
+                        left: Constants.spacingMiddle,
+                        right: Constants.spacingMiddle,
+                      ),
                       child: CircularProgressIndicator(
                         color: Theme.of(context).colorScheme.primary,
                       ),
@@ -150,8 +166,10 @@ class _OverviewEventsState extends State<OverviewEvents> {
                     children: [
                       Flexible(
                         child: Padding(
-                          padding:
-                              const EdgeInsets.all(Constants.spacingMiddle),
+                          padding: const EdgeInsets.only(
+                            left: Constants.spacingMiddle,
+                            right: Constants.spacingMiddle,
+                          ),
                           child: AppErrorWidget(
                             message: 'Could not load events',
                             details: snapshot.error.toString(),
@@ -164,41 +182,22 @@ class _OverviewEventsState extends State<OverviewEvents> {
                   );
                 }
 
-                return Wrap(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(
-                        top: Constants.spacingMiddle,
-                        left: Constants.spacingMiddle,
-                        right: Constants.spacingMiddle,
-                        bottom: Constants.spacingMiddle,
-                      ),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Text(
-                              'Warnings',
-                              style: primaryTextStyle(context, size: 18),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    ListView.builder(
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      padding: const EdgeInsets.only(
-                        right: Constants.spacingMiddle,
-                        left: Constants.spacingMiddle,
-                      ),
-                      itemCount: snapshot.data!.length,
-                      itemBuilder: (context, index) {
-                        return buildEventItem(
-                          snapshot.data![index],
-                        );
-                      },
-                    ),
-                  ],
+                return ListView.separated(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  padding: const EdgeInsets.only(
+                    right: Constants.spacingMiddle,
+                    left: Constants.spacingMiddle,
+                  ),
+                  separatorBuilder: (context, index) => const SizedBox(
+                    height: Constants.spacingMiddle,
+                  ),
+                  itemCount: snapshot.data!.length,
+                  itemBuilder: (context, index) {
+                    return buildEventItem(
+                      snapshot.data![index],
+                    );
+                  },
                 );
             }
           },

--- a/lib/widgets/home/overview/overview_metric.dart
+++ b/lib/widgets/home/overview/overview_metric.dart
@@ -473,58 +473,36 @@ class _OverviewMetricState extends State<OverviewMetric> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: FutureBuilder(
-        future: _futureFetchMetrics,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<Metrics> snapshot,
-        ) {
-          switch (snapshot.connectionState) {
-            case ConnectionState.none:
-            case ConnectionState.waiting:
-              return Flex(
-                direction: Axis.vertical,
-                children: [
-                  Expanded(
-                    child: Wrap(
-                      children: [
-                        CircularProgressIndicator(
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              );
-            default:
-              if (snapshot.hasError) {
-                return Flex(
-                  direction: Axis.vertical,
-                  children: [
-                    Expanded(
-                      child: Wrap(
-                        children: [
-                          AppErrorWidget(
-                            message: 'Could not load metrics',
-                            details: snapshot.error.toString(),
-                            icon: widget.icon,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                );
-              }
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: FutureBuilder(
+            future: _futureFetchMetrics,
+            builder: (
+              BuildContext context,
+              AsyncSnapshot<Metrics> snapshot,
+            ) {
+              switch (snapshot.connectionState) {
+                case ConnectionState.none:
+                case ConnectionState.waiting:
+                  return CircularProgressIndicator(
+                    color: Theme.of(context).colorScheme.primary,
+                  );
+                default:
+                  if (snapshot.hasError) {
+                    return AppErrorWidget(
+                      message: 'Could not load metrics',
+                      details: snapshot.error.toString(),
+                      icon: widget.icon,
+                    );
+                  }
 
-              return ListView(
-                shrinkWrap: false,
-                children: [
-                  const SizedBox(height: Constants.spacingMiddle),
-                  Container(
-                    margin: const EdgeInsets.only(
-                      left: Constants.spacingExtraSmall,
-                      right: Constants.spacingExtraSmall,
-                    ),
+                  return Container(
                     padding: const EdgeInsets.all(
                       Constants.spacingListItemContent,
                     ),
@@ -683,12 +661,11 @@ class _OverviewMetricState extends State<OverviewMetric> {
                         ...buildLegend(snapshot.data!),
                       ],
                     ),
-                  ),
-                  const SizedBox(height: Constants.spacingMiddle),
-                ],
-              );
-          }
-        },
+                  );
+              }
+            },
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/home/overview/overview_metrics.dart
+++ b/lib/widgets/home/overview/overview_metrics.dart
@@ -92,11 +92,8 @@ class OverviewMetrics extends StatelessWidget {
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.only(
-            top: Constants.spacingMiddle,
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-            bottom: Constants.spacingMiddle,
+          padding: const EdgeInsets.all(
+            Constants.spacingMiddle,
           ),
           child: Row(
             children: [
@@ -109,46 +106,52 @@ class OverviewMetrics extends StatelessWidget {
             ],
           ),
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            buildCard(
-              context,
-              'CPU',
-              Icons.bar_chart,
-              () {
-                showMetrics(
-                  context,
-                  MetricType.cpu,
-                  Icons.bar_chart,
-                );
-              },
-            ),
-            buildCard(
-              context,
-              'Memory',
-              Icons.area_chart,
-              () {
-                showMetrics(
-                  context,
-                  MetricType.memory,
-                  Icons.area_chart,
-                );
-              },
-            ),
-            buildCard(
-              context,
-              'Pods',
-              Icons.pie_chart,
-              () {
-                showMetrics(
-                  context,
-                  MetricType.pods,
-                  Icons.pie_chart,
-                );
-              },
-            ),
-          ],
+        Padding(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              buildCard(
+                context,
+                'CPU',
+                Icons.bar_chart,
+                () {
+                  showMetrics(
+                    context,
+                    MetricType.cpu,
+                    Icons.bar_chart,
+                  );
+                },
+              ),
+              buildCard(
+                context,
+                'Memory',
+                Icons.area_chart,
+                () {
+                  showMetrics(
+                    context,
+                    MetricType.memory,
+                    Icons.area_chart,
+                  );
+                },
+              ),
+              buildCard(
+                context,
+                'Pods',
+                Icons.pie_chart,
+                () {
+                  showMetrics(
+                    context,
+                    MetricType.pods,
+                    Icons.pie_chart,
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/widgets/plugins/helm/plugin_helm_details.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details.dart
@@ -242,8 +242,9 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Padding(
-                            padding:
-                                const EdgeInsets.all(Constants.spacingMiddle),
+                            padding: const EdgeInsets.all(
+                              Constants.spacingMiddle,
+                            ),
                             child: CircularProgressIndicator(
                               color: Theme.of(context).colorScheme.primary,
                             ),
@@ -348,28 +349,14 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                               BuildContext context,
                               AsyncSnapshot<List<Release>> snapshot,
                             ) {
-                              switch (snapshot.connectionState) {
-                                case ConnectionState.none:
-                                case ConnectionState.waiting:
-                                  return Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.all(
-                                          Constants.spacingMiddle,
-                                        ),
-                                        child: CircularProgressIndicator(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary,
-                                        ),
-                                      ),
-                                    ],
-                                  );
-                                default:
-                                  return AppVertialListSimpleWidget(
+                              if (snapshot.data == null ||
+                                  snapshot.data!.isEmpty) {
+                                return Container();
+                              }
+
+                              return Column(
+                                children: [
+                                  AppVertialListSimpleWidget(
                                     title: 'History',
                                     items: (snapshot.data ?? [])
                                         .map(
@@ -490,13 +477,16 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                           ),
                                         )
                                         .toList(),
-                                  );
-                              }
+                                  ),
+                                  const SizedBox(
+                                    height: Constants.spacingMiddle,
+                                  ),
+                                ],
+                              );
                             },
                           ),
-                          const SizedBox(height: Constants.spacingMiddle),
                           _buildTemplates(release),
-                          const SizedBox(height: Constants.spacingExtraLarge),
+                          const SizedBox(height: Constants.spacingMiddle),
                         ],
                       );
                   }

--- a/lib/widgets/plugins/helm/plugin_helm_details_template.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_template.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:code_text_field/code_text_field.dart';
 
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
@@ -55,31 +56,28 @@ class _PluginHelmDetailsTemplateState extends State<PluginHelmDetailsTemplate> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: Form(
-        child: ListView(
-          physics: const ClampingScrollPhysics(),
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: CodeTheme(
-                data: CodeThemeData(
-                  styles:
-                      Theme.of(context).extension<EditorColors>()!.getTheme(),
-                ),
-                child: CodeField(
-                  controller: _codeController,
-                  enabled: false,
-                  textStyle: TextStyle(
-                    fontSize: 14,
-                    fontFamily: getMonospaceFontFamily(),
-                  ),
-                ),
+      child: SingleChildScrollView(
+        physics: const ClampingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: CodeTheme(
+            data: CodeThemeData(
+              styles: Theme.of(context).extension<EditorColors>()!.getTheme(),
+            ),
+            child: CodeField(
+              controller: _codeController,
+              enabled: false,
+              textStyle: TextStyle(
+                fontSize: 14,
+                fontFamily: getMonospaceFontFamily(),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/plugins/helm/plugin_helm_details_values.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_values.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 import 'package:kubenav/models/plugins/helm.dart';
 import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/services/helpers_service.dart';
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/themes.dart';
@@ -93,31 +94,28 @@ class _PluginHelmDetailsValuesState extends State<PluginHelmDetailsValues> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: Form(
-        child: ListView(
-          physics: const ClampingScrollPhysics(),
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: CodeTheme(
-                data: CodeThemeData(
-                  styles:
-                      Theme.of(context).extension<EditorColors>()!.getTheme(),
-                ),
-                child: CodeField(
-                  controller: _codeController,
-                  enabled: false,
-                  textStyle: TextStyle(
-                    fontSize: 14,
-                    fontFamily: getMonospaceFontFamily(),
-                  ),
-                ),
+      child: SingleChildScrollView(
+        physics: const ClampingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: CodeTheme(
+            data: CodeThemeData(
+              styles: Theme.of(context).extension<EditorColors>()!.getTheme(),
+            ),
+            child: CodeField(
+              controller: _codeController,
+              enabled: false,
+              textStyle: TextStyle(
+                fontSize: 14,
+                fontFamily: getMonospaceFontFamily(),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/plugins/helm/plugin_helm_list.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list.dart
@@ -268,8 +268,9 @@ class _PluginHelmListState extends State<PluginHelmList> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Padding(
-                            padding:
-                                const EdgeInsets.all(Constants.spacingMiddle),
+                            padding: const EdgeInsets.all(
+                              Constants.spacingMiddle,
+                            ),
                             child: CircularProgressIndicator(
                               color: Theme.of(context).colorScheme.primary,
                             ),

--- a/lib/widgets/plugins/plugins.dart
+++ b/lib/widgets/plugins/plugins.dart
@@ -30,13 +30,14 @@ class Plugins extends StatelessWidget {
 
     if (clustersRepository.clusters.isEmpty) {
       return [
-        const SizedBox(height: Constants.spacingSmall),
-        const AppNoClustersWidget(),
+        const Padding(
+          padding: EdgeInsets.all(Constants.spacingMiddle),
+          child: AppNoClustersWidget(),
+        ),
       ];
     }
 
     return [
-      const SizedBox(height: Constants.spacingSmall),
       AppVertialListSimpleWidget(
         title: 'Plugins',
         items: [

--- a/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
+++ b/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
@@ -164,8 +164,9 @@ class _PluginPrometheusDetailsState extends State<PluginPrometheusDetails> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Padding(
-                            padding:
-                                const EdgeInsets.all(Constants.spacingMiddle),
+                            padding: const EdgeInsets.all(
+                              Constants.spacingMiddle,
+                            ),
                             child: CircularProgressIndicator(
                               color: Theme.of(context).colorScheme.primary,
                             ),

--- a/lib/widgets/plugins/prometheus/plugin_prometheus_list.dart
+++ b/lib/widgets/plugins/prometheus/plugin_prometheus_list.dart
@@ -235,8 +235,9 @@ class _PluginPrometheusListState extends State<PluginPrometheusList> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Padding(
-                            padding:
-                                const EdgeInsets.all(Constants.spacingMiddle),
+                            padding: const EdgeInsets.all(
+                              Constants.spacingMiddle,
+                            ),
                             child: CircularProgressIndicator(
                               color: Theme.of(context).colorScheme.primary,
                             ),

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -36,15 +36,25 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
     int index,
     Animation<double> animation,
   ) {
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (BuildContext context, Widget? child) {
-        return Material(
-          elevation: 0,
-          child: child,
-        );
-      },
-      child: child,
+    return Material(
+      elevation: 0,
+      color: Colors.transparent,
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: Material(
+              borderRadius: BorderRadius.circular(16),
+              elevation: 24,
+              color: Colors.transparent,
+            ),
+          ),
+          child,
+        ],
+      ),
     );
   }
 
@@ -141,7 +151,7 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              const SizedBox(height: Constants.spacingLarge),
+              const SizedBox(height: Constants.spacingMiddle),
               ReorderableListView.builder(
                 shrinkWrap: true,
                 buildDefaultDragHandles: false,
@@ -171,8 +181,7 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                     ),
                     child: Container(
                       margin: const EdgeInsets.only(
-                        top: Constants.spacingSmall,
-                        bottom: Constants.spacingSmall,
+                        bottom: Constants.spacingMiddle,
                         left: Constants.spacingMiddle,
                         right: Constants.spacingMiddle,
                       ),
@@ -289,7 +298,6 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                   );
                 },
               ),
-              const SizedBox(height: Constants.spacingSmall),
             ],
           ),
         ),

--- a/lib/widgets/resources/details/details_container.dart
+++ b/lib/widgets/resources/details/details_container.dart
@@ -49,7 +49,6 @@ class DetailsContainer extends StatelessWidget {
 
     return [
       DetailsItemWidget(
-        smallPadding: true,
         title: 'Status',
         details: [
           DetailsItemModel(
@@ -93,266 +92,269 @@ class DetailsContainer extends StatelessWidget {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: ListView(
-        shrinkWrap: false,
-        children: [
-          DetailsItemWidget(
-            smallPadding: true,
-            title: 'Configuration',
-            details: [
-              DetailsItemModel(
-                name: 'Image',
-                values: container.image ?? '-',
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            bottom: Constants.spacingMiddle,
+          ),
+          child: Column(
+            children: [
+              DetailsItemWidget(
+                title: 'Configuration',
+                details: [
+                  DetailsItemModel(
+                    name: 'Image',
+                    values: container.image ?? '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Image Pull Policy',
+                    values: container.imagePullPolicy ?? '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Command',
+                    values:
+                        container.command.isNotEmpty ? container.command : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Arguments',
+                    values: container.args.isNotEmpty ? container.args : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Ports',
+                    values: container.ports.isNotEmpty
+                        ? container.ports
+                            .map(
+                              (port) =>
+                                  '${port.containerPort}${port.hostPort != null ? '/${port.hostPort}' : ''}${port.protocol != null ? '/${port.protocol}' : ''}${port.name != null ? ' (${port.name})' : ''}',
+                            )
+                            .toList()
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Readiness Probe',
+                    values: container.readinessProbe != null
+                        ? getProbe(container.readinessProbe!)
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Liveness Probe',
+                    values: container.livenessProbe != null
+                        ? getProbe(container.livenessProbe!)
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Startup Probe',
+                    values: container.startupProbe != null
+                        ? getProbe(container.startupProbe!)
+                        : '-',
+                  ),
+                ],
               ),
-              DetailsItemModel(
-                name: 'Image Pull Policy',
-                values: container.imagePullPolicy ?? '-',
+              const SizedBox(height: Constants.spacingMiddle),
+              ...buildStatus(),
+              DetailsItemWidget(
+                title: 'Resources',
+                details: [
+                  DetailsItemModel(
+                    name: 'CPU Usage',
+                    values: containerMetric.isNotEmpty &&
+                            containerMetric[0].usage?.cpu != null
+                        ? formatCpuMetric(
+                            cpuMetricsStringToDouble(
+                              containerMetric[0].usage!.cpu!,
+                            ),
+                          )
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'CPU Requests',
+                    values: container.resources != null &&
+                            container.resources!.requests.containsKey('cpu')
+                        ? container.resources!.requests['cpu']
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'CPU Limits',
+                    values: container.resources != null &&
+                            container.resources!.limits.containsKey('cpu')
+                        ? container.resources!.limits['cpu']
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Memory Usage',
+                    values: containerMetric.isNotEmpty &&
+                            containerMetric[0].usage?.memory != null
+                        ? formatMemoryMetric(
+                            memoryMetricsStringToDouble(
+                              containerMetric[0].usage!.memory!,
+                            ),
+                          )
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Memory Requests',
+                    values: container.resources != null &&
+                            container.resources!.requests.containsKey('memory')
+                        ? container.resources!.requests['memory']
+                        : '-',
+                  ),
+                  DetailsItemModel(
+                    name: 'Memory Limits',
+                    values: container.resources != null &&
+                            container.resources!.limits.containsKey('memory')
+                        ? container.resources!.limits['memory']
+                        : '-',
+                  ),
+                ],
               ),
-              DetailsItemModel(
-                name: 'Command',
-                values: container.command.isNotEmpty ? container.command : '-',
+              const SizedBox(height: Constants.spacingMiddle),
+              AppVertialListSimpleWidget(
+                title: 'Environment Variables',
+                items: container.env
+                    .map(
+                      (env) => AppVertialListSimpleModel(
+                        onTap: () {
+                          showSnackbar(
+                            context,
+                            env.name,
+                            env.value != null
+                                ? env.value!
+                                : env.valueFrom != null
+                                    ? getValueFrom(env.valueFrom!)
+                                    : '-',
+                          );
+                        },
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.primary,
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(Constants.sizeBorderRadius),
+                              ),
+                            ),
+                            height: 54,
+                            width: 54,
+                            padding: const EdgeInsets.all(
+                              Constants.spacingIcon54x54,
+                            ),
+                            child: SvgPicture.asset(
+                              'assets/resources/secrets.svg',
+                            ),
+                          ),
+                          const SizedBox(width: Constants.spacingSmall),
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  env.name,
+                                  style: primaryTextStyle(
+                                    context,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                Text(
+                                  env.value != null
+                                      ? env.value!
+                                      : env.valueFrom != null
+                                          ? getValueFrom(env.valueFrom!)
+                                          : '-',
+                                  style: secondaryTextStyle(
+                                    context,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: Constants.spacingSmall),
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            color: Theme.of(context)
+                                .extension<CustomColors>()!
+                                .textSecondary
+                                .withOpacity(Constants.opacityIcon),
+                            size: 24,
+                          ),
+                        ],
+                      ),
+                    )
+                    .toList(),
               ),
-              DetailsItemModel(
-                name: 'Arguments',
-                values: container.args.isNotEmpty ? container.args : '-',
-              ),
-              DetailsItemModel(
-                name: 'Ports',
-                values: container.ports.isNotEmpty
-                    ? container.ports
-                        .map(
-                          (port) =>
-                              '${port.containerPort}${port.hostPort != null ? '/${port.hostPort}' : ''}${port.protocol != null ? '/${port.protocol}' : ''}${port.name != null ? ' (${port.name})' : ''}',
-                        )
-                        .toList()
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Readiness Probe',
-                values: container.readinessProbe != null
-                    ? getProbe(container.readinessProbe!)
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Liveness Probe',
-                values: container.livenessProbe != null
-                    ? getProbe(container.livenessProbe!)
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Startup Probe',
-                values: container.startupProbe != null
-                    ? getProbe(container.startupProbe!)
-                    : '-',
+              AppVertialListSimpleWidget(
+                title: 'Volume Mounts',
+                items: container.volumeMounts
+                    .map(
+                      (volumeMount) => AppVertialListSimpleModel(
+                        onTap: () {
+                          showSnackbar(
+                            context,
+                            volumeMount.name,
+                            'Path: ${volumeMount.mountPath}\nSub-Path: ${volumeMount.subPath ?? '-'}\nReadonly: ${volumeMount.readOnly == true ? 'True' : 'False'}',
+                          );
+                        },
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.primary,
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(Constants.sizeBorderRadius),
+                              ),
+                            ),
+                            height: 54,
+                            width: 54,
+                            padding: const EdgeInsets.all(
+                              Constants.spacingIcon54x54,
+                            ),
+                            child: SvgPicture.asset(
+                              'assets/resources/persistentvolumes.svg',
+                            ),
+                          ),
+                          const SizedBox(width: Constants.spacingSmall),
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  volumeMount.name,
+                                  style: primaryTextStyle(
+                                    context,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                Text(
+                                  volumeMount.mountPath,
+                                  style: secondaryTextStyle(
+                                    context,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: Constants.spacingSmall),
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            color: Theme.of(context)
+                                .extension<CustomColors>()!
+                                .textSecondary
+                                .withOpacity(Constants.opacityIcon),
+                            size: 24,
+                          ),
+                        ],
+                      ),
+                    )
+                    .toList(),
               ),
             ],
           ),
-          const SizedBox(height: Constants.spacingMiddle),
-          ...buildStatus(),
-          DetailsItemWidget(
-            smallPadding: true,
-            title: 'Resources',
-            details: [
-              DetailsItemModel(
-                name: 'CPU Usage',
-                values: containerMetric.isNotEmpty &&
-                        containerMetric[0].usage?.cpu != null
-                    ? formatCpuMetric(
-                        cpuMetricsStringToDouble(
-                          containerMetric[0].usage!.cpu!,
-                        ),
-                      )
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'CPU Requests',
-                values: container.resources != null &&
-                        container.resources!.requests.containsKey('cpu')
-                    ? container.resources!.requests['cpu']
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'CPU Limits',
-                values: container.resources != null &&
-                        container.resources!.limits.containsKey('cpu')
-                    ? container.resources!.limits['cpu']
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Memory Usage',
-                values: containerMetric.isNotEmpty &&
-                        containerMetric[0].usage?.memory != null
-                    ? formatMemoryMetric(
-                        memoryMetricsStringToDouble(
-                          containerMetric[0].usage!.memory!,
-                        ),
-                      )
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Memory Requests',
-                values: container.resources != null &&
-                        container.resources!.requests.containsKey('memory')
-                    ? container.resources!.requests['memory']
-                    : '-',
-              ),
-              DetailsItemModel(
-                name: 'Memory Limits',
-                values: container.resources != null &&
-                        container.resources!.limits.containsKey('memory')
-                    ? container.resources!.limits['memory']
-                    : '-',
-              ),
-            ],
-          ),
-          const SizedBox(height: Constants.spacingMiddle),
-          AppVertialListSimpleWidget(
-            smallPadding: true,
-            title: 'Environment Variables',
-            items: container.env
-                .map(
-                  (env) => AppVertialListSimpleModel(
-                    onTap: () {
-                      showSnackbar(
-                        context,
-                        env.name,
-                        env.value != null
-                            ? env.value!
-                            : env.valueFrom != null
-                                ? getValueFrom(env.valueFrom!)
-                                : '-',
-                      );
-                    },
-                    children: [
-                      Container(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.primary,
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(Constants.sizeBorderRadius),
-                          ),
-                        ),
-                        height: 54,
-                        width: 54,
-                        padding: const EdgeInsets.all(
-                          Constants.spacingIcon54x54,
-                        ),
-                        child: SvgPicture.asset(
-                          'assets/resources/secrets.svg',
-                        ),
-                      ),
-                      const SizedBox(width: Constants.spacingSmall),
-                      Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              env.name,
-                              style: primaryTextStyle(
-                                context,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            Text(
-                              env.value != null
-                                  ? env.value!
-                                  : env.valueFrom != null
-                                      ? getValueFrom(env.valueFrom!)
-                                      : '-',
-                              style: secondaryTextStyle(
-                                context,
-                              ),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: Constants.spacingSmall),
-                      Icon(
-                        Icons.arrow_forward_ios,
-                        color: Theme.of(context)
-                            .extension<CustomColors>()!
-                            .textSecondary
-                            .withOpacity(Constants.opacityIcon),
-                        size: 24,
-                      ),
-                    ],
-                  ),
-                )
-                .toList(),
-          ),
-          AppVertialListSimpleWidget(
-            smallPadding: true,
-            title: 'Volume Mounts',
-            items: container.volumeMounts
-                .map(
-                  (volumeMount) => AppVertialListSimpleModel(
-                    onTap: () {
-                      showSnackbar(
-                        context,
-                        volumeMount.name,
-                        'Path: ${volumeMount.mountPath}\nSub-Path: ${volumeMount.subPath ?? '-'}\nReadonly: ${volumeMount.readOnly == true ? 'True' : 'False'}',
-                      );
-                    },
-                    children: [
-                      Container(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.primary,
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(Constants.sizeBorderRadius),
-                          ),
-                        ),
-                        height: 54,
-                        width: 54,
-                        padding: const EdgeInsets.all(
-                          Constants.spacingIcon54x54,
-                        ),
-                        child: SvgPicture.asset(
-                          'assets/resources/persistentvolumes.svg',
-                        ),
-                      ),
-                      const SizedBox(width: Constants.spacingSmall),
-                      Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              volumeMount.name,
-                              style: primaryTextStyle(
-                                context,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            Text(
-                              volumeMount.mountPath,
-                              style: secondaryTextStyle(
-                                context,
-                              ),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: Constants.spacingSmall),
-                      Icon(
-                        Icons.arrow_forward_ios,
-                        color: Theme.of(context)
-                            .extension<CustomColors>()!
-                            .textSecondary
-                            .withOpacity(Constants.opacityIcon),
-                        size: 24,
-                      ),
-                    ],
-                  ),
-                )
-                .toList(),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/widgets/resources/details/details_create_job.dart
+++ b/lib/widgets/resources/details/details_create_job.dart
@@ -151,19 +151,17 @@ class _DetailsCreateJobState extends State<DetailsCreateJob> {
         _createJob();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'Do you really want to create a Job for the CronJob ${widget.name} in namespace ${widget.namespace}?',
-              ),
-            ),
-          ],
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to create a Job for the CronJob ${widget.name} in namespace ${widget.namespace}?',
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_delete_resource.dart
+++ b/lib/widgets/resources/details/details_delete_resource.dart
@@ -137,27 +137,27 @@ class _DetailsDeleteResourceState extends State<DetailsDeleteResource> {
         _deleteResource();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Column(
+            children: [
+              Container(
+                child: widget.namespace != null
+                    ? Text(
+                        'Do you really want to delete ${widget.name} in namespace ${widget.namespace}?',
+                      )
+                    : Text(
+                        'Do you really want to delete ${widget.name}?',
+                      ),
               ),
-              child: widget.namespace != null
-                  ? Text(
-                      'Do you really want to delete ${widget.name} in namespace ${widget.namespace}?',
-                    )
-                  : Text(
-                      'Do you really want to delete ${widget.name}?',
-                    ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
+              const SizedBox(height: Constants.spacingMiddle),
+              Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
@@ -173,8 +173,8 @@ class _DetailsDeleteResourceState extends State<DetailsDeleteResource> {
                   ),
                 ],
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_edit_resource.dart
+++ b/lib/widgets/resources/details/details_edit_resource.dart
@@ -12,6 +12,7 @@ import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/services/helpers_service.dart';
 import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/showmodal.dart';
@@ -189,31 +190,28 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
         _save();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          physics: const ClampingScrollPhysics(),
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: CodeTheme(
-                data: CodeThemeData(
-                  styles:
-                      Theme.of(context).extension<EditorColors>()!.getTheme(),
-                ),
-                child: CodeField(
-                  controller: _codeController,
-                  enabled: true,
-                  textStyle: TextStyle(
-                    fontSize: 14,
-                    fontFamily: getMonospaceFontFamily(),
-                  ),
-                ),
+      child: SingleChildScrollView(
+        physics: const ClampingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: CodeTheme(
+            data: CodeThemeData(
+              styles: Theme.of(context).extension<EditorColors>()!.getTheme(),
+            ),
+            child: CodeField(
+              controller: _codeController,
+              enabled: true,
+              textStyle: TextStyle(
+                fontSize: 14,
+                fontFamily: getMonospaceFontFamily(),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_get_logs.dart
+++ b/lib/widgets/resources/details/details_get_logs.dart
@@ -100,7 +100,6 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
             final channel = IOWebSocketChannel.connect(
               'ws://localhost:14122/logs?name=${widget.names}&namespace=${widget.namespace}&container=$_container&since=$_since',
               headers: <String, dynamic>{
-                'X-CONTEXT-NAME': cluster.name,
                 'X-CLUSTER-SERVER': cluster.clusterServer,
                 'X-CLUSTER-CERTIFICATE-AUTHORITY-DATA':
                     cluster.clusterCertificateAuthorityData,
@@ -252,155 +251,143 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _logsFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Container'),
-                  DropdownButton(
-                    value: _container,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? value) {
-                      setState(() {
-                        _container = value ?? '';
-                      });
-                    },
-                    items: _containers.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Since'),
-                  DropdownButton(
-                    value: _since,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? value) {
-                      setState(() {
-                        _since = value ?? '';
-                      });
-                    },
-                    items: [
-                      '5 Minutes',
-                      '15 Minutes',
-                      '30 Minutes',
-                      '1 Hour',
-                      '3 Hours',
-                      '6 Hours',
-                      '12 Hours',
-                      '1 Day',
-                      '2 Days',
-                      '7 Days',
-                    ].map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Container'),
+                    DropdownButton(
+                      value: _container,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? value) {
+                        setState(() {
+                          _container = value ?? '';
+                        });
+                      },
+                      items: _containers.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _filterController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Filter',
+                        );
+                      }).toList(),
+                    ),
+                  ],
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Previous'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (value) {
-                      setState(() {
-                        _previous = !_previous;
-                      });
-                    },
-                    value: _previous,
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Since'),
+                    DropdownButton(
+                      value: _since,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? value) {
+                        setState(() {
+                          _since = value ?? '';
+                        });
+                      },
+                      items: [
+                        '5 Minutes',
+                        '15 Minutes',
+                        '30 Minutes',
+                        '1 Hour',
+                        '3 Hours',
+                        '6 Hours',
+                        '12 Hours',
+                        '1 Day',
+                        '2 Days',
+                        '7 Days',
+                      ].map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _filterController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Filter',
                   ),
-                ],
-              ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Previous'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _previous = !_previous;
+                        });
+                      },
+                      value: _previous,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Follow'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: widget.names.split(',').length > 1
+                          ? null
+                          : (value) {
+                              setState(() {
+                                _follow = !_follow;
+                              });
+                            },
+                      value: _follow,
+                    ),
+                  ],
+                ),
+              ],
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Follow'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: widget.names.split(',').length > 1
-                        ? null
-                        : (value) {
-                            setState(() {
-                              _follow = !_follow;
-                            });
-                          },
-                    value: _follow,
-                  ),
-                ],
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_get_logs_pods.dart
+++ b/lib/widgets/resources/details/details_get_logs_pods.dart
@@ -86,7 +86,7 @@ class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
     } catch (err) {
       Logger.log(
         'DetailsGetLogsPods _getPods',
-        'Could not get clusters',
+        'Could not get pods',
         err,
       );
       setState(() {
@@ -102,110 +102,80 @@ class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
   /// which can be selected by the user to add them to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.google.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load Pods',
+        details: _error,
+        icon: ClusterProviderType.google.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _pods.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(0),
+      separatorBuilder: (context, index) {
+        return const SizedBox(height: Constants.spacingMiddle);
+      },
+      itemCount: _pods.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedPods
+                    .where(
+                      (p) => p.metadata?.name == _pods[index].metadata?.name,
+                    )
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedPods.add(_pods[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedPods = _selectedPods
+                      .where(
+                        (p) => p.metadata?.name != _pods[index].metadata?.name,
+                      )
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                _pods[index].metadata?.name ?? '',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedPods
-                        .where(
-                          (p) =>
-                              p.metadata?.name == _pods[index].metadata?.name,
-                        )
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedPods.add(_pods[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedPods = _selectedPods
-                          .where(
-                            (p) =>
-                                p.metadata?.name != _pods[index].metadata?.name,
-                          )
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    _pods[index].metadata?.name ?? '',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -242,7 +212,17 @@ class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
         }
       },
       actionIsLoading: _isLoading,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/resources/details/details_item.dart
+++ b/lib/widgets/resources/details/details_item.dart
@@ -41,14 +41,12 @@ class DetailsItemWidget extends StatelessWidget {
     super.key,
     required this.title,
     required this.details,
-    this.smallPadding = false,
     this.goTo,
     this.goToOnTap,
   });
 
   final String title;
   final List<DetailsItemModel> details;
-  final bool smallPadding;
   final String? goTo;
   final void Function()? goToOnTap;
 
@@ -145,16 +143,7 @@ class DetailsItemWidget extends StatelessWidget {
     return Wrap(
       children: [
         Padding(
-          padding: EdgeInsets.only(
-            top: Constants.spacingMiddle,
-            left: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            right: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            bottom: Constants.spacingMiddle,
-          ),
+          padding: const EdgeInsets.all(Constants.spacingMiddle),
           child: Row(
             children: [
               Expanded(
@@ -169,13 +158,9 @@ class DetailsItemWidget extends StatelessWidget {
         ),
         Container(
           width: double.infinity,
-          margin: EdgeInsets.only(
-            left: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            right: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
+          margin: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
           ),
           padding: const EdgeInsets.all(Constants.spacingListItemContent),
           decoration: BoxDecoration(

--- a/lib/widgets/resources/details/details_item_additional_printer_columns.dart
+++ b/lib/widgets/resources/details/details_item_additional_printer_columns.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:kubenav/models/resource.dart';
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/resources/general.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/resources/details/details_item.dart';
@@ -50,9 +51,14 @@ class DetailsItemAdditionalPrinterColumns extends StatelessWidget {
       return Container();
     }
 
-    return DetailsItemWidget(
-      title: 'Additional Information',
-      details: _buildDetailsItems(context),
+    return Column(
+      children: [
+        const SizedBox(height: Constants.spacingMiddle),
+        DetailsItemWidget(
+          title: 'Additional Information',
+          details: _buildDetailsItems(context),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/resources/details/details_item_conditions.dart
+++ b/lib/widgets/resources/details/details_item_conditions.dart
@@ -27,11 +27,8 @@ class DetailsItemConditions extends StatelessWidget {
           Wrap(
             children: [
               Padding(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  left: Constants.spacingMiddle,
-                  right: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
+                padding: const EdgeInsets.all(
+                  Constants.spacingMiddle,
                 ),
                 child: Row(
                   children: [
@@ -54,7 +51,7 @@ class DetailsItemConditions extends StatelessWidget {
                   scrollDirection: Axis.horizontal,
                   crossAxisCount: 2,
                   childAspectRatio: 0.25,
-                  mainAxisSpacing: 16.0,
+                  mainAxisSpacing: Constants.spacingMiddle,
                   children: List.generate(
                     item['status']['conditions'].length,
                     (index) {

--- a/lib/widgets/resources/details/details_live_metrics.dart
+++ b/lib/widgets/resources/details/details_live_metrics.dart
@@ -239,39 +239,45 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
         length: 2,
         child: Column(
           children: [
-            SizedBox(
-              height: 32,
-              child: TabBar(
-                isScrollable: false,
-                tabAlignment: TabAlignment.fill,
-                labelColor: Theme.of(context).colorScheme.onPrimary,
-                unselectedLabelColor: Theme.of(context).colorScheme.primary,
-                labelPadding: EdgeInsets.zero,
-                indicatorPadding: const EdgeInsets.symmetric(horizontal: 5),
-                indicatorSize: TabBarIndicatorSize.tab,
-                indicator: BoxDecoration(
-                  borderRadius: BorderRadius.circular(
-                    Constants.sizeBorderRadius,
+            Padding(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: SizedBox(
+                height: 32,
+                child: TabBar(
+                  isScrollable: false,
+                  tabAlignment: TabAlignment.fill,
+                  labelColor: Theme.of(context).colorScheme.onPrimary,
+                  unselectedLabelColor: Theme.of(context).colorScheme.primary,
+                  labelPadding: EdgeInsets.zero,
+                  indicatorPadding: const EdgeInsets.symmetric(horizontal: 5),
+                  indicatorSize: TabBarIndicatorSize.tab,
+                  indicator: BoxDecoration(
+                    borderRadius: BorderRadius.circular(
+                      Constants.sizeBorderRadius,
+                    ),
+                    color: Theme.of(context).colorScheme.primary,
                   ),
-                  color: Theme.of(context).colorScheme.primary,
+                  tabs: const [
+                    Tab(text: 'CPU'),
+                    Tab(text: 'Memory'),
+                  ],
                 ),
-                tabs: const [
-                  Tab(text: 'CPU'),
-                  Tab(text: 'Memory'),
-                ],
               ),
             ),
-            const SizedBox(height: Constants.spacingMiddle),
             Expanded(
               child: TabBarView(
                 children: [
                   SingleChildScrollView(
                     child: Container(
                       margin: const EdgeInsets.only(
-                        top: Constants.spacingSmall,
                         bottom: Constants.spacingMiddle,
-                        left: Constants.spacingExtraSmall,
-                        right: Constants.spacingExtraSmall,
+                        left: Constants.spacingMiddle,
+                        right: Constants.spacingMiddle,
                       ),
                       padding: const EdgeInsets.all(
                         Constants.spacingListItemContent,
@@ -442,10 +448,9 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
                   SingleChildScrollView(
                     child: Container(
                       margin: const EdgeInsets.only(
-                        top: Constants.spacingSmall,
                         bottom: Constants.spacingMiddle,
-                        left: Constants.spacingExtraSmall,
-                        right: Constants.spacingExtraSmall,
+                        left: Constants.spacingMiddle,
+                        right: Constants.spacingMiddle,
                       ),
                       padding: const EdgeInsets.all(
                         Constants.spacingListItemContent,

--- a/lib/widgets/resources/details/details_restart_resource.dart
+++ b/lib/widgets/resources/details/details_restart_resource.dart
@@ -144,19 +144,17 @@ class _DetailsRestartResourceState extends State<DetailsRestartResource> {
         _restartResource();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'Do you really want to restart ${widget.name} in namespace ${widget.namespace}?',
-              ),
-            ),
-          ],
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to restart ${widget.name} in namespace ${widget.namespace}?',
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_scale_resource.dart
+++ b/lib/widgets/resources/details/details_scale_resource.dart
@@ -166,24 +166,21 @@ class _DetailsScaleResourceState extends State<DetailsScaleResource> {
         _scaleResource();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        key: _scaleFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Column(
+            children: [
+              Text(
                 'Change the number of replicas for ${widget.name} in namespace ${widget.namespace}:',
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
+              const SizedBox(height: Constants.spacingMiddle),
+              TextFormField(
                 controller: _replicasController,
                 keyboardType: TextInputType.number,
                 autocorrect: false,
@@ -195,8 +192,8 @@ class _DetailsScaleResourceState extends State<DetailsScaleResource> {
                 ),
                 validator: _validator,
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_show_yaml.dart
+++ b/lib/widgets/resources/details/details_show_yaml.dart
@@ -11,6 +11,7 @@ import 'package:provider/provider.dart';
 
 import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/services/helpers_service.dart';
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/showmodal.dart';
@@ -157,31 +158,28 @@ class _DetailsShowYamlState extends State<DetailsShowYaml> {
         _export();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          physics: const ClampingScrollPhysics(),
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: CodeTheme(
-                data: CodeThemeData(
-                  styles:
-                      Theme.of(context).extension<EditorColors>()!.getTheme(),
-                ),
-                child: CodeField(
-                  controller: _codeController,
-                  enabled: false,
-                  textStyle: TextStyle(
-                    fontSize: 14,
-                    fontFamily: getMonospaceFontFamily(),
-                  ),
-                ),
+      child: SingleChildScrollView(
+        physics: const ClampingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: CodeTheme(
+            data: CodeThemeData(
+              styles: Theme.of(context).extension<EditorColors>()!.getTheme(),
+            ),
+            child: CodeField(
+              controller: _codeController,
+              enabled: false,
+              textStyle: TextStyle(
+                fontSize: 14,
+                fontFamily: getMonospaceFontFamily(),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -72,7 +72,6 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
           final channel = IOWebSocketChannel.connect(
             'ws://localhost:14122/terminal?name=${widget.item['metadata']['name']}&namespace=${widget.item['metadata']['namespace']}&container=$_container&shell=$_shell',
             headers: <String, dynamic>{
-              'X-CONTEXT-NAME': cluster.name,
               'X-CLUSTER-SERVER': cluster.clusterServer,
               'X-CLUSTER-CERTIFICATE-AUTHORITY-DATA':
                   cluster.clusterCertificateAuthorityData,
@@ -181,89 +180,89 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _terminalFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Container'),
-                  DropdownButton(
-                    value: _container,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? value) {
-                      setState(() {
-                        _container = value ?? '';
-                      });
-                    },
-                    items: _containers.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Shell'),
-                  DropdownButton(
-                    value: _shell,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? value) {
-                      setState(() {
-                        _shell = value ?? 'sh';
-                      });
-                    },
-                    items: [
-                      'sh',
-                      'bash',
-                      'pwsh',
-                      'cmd',
-                    ].map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Container'),
+                    DropdownButton(
+                      value: _container,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? value) {
+                        setState(() {
+                          _container = value ?? '';
+                        });
+                      },
+                      items: _containers.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Shell'),
+                    DropdownButton(
+                      value: _shell,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? value) {
+                        setState(() {
+                          _shell = value ?? 'sh';
+                        });
+                      },
+                      items: [
+                        'sh',
+                        'bash',
+                        'pwsh',
+                        'cmd',
+                      ].map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/list/list_create_resource.dart
+++ b/lib/widgets/resources/list/list_create_resource.dart
@@ -13,6 +13,7 @@ import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/services/helpers_service.dart';
 import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/showmodal.dart';
@@ -205,30 +206,28 @@ class _ListCreateResourceState extends State<ListCreateResource> {
         _createResource();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: CodeTheme(
-                data: CodeThemeData(
-                  styles:
-                      Theme.of(context).extension<EditorColors>()!.getTheme(),
-                ),
-                child: CodeField(
-                  controller: _codeController,
-                  enabled: true,
-                  textStyle: TextStyle(
-                    fontSize: 14,
-                    fontFamily: getMonospaceFontFamily(),
-                  ),
-                ),
+      child: SingleChildScrollView(
+        physics: const ClampingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: CodeTheme(
+            data: CodeThemeData(
+              styles: Theme.of(context).extension<EditorColors>()!.getTheme(),
+            ),
+            child: CodeField(
+              controller: _codeController,
+              enabled: true,
+              textStyle: TextStyle(
+                fontSize: 14,
+                fontFamily: getMonospaceFontFamily(),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/resources/list/list_item.dart
+++ b/lib/widgets/resources/list/list_item.dart
@@ -109,66 +109,61 @@ class ListItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.only(
-        bottom: Constants.spacingMiddle,
-      ),
-      child: AppListItem(
-        onTap: () {
-          navigate(
-            context,
-            ResourcesDetails(
-              title: title,
-              resource: resource,
-              path: path,
-              scope: scope,
-              additionalPrinterColumns: additionalPrinterColumns,
-              name: name,
-              namespace: namespace,
-            ),
-          );
-        },
-        onDoubleTap: item == null
-            ? null
-            : () {
-                showActions(
-                  context,
-                  ListItemActions(
-                    title: title,
-                    resource: resource,
-                    path: path,
-                    scope: scope,
-                    additionalPrinterColumns: additionalPrinterColumns,
-                    name: name,
-                    namespace: namespace,
-                    item: item,
+    return AppListItem(
+      onTap: () {
+        navigate(
+          context,
+          ResourcesDetails(
+            title: title,
+            resource: resource,
+            path: path,
+            scope: scope,
+            additionalPrinterColumns: additionalPrinterColumns,
+            name: name,
+            namespace: namespace,
+          ),
+        );
+      },
+      onDoubleTap: item == null
+          ? null
+          : () {
+              showActions(
+                context,
+                ListItemActions(
+                  title: title,
+                  resource: resource,
+                  path: path,
+                  scope: scope,
+                  additionalPrinterColumns: additionalPrinterColumns,
+                  name: name,
+                  namespace: namespace,
+                  item: item,
+                ),
+              );
+            },
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  Characters(name)
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: primaryTextStyle(
+                    context,
                   ),
-                );
-              },
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    Characters(name)
-                        .replaceAll(Characters(''), Characters('\u{200B}'))
-                        .toString(),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: primaryTextStyle(
-                      context,
-                    ),
-                  ),
-                  buildInfo(context, info),
-                ],
-              ),
+                ),
+                buildInfo(context, info),
+              ],
             ),
-            buildStatus(context),
-          ],
-        ),
+          ),
+          buildStatus(context),
+        ],
       ),
     );
   }

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -596,7 +596,6 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
                             widget.namespace,
                             snapshot.data,
                           ),
-                          const SizedBox(height: Constants.spacingExtraLarge),
                         ],
                       );
                   }

--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -122,13 +122,14 @@ class Resources extends StatelessWidget {
 
     if (clustersRepository.clusters.isEmpty) {
       return [
-        const SizedBox(height: Constants.spacingSmall),
-        const AppNoClustersWidget(),
+        const Padding(
+          padding: EdgeInsets.all(Constants.spacingMiddle),
+          child: AppNoClustersWidget(),
+        ),
       ];
     }
 
     return [
-      const SizedBox(height: Constants.spacingSmall),
       const ResourcesBookmarksPreview(),
       AppVertialListSimpleWidget(
         title: 'Workloads',
@@ -137,6 +138,7 @@ class Resources extends StatelessWidget {
           resource_model.ResourceType.workload,
         ),
       ),
+      const SizedBox(height: Constants.spacingMiddle),
       AppVertialListSimpleWidget(
         title: 'Discovery and Load Balancing',
         items: getItems(
@@ -144,6 +146,7 @@ class Resources extends StatelessWidget {
           resource_model.ResourceType.discoveryandloadbalancing,
         ),
       ),
+      const SizedBox(height: Constants.spacingMiddle),
       AppVertialListSimpleWidget(
         title: 'Config and Storage',
         items: getItems(
@@ -151,6 +154,7 @@ class Resources extends StatelessWidget {
           resource_model.ResourceType.configandstorage,
         ),
       ),
+      const SizedBox(height: Constants.spacingMiddle),
       AppVertialListSimpleWidget(
         title: 'RBAC',
         items: getItems(
@@ -158,6 +162,7 @@ class Resources extends StatelessWidget {
           resource_model.ResourceType.rbac,
         ),
       ),
+      const SizedBox(height: Constants.spacingMiddle),
       AppVertialListSimpleWidget(
         title: 'Cluster',
         items: getItems(
@@ -165,6 +170,7 @@ class Resources extends StatelessWidget {
           resource_model.ResourceType.cluster,
         ),
       ),
+      const SizedBox(height: Constants.spacingMiddle),
     ];
   }
 

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -552,12 +552,16 @@ class _ResourcesListState extends State<ResourcesList> {
                               top: Constants.spacingMiddle,
                               bottom: Constants.spacingMiddle,
                             ),
-                            child: ListView.builder(
+                            child: ListView.separated(
                               shrinkWrap: true,
                               physics: const NeverScrollableScrollPhysics(),
                               padding: const EdgeInsets.only(
                                 right: Constants.spacingMiddle,
                                 left: Constants.spacingMiddle,
+                              ),
+                              separatorBuilder: (context, index) =>
+                                  const SizedBox(
+                                height: Constants.spacingMiddle,
                               ),
                               itemCount: filteredItems.length,
                               itemBuilder: (context, index) {

--- a/lib/widgets/resources/resources_list_crds.dart
+++ b/lib/widgets/resources/resources_list_crds.dart
@@ -274,11 +274,8 @@ class _ResourcesListCRDsState extends State<ResourcesListCRDs> {
                       return Wrap(
                         children: [
                           Container(
-                            padding: const EdgeInsets.only(
-                              top: Constants.spacingMiddle,
-                              bottom: Constants.spacingMiddle,
-                              left: Constants.spacingMiddle,
-                              right: Constants.spacingMiddle,
+                            padding: const EdgeInsets.all(
+                              Constants.spacingMiddle,
                             ),
                             color: Theme.of(context).colorScheme.primary,
                             child: TextField(

--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -150,104 +150,77 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
   /// list, where the user can select the clusters he wants to add to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.aws.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.aws.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -271,7 +244,17 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -155,104 +155,77 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
   /// displayed.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.awssso.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.awssso.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                'aws_${widget.provider.awssso?.region}_${_clusters[index].name}',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    'aws_${widget.provider.awssso?.region}_${_clusters[index].name}',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -276,7 +249,17 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
@@ -139,104 +139,77 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
   /// can select the clusters he wants to add to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.azure.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.azure.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                _clusters[index].name ?? '',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    _clusters[index].name ?? '',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -260,7 +233,17 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
@@ -157,104 +157,77 @@ class _SettingsAddClusterDigitalOceanState
   /// to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.digitalocean.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.digitalocean.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                _clusters[index].name ?? '',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    _clusters[index].name ?? '',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -278,7 +251,17 @@ class _SettingsAddClusterDigitalOceanState
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_add_cluster_google.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_google.dart
@@ -148,104 +148,77 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
   /// which can be selected by the user to add them to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.google.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.google.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(
+                'gke_${_clusters[index].location}_${_clusters[index].name}',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(
-                    'gke_${_clusters[index].location}_${_clusters[index].name}',
-                  )
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -269,7 +242,17 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_add_cluster_kubeconfig.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_kubeconfig.dart
@@ -153,83 +153,78 @@ class _SettingsAddClusterKubeconfigState
       actionIsLoading: _isLoadingAddCluster,
       child: Form(
         key: _addClusterKubeconfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
-                    ),
-                  ),
-                ),
-                onPressed: () {
-                  _selectKubeconfigFile();
-                },
-                child: Text(
-                  'Select Kubeconfig',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.only(
-                top: Constants.spacingMiddle,
-                bottom: Constants.spacingMiddle,
-              ),
-              child: Row(
-                children: [
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
+            child: Column(
+              children: [
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                  Text(
-                    'or paste content',
-                    style: secondaryTextStyle(
+                  onPressed: () {
+                    _selectKubeconfigFile();
+                  },
+                  child: Text(
+                    'Select Kubeconfig',
+                    style: primaryTextStyle(
                       context,
+                      color: Theme.of(context).colorScheme.onPrimary,
                     ),
+                    textAlign: TextAlign.center,
                   ),
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 8,
-              ),
-              child: TextFormField(
-                controller: _kubeconfigController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Kubeconfig',
                 ),
-                validator: _validator,
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                    Text(
+                      'or paste content',
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _kubeconfigController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Kubeconfig',
+                  ),
+                  validator: _validator,
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/clusters/settings_add_cluster_manual.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_manual.dart
@@ -144,178 +144,146 @@ class _SettingsAddClusterManualState extends State<SettingsAddClusterManual> {
       actionIsLoading: _isLoadingAddCluster,
       child: Form(
         key: _addClusterManualFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterServerController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Server',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterCertificateAuthorityDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Certificate Authority Data',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Insecure Skip TLS Verify'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (val) => {
-                      setState(() {
-                        _clusterInsecureSkipTLSVerify =
-                            !_clusterInsecureSkipTLSVerify;
-                      }),
-                    },
-                    value: _clusterInsecureSkipTLSVerify,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userClientCertificateDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Certificate Data',
+                  validator: _validator,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userClientKeyDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Key Data',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterServerController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Server',
+                  ),
+                  validator: _validator,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userTokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Token',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterCertificateAuthorityDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Certificate Authority Data',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userUsernameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Username',
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Insecure Skip TLS Verify'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (val) => {
+                        setState(() {
+                          _clusterInsecureSkipTLSVerify =
+                              !_clusterInsecureSkipTLSVerify;
+                        }),
+                      },
+                      value: _clusterInsecureSkipTLSVerify,
+                    ),
+                  ],
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userPasswordController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Password',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userClientCertificateDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Certificate Data',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _namespaceController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Namespace',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userClientKeyDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Key Data',
+                  ),
                 ),
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userTokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Token',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userUsernameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Username',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userPasswordController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Password',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _namespaceController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Namespace',
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/clusters/settings_add_cluster_oidc.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_oidc.dart
@@ -126,98 +126,86 @@ class _SettingsAddClusterOIDCState extends State<SettingsAddClusterOIDC> {
       actionIsLoading: _isLoadingAddCluster,
       child: Form(
         key: _addClusterOIDCFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterServerController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Server',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterCertificateAuthorityDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Certificate Authority Data',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Insecure Skip TLS Verify'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (value) {
-                      setState(() {
-                        _clusterInsecureSkipTLSVerify =
-                            !_clusterInsecureSkipTLSVerify;
-                      });
-                    },
-                    value: _clusterInsecureSkipTLSVerify,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _namespaceController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Namespace',
+                  validator: _validator,
                 ),
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterServerController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Server',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterCertificateAuthorityDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Certificate Authority Data',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Insecure Skip TLS Verify'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _clusterInsecureSkipTLSVerify =
+                              !_clusterInsecureSkipTLSVerify;
+                        });
+                      },
+                      value: _clusterInsecureSkipTLSVerify,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _namespaceController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Namespace',
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/clusters/settings_add_cluster_rancher.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_rancher.dart
@@ -147,102 +147,77 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
   /// which can be selected by the user to add them to the app.
   Widget _buildContent() {
     if (_isLoading) {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ],
-            ),
-          ),
-        ],
+      return CircularProgressIndicator(
+        color: Theme.of(context).colorScheme.primary,
       );
     }
 
     if (_error != '') {
-      return Flex(
-        direction: Axis.vertical,
-        children: [
-          Expanded(
-            child: Wrap(
-              children: [
-                AppErrorWidget(
-                  message: 'Could not load clusters',
-                  details: _error,
-                  icon: ClusterProviderType.rancher.icon(),
-                ),
-              ],
-            ),
-          ),
-        ],
+      return AppErrorWidget(
+        message: 'Could not load clusters',
+        details: _error,
+        icon: ClusterProviderType.rancher.icon(),
       );
     }
 
-    return ListView(
-      children: [
-        ...List.generate(
-          _clusters.length,
-          (index) {
-            return Container(
-              margin: const EdgeInsets.only(
-                top: Constants.spacingSmall,
-                bottom: Constants.spacingSmall,
-                left: Constants.spacingExtraSmall,
-                right: Constants.spacingExtraSmall,
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      separatorBuilder: (context, index) {
+        return const SizedBox(
+          height: Constants.spacingMiddle,
+        );
+      },
+      itemCount: _clusters.length,
+      itemBuilder: (context, index) {
+        return Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).extension<CustomColors>()!.shadow,
+                blurRadius: Constants.sizeBorderBlurRadius,
+                spreadRadius: Constants.sizeBorderSpreadRadius,
+                offset: const Offset(0.0, 0.0),
               ),
-              decoration: BoxDecoration(
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(context).extension<CustomColors>()!.shadow,
-                    blurRadius: Constants.sizeBorderBlurRadius,
-                    spreadRadius: Constants.sizeBorderSpreadRadius,
-                    offset: const Offset(0.0, 0.0),
-                  ),
-                ],
-                color: Theme.of(context).colorScheme.background,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
+            ],
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(Constants.sizeBorderRadius),
+            ),
+          ),
+          child: CheckboxListTile(
+            controlAffinity: ListTileControlAffinity.leading,
+            value: _selectedClusters
+                    .where((c) => c.name == _clusters[index].name)
+                    .toList()
+                    .length ==
+                1,
+            onChanged: (bool? value) {
+              if (value == true) {
+                setState(() {
+                  _selectedClusters.add(_clusters[index]);
+                });
+              }
+              if (value == false) {
+                setState(() {
+                  _selectedClusters = _selectedClusters
+                      .where((c) => c.name != _clusters[index].name)
+                      .toList();
+                });
+              }
+            },
+            title: Text(
+              Characters(_clusters[index].name ?? '')
+                  .replaceAll(Characters(''), Characters('\u{200B}'))
+                  .toString(),
+              style: noramlTextStyle(
+                context,
               ),
-              child: CheckboxListTile(
-                controlAffinity: ListTileControlAffinity.leading,
-                value: _selectedClusters
-                        .where((c) => c.name == _clusters[index].name)
-                        .toList()
-                        .length ==
-                    1,
-                onChanged: (bool? value) {
-                  if (value == true) {
-                    setState(() {
-                      _selectedClusters.add(_clusters[index]);
-                    });
-                  }
-                  if (value == false) {
-                    setState(() {
-                      _selectedClusters = _selectedClusters
-                          .where((c) => c.name != _clusters[index].name)
-                          .toList();
-                    });
-                  }
-                },
-                title: Text(
-                  Characters(_clusters[index].name ?? '')
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-        ),
-      ],
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -266,7 +241,17 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
         _addClusters();
       },
       actionIsLoading: _isLoading || _isLoadingAddCluster,
-      child: _buildContent(),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: _buildContent(),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -93,8 +93,7 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.only(
-        top: Constants.spacingSmall,
-        bottom: Constants.spacingSmall,
+        bottom: Constants.spacingMiddle,
         left: Constants.spacingMiddle,
         right: Constants.spacingMiddle,
       ),

--- a/lib/widgets/settings/clusters/settings_edit_cluster.dart
+++ b/lib/widgets/settings/clusters/settings_edit_cluster.dart
@@ -158,178 +158,146 @@ class _SettingsEditClusterState extends State<SettingsEditCluster> {
       actionIsLoading: _isLoadingAddCluster,
       child: Form(
         key: _editClusterFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterServerController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Server',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clusterCertificateAuthorityDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Certificate Authority Data',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Insecure Skip TLS Verify'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (value) {
-                      setState(() {
-                        _clusterInsecureSkipTLSVerify =
-                            !_clusterInsecureSkipTLSVerify;
-                      });
-                    },
-                    value: _clusterInsecureSkipTLSVerify,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userClientCertificateDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Certificate Data',
+                  validator: _validator,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userClientKeyDataController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Key Data',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterServerController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Server',
+                  ),
+                  validator: _validator,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userTokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Token',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clusterCertificateAuthorityDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Certificate Authority Data',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userUsernameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Username',
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Insecure Skip TLS Verify'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _clusterInsecureSkipTLSVerify =
+                              !_clusterInsecureSkipTLSVerify;
+                        });
+                      },
+                      value: _clusterInsecureSkipTLSVerify,
+                    ),
+                  ],
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _userPasswordController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Password',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userClientCertificateDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Certificate Data',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _namespaceController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Namespace',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userClientKeyDataController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Key Data',
+                  ),
                 ),
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userTokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Token',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userUsernameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Username',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _userPasswordController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Password',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _namespaceController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Namespace',
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/namespaces/settings_add_namespace.dart
+++ b/lib/widgets/settings/namespaces/settings_add_namespace.dart
@@ -55,35 +55,39 @@ class _SettingsAddNamespaceState extends State<SettingsAddNamespace> {
       actionIsLoading: false,
       child: Form(
         key: _namespaceFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'Enter the name of one of your favorite namespaces for quick access:',
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _namespaceController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Namespace',
+            child: Column(
+              children: [
+                const Text(
+                  'Enter the name of one of your favorite namespaces for quick access:',
                 ),
-                validator: _validator,
-              ),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    top: Constants.spacingMiddle,
+                  ),
+                  child: TextFormField(
+                    controller: _namespaceController,
+                    keyboardType: TextInputType.text,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                    maxLines: 1,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Namespace',
+                    ),
+                    validator: _validator,
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_aws_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_aws_provider_config.dart
@@ -154,130 +154,114 @@ class _SettingsAWSProviderState extends State<SettingsAWSProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _accessKeyIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Access Key ID',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _secretKeyController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Secret Key',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Region'),
-                  DropdownButton(
-                    value: _region,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        _region = newValue ?? '';
-                      });
-                    },
-                    items: awsRegions.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
-                          ),
-                        ),
-                      );
-                    }).toList(),
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _sessionTokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Session Token (optional)',
+                  validator: _validator,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _roleArnController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Role ARN (optional)',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _accessKeyIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Access Key ID',
+                  ),
+                  validator: _validator,
                 ),
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _secretKeyController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Secret Key',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Region'),
+                    DropdownButton(
+                      value: _region,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? newValue) {
+                        setState(() {
+                          _region = newValue ?? '';
+                        });
+                      },
+                      items: awsRegions.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _sessionTokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Session Token (optional)',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _roleArnController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Role ARN (optional)',
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
@@ -165,116 +165,108 @@ class _SettingsAWSSSOMultipleProvidersState
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _startURLController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Start URL',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('SSO Region'),
-                  DropdownButton(
-                    value: _ssoRegion,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        _ssoRegion = newValue ?? '';
-                      });
-                    },
-                    items: awsRegions.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _startURLController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Start URL',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('SSO Region'),
+                    DropdownButton(
+                      value: _ssoRegion,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? newValue) {
+                        setState(() {
+                          _ssoRegion = newValue ?? '';
+                        });
+                      },
+                      items: awsRegions.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _startSSOFlow,
-                child: Text(
-                  'Sign In',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _startSSOFlow,
+                  child: Text(
+                    'Sign In',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _awsSSOConfig == null ? null : _verifyDevice,
-                child: Text(
-                  'Verify',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _awsSSOConfig == null ? null : _verifyDevice,
+                  child: Text(
+                    'Verify',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
@@ -149,11 +149,24 @@ class _SettingsAWSSSOMultipleProvidersSelectState
         _addProviders();
       },
       actionIsLoading: _isLoading,
-      child: ListView(
-        children: [
-          ...List.generate(
-            widget.accounts.length,
-            (accountIndex) {
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            separatorBuilder: (context, index) {
+              return const SizedBox(
+                height: Constants.spacingMiddle,
+              );
+            },
+            itemCount: widget.accounts.length,
+            itemBuilder: (context, accountIndex) {
               return Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -170,113 +183,106 @@ class _SettingsAWSSSOMultipleProvidersSelectState
                       style: primaryTextStyle(context),
                     ),
                   ),
-                  ListView(
+                  ListView.separated(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    children: [
-                      ...List.generate(
-                        widget.accounts[accountIndex].roles?.length ?? 0,
-                        (roleIndex) {
-                          return Container(
-                            margin: const EdgeInsets.only(
-                              top: Constants.spacingSmall,
-                              bottom: Constants.spacingSmall,
-                              left: Constants.spacingExtraSmall,
-                              right: Constants.spacingExtraSmall,
+                    separatorBuilder: (context, index) {
+                      return const SizedBox(
+                        height: Constants.spacingMiddle,
+                      );
+                    },
+                    itemCount: widget.accounts[accountIndex].roles?.length ?? 0,
+                    itemBuilder: (context, roleIndex) {
+                      return Container(
+                        decoration: BoxDecoration(
+                          boxShadow: [
+                            BoxShadow(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .shadow,
+                              blurRadius: Constants.sizeBorderBlurRadius,
+                              spreadRadius: Constants.sizeBorderSpreadRadius,
+                              offset: const Offset(0.0, 0.0),
                             ),
-                            decoration: BoxDecoration(
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Theme.of(context)
-                                      .extension<CustomColors>()!
-                                      .shadow,
-                                  blurRadius: Constants.sizeBorderBlurRadius,
-                                  spreadRadius:
-                                      Constants.sizeBorderSpreadRadius,
-                                  offset: const Offset(0.0, 0.0),
-                                ),
-                              ],
-                              color: Theme.of(context).colorScheme.background,
-                              borderRadius: const BorderRadius.all(
-                                Radius.circular(Constants.sizeBorderRadius),
-                              ),
-                            ),
-                            child: CheckboxListTile(
-                              controlAffinity: ListTileControlAffinity.leading,
-                              value: _selectedAccounts
-                                      .where(
-                                        (a) =>
-                                            a.accountId ==
-                                                widget.accounts[accountIndex]
-                                                    .accountId &&
-                                            a.role ==
-                                                widget.accounts[accountIndex]
-                                                    .roles![roleIndex],
-                                      )
-                                      .toList()
-                                      .length ==
-                                  1,
-                              onChanged: (bool? value) {
-                                if (value == true) {
-                                  setState(() {
-                                    _selectedAccounts.add(
-                                      SelectedAWSSSOAccount(
-                                        accountId: widget
-                                            .accounts[accountIndex].accountId,
-                                        accountName: widget
-                                            .accounts[accountIndex].accountName,
-                                        role: widget.accounts[accountIndex]
-                                            .roles![roleIndex],
-                                        accessToken: widget
-                                            .accounts[accountIndex].accessToken,
-                                        accessTokenExpire: widget
-                                            .accounts[accountIndex]
-                                            .accessTokenExpire,
-                                      ),
-                                    );
-                                  });
-                                }
-                                if (value == false) {
-                                  setState(() {
-                                    _selectedAccounts = _selectedAccounts
-                                        .where(
-                                          (a) => !(a.accountId ==
-                                                  widget.accounts[accountIndex]
-                                                      .accountId &&
-                                              a.role ==
-                                                  widget.accounts[accountIndex]
-                                                      .roles![roleIndex]),
-                                        )
-                                        .toList();
-                                  });
-                                }
-                              },
-                              title: Text(
-                                Characters(
-                                  widget
-                                      .accounts[accountIndex].roles![roleIndex],
-                                )
-                                    .replaceAll(
-                                      Characters(''),
-                                      Characters('\u{200B}'),
+                          ],
+                          color: Theme.of(context).colorScheme.background,
+                          borderRadius: const BorderRadius.all(
+                            Radius.circular(Constants.sizeBorderRadius),
+                          ),
+                        ),
+                        child: CheckboxListTile(
+                          controlAffinity: ListTileControlAffinity.leading,
+                          value: _selectedAccounts
+                                  .where(
+                                    (a) =>
+                                        a.accountId ==
+                                            widget.accounts[accountIndex]
+                                                .accountId &&
+                                        a.role ==
+                                            widget.accounts[accountIndex]
+                                                .roles![roleIndex],
+                                  )
+                                  .toList()
+                                  .length ==
+                              1,
+                          onChanged: (bool? value) {
+                            if (value == true) {
+                              setState(() {
+                                _selectedAccounts.add(
+                                  SelectedAWSSSOAccount(
+                                    accountId:
+                                        widget.accounts[accountIndex].accountId,
+                                    accountName: widget
+                                        .accounts[accountIndex].accountName,
+                                    role: widget.accounts[accountIndex]
+                                        .roles![roleIndex],
+                                    accessToken: widget
+                                        .accounts[accountIndex].accessToken,
+                                    accessTokenExpire: widget
+                                        .accounts[accountIndex]
+                                        .accessTokenExpire,
+                                  ),
+                                );
+                              });
+                            }
+                            if (value == false) {
+                              setState(() {
+                                _selectedAccounts = _selectedAccounts
+                                    .where(
+                                      (a) => !(a.accountId ==
+                                              widget.accounts[accountIndex]
+                                                  .accountId &&
+                                          a.role ==
+                                              widget.accounts[accountIndex]
+                                                  .roles![roleIndex]),
                                     )
-                                    .toString(),
-                                style: noramlTextStyle(
-                                  context,
-                                ),
-                                overflow: TextOverflow.ellipsis,
-                              ),
+                                    .toList();
+                              });
+                            }
+                          },
+                          title: Text(
+                            Characters(
+                              widget.accounts[accountIndex].roles![roleIndex],
+                            )
+                                .replaceAll(
+                                  Characters(''),
+                                  Characters('\u{200B}'),
+                                )
+                                .toString(),
+                            style: noramlTextStyle(
+                              context,
                             ),
-                          );
-                        },
-                      ),
-                    ],
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      );
+                    },
                   ),
                 ],
               );
             },
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/widgets/settings/providers/settings_awssso_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_provider_config.dart
@@ -266,232 +266,204 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _startURLController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Start URL',
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _accountIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Account ID',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _startURLController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Start URL',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _roleNameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Role Name',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _accountIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Account ID',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('SSO Region'),
-                  DropdownButton(
-                    value: _ssoRegion,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        _ssoRegion = newValue ?? '';
-                      });
-                    },
-                    items: awsRegions.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _roleNameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Role Name',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('SSO Region'),
+                    DropdownButton(
+                      value: _ssoRegion,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? newValue) {
+                        setState(() {
+                          _ssoRegion = newValue ?? '';
+                        });
+                      },
+                      items: awsRegions.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Region'),
-                  DropdownButton(
-                    value: _region,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
+                        );
+                      }).toList(),
                     ),
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        _region = newValue ?? '';
-                      });
-                    },
-                    items: awsRegions.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Region'),
+                    DropdownButton(
+                      value: _region,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? newValue) {
+                        setState(() {
+                          _region = newValue ?? '';
+                        });
+                      },
+                      items: awsRegions.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value,
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _startSSOFlow,
-                child: Text(
-                  'Sign In',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _startSSOFlow,
+                  child: Text(
+                    'Sign In',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _awsSSOConfig == null ? null : _verifyDevice,
-                child: Text(
-                  'Verify',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _awsSSOConfig == null ? null : _verifyDevice,
+                  child: Text(
+                    'Verify',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _awsSSOConfig == null || !_verified
-                    ? null
-                    : _getSSOCredentials,
-                child: Text(
-                  'Get Credentials',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _awsSSOConfig == null || !_verified
+                      ? null
+                      : _getSSOCredentials,
+                  child: Text(
+                    'Get Credentials',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_azure_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_azure_provider_config.dart
@@ -153,116 +153,100 @@ class _SettingsAzureProviderState extends State<SettingsAzureProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _subscriptionIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Subscription ID',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _tenantIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Tenant ID',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clientIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client ID',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clientSecretController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Secret',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Admin'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (val) {
-                      setState(() {
-                        _isAdmin = !_isAdmin;
-                      });
-                    },
-                    value: _isAdmin,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _subscriptionIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Subscription ID',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _tenantIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Tenant ID',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clientIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client ID',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clientSecretController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Secret',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Admin'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (val) {
+                        setState(() {
+                          _isAdmin = !_isAdmin;
+                        });
+                      },
+                      value: _isAdmin,
+                    ),
+                  ],
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_digitalocean_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_digitalocean_provider_config.dart
@@ -141,44 +141,44 @@ class _SettingsDigitalOceanProviderState
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _tokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'API Token',
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _tokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'API Token',
+                  ),
+                  validator: _validator,
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_google_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_google_provider_config.dart
@@ -214,121 +214,105 @@ class _SettingsGoogleProviderState extends State<SettingsGoogleProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clientIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client ID',
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clientSecretController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client Secret',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clientIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client ID',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _redirectURLController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Redirect URL',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clientSecretController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client Secret',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _redirectURLController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Redirect URL',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _signIn,
-                child: Text(
-                  'Sign In',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _signIn,
+                  child: Text(
+                    'Sign In',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _codeController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Code',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _codeController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Code',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_oidc_provider_config.dart
@@ -393,8 +393,8 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   Widget _buildPkceMethod() {
     if (_pkceMethod == '') {
       return Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
+        padding: const EdgeInsets.only(
+          top: Constants.spacingMiddle,
         ),
         child: TextFormField(
           controller: _clientSecretController,
@@ -416,77 +416,61 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   List<Widget> _buildDeviceAuth() {
     if (_deviceAuthData != null) {
       return [
-        const Padding(
-          padding: EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
+        const SizedBox(height: Constants.spacingMiddle),
+        const Text(
+          'Copy the code shown in the input field from below and click the verify button to verify your device.',
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+        TextFormField(
+          initialValue: _deviceAuthData?.userCode ?? '',
+          keyboardType: TextInputType.text,
+          autocorrect: false,
+          enableSuggestions: false,
+          maxLines: 1,
+          readOnly: true,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Code',
           ),
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            minimumSize: const Size.fromHeight(40),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(
+                Constants.sizeBorderRadius,
+              ),
+            ),
+          ),
+          onPressed: _verifyDeviceFlow,
           child: Text(
-            'Copy the code shown in the input field from below and click the verify button to verify your device.',
+            'Verify',
+            style: primaryTextStyle(
+              context,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            textAlign: TextAlign.center,
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
-          ),
-          child: TextFormField(
-            initialValue: _deviceAuthData?.userCode ?? '',
-            keyboardType: TextInputType.text,
-            autocorrect: false,
-            enableSuggestions: false,
-            maxLines: 1,
-            readOnly: true,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              labelText: 'Code',
+        const SizedBox(height: Constants.spacingMiddle),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Text('Use Access Token instead of ID Token'),
+            Switch(
+              activeColor: Theme.of(context).colorScheme.primary,
+              onChanged: (val) => {
+                setState(() {
+                  _useAccessToken = !_useAccessToken;
+                }),
+              },
+              value: _useAccessToken,
             ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
-          ),
-          child: ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              minimumSize: const Size.fromHeight(40),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(
-                  Constants.sizeBorderRadius,
-                ),
-              ),
-            ),
-            onPressed: _verifyDeviceFlow,
-            child: Text(
-              'Verify',
-              style: primaryTextStyle(
-                context,
-                color: Theme.of(context).colorScheme.onPrimary,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const Text('Use Access Token instead of ID Token'),
-              Switch(
-                activeColor: Theme.of(context).colorScheme.primary,
-                onChanged: (val) => {
-                  setState(() {
-                    _useAccessToken = !_useAccessToken;
-                  }),
-                },
-                value: _useAccessToken,
-              ),
-            ],
-          ),
+          ],
         ),
       ];
     } else {
@@ -500,46 +484,38 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   List<Widget> _buildFormForFlow() {
     if (_flow == OIDCFlow.device) {
       return [
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
-          ),
-          child: TextFormField(
-            controller: _scopesController,
-            keyboardType: TextInputType.text,
-            autocorrect: false,
-            enableSuggestions: false,
-            maxLines: 1,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              labelText: 'Scopes (optional)',
-            ),
+        const SizedBox(height: Constants.spacingMiddle),
+        TextFormField(
+          controller: _scopesController,
+          keyboardType: TextInputType.text,
+          autocorrect: false,
+          enableSuggestions: false,
+          maxLines: 1,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Scopes (optional)',
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: Constants.spacingSmall,
+        const SizedBox(height: Constants.spacingMiddle),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            minimumSize: const Size.fromHeight(40),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(
+                Constants.sizeBorderRadius,
+              ),
+            ),
           ),
-          child: ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              minimumSize: const Size.fromHeight(40),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(
-                  Constants.sizeBorderRadius,
-                ),
-              ),
+          onPressed: _initDeviceFlow,
+          child: Text(
+            'Initialize Device Flow',
+            style: primaryTextStyle(
+              context,
+              color: Theme.of(context).colorScheme.onPrimary,
             ),
-            onPressed: _initDeviceFlow,
-            child: Text(
-              'Initialize Device Flow',
-              style: primaryTextStyle(
-                context,
-                color: Theme.of(context).colorScheme.onPrimary,
-              ),
-              textAlign: TextAlign.center,
-            ),
+            textAlign: TextAlign.center,
           ),
         ),
         ..._buildDeviceAuth(),
@@ -771,99 +747,91 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Authentication Flow'),
-                  DropdownButton(
-                    value: _flow,
-                    underline: Container(
-                      height: 2,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onChanged: (OIDCFlow? newValue) {
-                      setState(() {
-                        _flow = newValue ?? OIDCFlow.standard;
-                      });
-                    },
-                    items: OIDCFlow.values.map((value) {
-                      return DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value.pretty(),
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
-                          ),
-                        ),
-                      );
-                    }).toList(),
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _discoveryURLController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Discovery URL',
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _clientIDController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Client ID',
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Authentication Flow'),
+                    DropdownButton(
+                      value: _flow,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (OIDCFlow? newValue) {
+                        setState(() {
+                          _flow = newValue ?? OIDCFlow.standard;
+                        });
+                      },
+                      items: OIDCFlow.values.map((value) {
+                        return DropdownMenuItem(
+                          value: value,
+                          child: Text(
+                            value.pretty(),
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ],
                 ),
-                validator: _validator,
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _discoveryURLController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Discovery URL',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _clientIDController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Client ID',
+                  ),
+                  validator: _validator,
+                ),
+                ..._buildFormForFlow(),
+              ],
             ),
-            ..._buildFormForFlow(),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/providers/settings_rancher_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_rancher_provider_config.dart
@@ -196,142 +196,123 @@ class _SettingsRancherProviderState extends State<SettingsRancherProvider> {
       actionIsLoading: _isLoading,
       child: Form(
         key: _providerConfigFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _nameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Name',
-                ),
-                validator: _validator,
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _serverAddressController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Server Address',
-                ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Allow Insecure Connections'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (value) {
-                      setState(() {
-                        _allowInsecureConnections = !_allowInsecureConnections;
-                      });
-                    },
-                    value: _allowInsecureConnections,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Name',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _usernameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Username',
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _passwordController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Password',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _serverAddressController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Server Address',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                  minimumSize: const Size.fromHeight(40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      Constants.sizeBorderRadius,
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Allow Insecure Connections'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _allowInsecureConnections =
+                              !_allowInsecureConnections;
+                        });
+                      },
+                      value: _allowInsecureConnections,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _usernameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Username',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _passwordController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Password',
+                  ),
+                  validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
                     ),
                   ),
-                ),
-                onPressed: _signIn,
-                child: Text(
-                  'Sign In',
-                  style: primaryTextStyle(
-                    context,
-                    color: Theme.of(context).colorScheme.onPrimary,
+                  onPressed: _signIn,
+                  child: Text(
+                    'Sign In',
+                    style: primaryTextStyle(
+                      context,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _tokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Token (optional)',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _tokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Token (optional)',
+                  ),
+                  validator: _validator,
                 ),
-                validator: _validator,
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -49,7 +49,13 @@ class Settings extends StatelessWidget {
     );
 
     if (clustersRepository.clusters.isEmpty) {
-      return const AppNoClustersWidget();
+      return const Padding(
+        padding: EdgeInsets.only(
+          left: Constants.spacingMiddle,
+          right: Constants.spacingMiddle,
+        ),
+        child: AppNoClustersWidget(),
+      );
     }
 
     int maxClusters = 6;
@@ -64,7 +70,7 @@ class Settings extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         crossAxisCount: 2,
         childAspectRatio: 0.25,
-        mainAxisSpacing: 16.0,
+        mainAxisSpacing: Constants.spacingMiddle,
         children: List.generate(
           clustersRepository.clusters.length <= maxClusters
               ? clustersRepository.clusters.length
@@ -119,11 +125,8 @@ class Settings extends StatelessWidget {
   /// page, where a user can add more clusters or reorder his existing clusters.
   Widget _buildViewAllClusters(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(
-        top: Constants.spacingMiddle,
-        left: Constants.spacingMiddle,
-        right: Constants.spacingMiddle,
-        bottom: Constants.spacingSmall,
+      padding: const EdgeInsets.all(
+        Constants.spacingMiddle,
       ),
       child: Row(
         children: [
@@ -278,10 +281,10 @@ class Settings extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              const SizedBox(height: Constants.spacingSmall),
               const SettingsSponsorBanner(),
               _buildViewAllClusters(context),
               _buildClusters(context),
+              const SizedBox(height: Constants.spacingMiddle),
               AppVertialListSimpleWidget(
                 title: 'Settings',
                 items: [
@@ -588,8 +591,11 @@ class Settings extends StatelessWidget {
                   ),
                 ],
               ),
+              const SizedBox(height: Constants.spacingMiddle),
               const SettingsSponsor(),
+              const SizedBox(height: Constants.spacingMiddle),
               buildHelp(context),
+              const SizedBox(height: Constants.spacingMiddle),
               const SettingsInfo(),
               const SizedBox(height: Constants.spacingMiddle),
             ],

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -310,25 +310,22 @@ class _SettingsInfoState extends State<SettingsInfo> {
                   Navigator.pop(context);
                 },
                 actionIsLoading: false,
-                child: Form(
-                  key: const Key('settings/license'),
-                  child: ListView(
-                    shrinkWrap: false,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: 8,
-                        ),
-                        child: Text(
-                          licenseText,
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .textPrimary,
-                          ),
-                        ),
+                child: SingleChildScrollView(
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                      top: Constants.spacingMiddle,
+                      bottom: Constants.spacingMiddle,
+                      left: Constants.spacingMiddle,
+                      right: Constants.spacingMiddle,
+                    ),
+                    child: Text(
+                      licenseText,
+                      style: TextStyle(
+                        color: Theme.of(context)
+                            .extension<CustomColors>()!
+                            .textPrimary,
                       ),
-                    ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/widgets/settings/settings/settings_prometheus.dart
+++ b/lib/widgets/settings/settings/settings_prometheus.dart
@@ -125,256 +125,206 @@ class _SettingsPrometheusState extends State<SettingsPrometheus> {
       actionIsLoading: false,
       child: Form(
         key: _prometheusFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'You can specify the address of a Prometheus instance, or if your Prometheus instance is not reachable via a public address you can specify a namespace, label selector, container and port running inside your cluster',
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text('Enabled'),
-                  Switch(
-                    activeColor: Theme.of(context).colorScheme.primary,
-                    onChanged: (value) {
-                      setState(() {
-                        _enabled = !_enabled;
-                      });
-                    },
-                    value: _enabled,
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _addressController,
-                keyboardType: TextInputType.url,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Address',
+            child: Column(
+              children: [
+                const Text(
+                  'You can specify the address of a Prometheus instance, or if your Prometheus instance is not reachable via a public address you can specify a namespace, label selector, container and port running inside your cluster',
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(
-                top: Constants.spacingMiddle,
-                bottom: Constants.spacingMiddle,
-              ),
-              child: Row(
-                children: [
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Enabled'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _enabled = !_enabled;
+                        });
+                      },
+                      value: _enabled,
                     ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _addressController,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Address',
                   ),
-                  Text(
-                    'In-Cluster Configuration',
-                    style: secondaryTextStyle(
-                      context,
+                ),
+                const SizedBox(height: Constants.spacingExtraLarge),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
                     ),
-                  ),
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
+                    Text(
+                      'In-Cluster Configuration',
+                      style: secondaryTextStyle(
+                        context,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _namespaceController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Namespace',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _labelSelectorController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Label Selector',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _containerController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Container',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _portController,
-                keyboardType: TextInputType.number,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Port',
-                ),
-                validator: _portValidator,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _pathController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Path',
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(
-                top: Constants.spacingMiddle,
-                bottom: Constants.spacingMiddle,
-              ),
-              child: Row(
-                children: [
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
                     ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _namespaceController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Namespace',
                   ),
-                  Text(
-                    'Credentials',
-                    style: secondaryTextStyle(
-                      context,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _labelSelectorController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Label Selector',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _containerController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Container',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _portController,
+                  keyboardType: TextInputType.number,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Port',
+                  ),
+                  validator: _portValidator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _pathController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Path',
+                  ),
+                ),
+                const SizedBox(height: Constants.spacingExtraLarge),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
                     ),
-                  ),
-                  const Expanded(
-                    child: Divider(
-                      height: 0,
-                      thickness: 1.0,
+                    Text(
+                      'Credentials',
+                      style: secondaryTextStyle(
+                        context,
+                      ),
                     ),
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _usernameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Username',
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _usernameController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Username',
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _passwordController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Password',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _passwordController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Password',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _tokenController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Token',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _tokenController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Token',
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _certificateController,
-                keyboardType: TextInputType.text,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Certificate',
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _certificateController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Certificate',
+                  ),
                 ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings/settings_proxy.dart
+++ b/lib/widgets/settings/settings/settings_proxy.dart
@@ -58,26 +58,34 @@ class _SettingsProxyState extends State<SettingsProxy> {
       actionIsLoading: false,
       child: Form(
         key: _proxyFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _proxyController,
-                keyboardType: TextInputType.url,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Proxy',
-                ),
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-          ],
+            child: Column(
+              children: [
+                const Text(
+                  'Set a proxy for all Kubernetes requests. The proxy must be a valid URL.',
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _proxyController,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Proxy',
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings/settings_sponsor.dart
+++ b/lib/widgets/settings/settings/settings_sponsor.dart
@@ -51,10 +51,8 @@ class SettingsSponsor extends StatelessWidget {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(
-              left: Constants.spacingMiddle,
-              right: Constants.spacingMiddle,
-              bottom: Constants.spacingMiddle,
+            padding: const EdgeInsets.all(
+              Constants.spacingMiddle,
             ),
             child: Center(
               child: CircularProgressIndicator(

--- a/lib/widgets/settings/settings/settings_timeout.dart
+++ b/lib/widgets/settings/settings/settings_timeout.dart
@@ -80,35 +80,35 @@ class _SettingsTimeoutState extends State<SettingsTimeout> {
       actionIsLoading: false,
       child: Form(
         key: _timeoutFormKey,
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'Set the timeout for requests against the Kubernetes API in seconds. A value of "0" means no timeout:',
-              ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: TextFormField(
-                controller: _timeoutController,
-                keyboardType: TextInputType.url,
-                autocorrect: false,
-                enableSuggestions: false,
-                maxLines: 1,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Timeout',
+            child: Column(
+              children: [
+                const Text(
+                  'Set the timeout for requests against the Kubernetes API in seconds. A value of "0" means no timeout:',
                 ),
-                validator: _validator,
-              ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _timeoutController,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Timeout',
+                  ),
+                  validator: _validator,
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_banner.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_banner.dart
@@ -30,84 +30,77 @@ class SettingsSponsorBanner extends StatelessWidget {
         DateTime.now().millisecondsSinceEpoch >
             appRepository.settings.sponsorReminder) {
       return Container(
-        padding: const EdgeInsets.only(
-          left: Constants.spacingMiddle,
-          right: Constants.spacingMiddle,
+        margin: const EdgeInsets.all(
+          Constants.spacingMiddle,
         ),
-        child: Container(
-          margin: const EdgeInsets.only(
-            top: Constants.spacingSmall,
-            bottom: Constants.spacingSmall,
+        decoration: BoxDecoration(
+          boxShadow: [
+            BoxShadow(
+              color: Theme.of(context).extension<CustomColors>()!.shadow,
+              blurRadius: Constants.sizeBorderBlurRadius,
+              spreadRadius: Constants.sizeBorderSpreadRadius,
+              offset: const Offset(0.0, 0.0),
+            ),
+          ],
+          color: Theme.of(context).colorScheme.background,
+          borderRadius: const BorderRadius.all(
+            Radius.circular(Constants.sizeBorderRadius),
           ),
-          decoration: BoxDecoration(
-            boxShadow: [
-              BoxShadow(
-                color: Theme.of(context).extension<CustomColors>()!.shadow,
-                blurRadius: Constants.sizeBorderBlurRadius,
-                spreadRadius: Constants.sizeBorderSpreadRadius,
-                offset: const Offset(0.0, 0.0),
+        ),
+        child: InkWell(
+          onTap: () {
+            showActions(
+              context,
+              const SettingsSponsorActions(
+                showDismiss: true,
               ),
+            );
+          },
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(Constants.sizeBorderRadius),
+                    topRight: Radius.circular(Constants.sizeBorderRadius),
+                  ),
+                ),
+                height: 140,
+                width: MediaQuery.of(context).size.width,
+                child: Icon(
+                  Icons.favorite,
+                  color: Theme.of(context).colorScheme.onPrimary,
+                  size: 108,
+                ),
+              ),
+              const SizedBox(height: Constants.spacingSmall),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: Constants.spacingSmall,
+                ),
+                child: Text(
+                  'Sponsor',
+                  style: primaryTextStyle(
+                    context,
+                  ),
+                ),
+              ),
+              const SizedBox(height: Constants.spacingExtraSmall),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: Constants.spacingSmall,
+                ),
+                child: Text(
+                  'Support the development of kubenav by becoming a sponsor.',
+                  style: secondaryTextStyle(
+                    context,
+                  ),
+                ),
+              ),
+              const SizedBox(height: Constants.spacingSmall),
             ],
-            color: Theme.of(context).colorScheme.background,
-            borderRadius: const BorderRadius.all(
-              Radius.circular(Constants.sizeBorderRadius),
-            ),
-          ),
-          child: InkWell(
-            onTap: () {
-              showActions(
-                context,
-                const SettingsSponsorActions(
-                  showDismiss: true,
-                ),
-              );
-            },
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(Constants.sizeBorderRadius),
-                      topRight: Radius.circular(Constants.sizeBorderRadius),
-                    ),
-                  ),
-                  height: 140,
-                  width: MediaQuery.of(context).size.width,
-                  child: Icon(
-                    Icons.favorite,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                    size: 108,
-                  ),
-                ),
-                const SizedBox(height: Constants.spacingSmall),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: Constants.spacingSmall,
-                  ),
-                  child: Text(
-                    'Sponsor',
-                    style: primaryTextStyle(
-                      context,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: Constants.spacingExtraSmall),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: Constants.spacingSmall,
-                  ),
-                  child: Text(
-                    'Support the development of kubenav by becoming a sponsor.',
-                    style: secondaryTextStyle(
-                      context,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: Constants.spacingSmall),
-              ],
-            ),
           ),
         ),
       );

--- a/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
+++ b/lib/widgets/settings/settings/sponsor/settings_sponsor_subscribe.dart
@@ -72,8 +72,8 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
   Widget _buildIOSNotes() {
     if (Platform.isIOS) {
       return Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
+        padding: const EdgeInsets.only(
+          top: Constants.spacingMiddle,
         ),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
@@ -174,36 +174,38 @@ class _SettingsSponsorSubscribeState extends State<SettingsSponsorSubscribe> {
         _subscribe();
       },
       actionIsLoading: _isLoading,
-      child: Form(
-        child: ListView(
-          shrinkWrap: false,
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Column(
+            children: [
+              const Text(
                 'We believe in open source. This means that we will never put any features behind a paywall. You will always be able to use all features of kubenav for free.',
               ),
-            ),
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
+              const Padding(
+                padding: EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                ),
+                child: Text(
+                  'With the monthly and yearly sponsoring you can remove the "Sponsor" banner in the settings screen and support the development of kubenav.',
+                ),
               ),
-              child: Text(
-                'With the monthly and yearly sponsoring you can remove the "Sponsor" banner in the settings screen and support the development of kubenav.',
+              const Padding(
+                padding: EdgeInsets.only(
+                  top: Constants.spacingMiddle,
+                ),
+                child: Text(
+                  'You can also support us by reporting bugs, submitting fixes, proposing new features or by becoming a maintainer. For more information you can have a look at the contributing guide in our GitHub repository. The repository is available at https://github.com/kubenav/kubenav.',
+                ),
               ),
-            ),
-            const Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: Constants.spacingSmall,
-              ),
-              child: Text(
-                'You can also support us by reporting bugs, submitting fixes, proposing new features or by becoming a maintainer. For more information you can have a look at the contributing guide in our GitHub repository. The repository is available at https://github.com/kubenav/kubenav.',
-              ),
-            ),
-            _buildIOSNotes(),
-          ],
+              _buildIOSNotes(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings_clusters.dart
+++ b/lib/widgets/settings/settings_clusters.dart
@@ -26,23 +26,32 @@ import 'package:kubenav/widgets/shared/app_horizontal_list_cards_widget.dart';
 class SettingsClusters extends StatelessWidget {
   const SettingsClusters({super.key});
 
-  /// [_proxyDecorator] is used to highlight the cluster which is currently
+  /// [_proxyDecorator] is used to highlight the bookmark which is currently
   /// draged by the user.
   Widget _proxyDecorator(
-    BuildContext context,
     Widget child,
     int index,
     Animation<double> animation,
   ) {
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (BuildContext context, Widget? child) {
-        return Material(
-          elevation: 0,
-          child: child,
-        );
-      },
-      child: child,
+    return Material(
+      elevation: 0,
+      color: Colors.transparent,
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: Material(
+              borderRadius: BorderRadius.circular(16),
+              elevation: 24,
+              color: Colors.transparent,
+            ),
+          ),
+          child,
+        ],
+      ),
     );
   }
 
@@ -120,13 +129,14 @@ class SettingsClusters extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              const SizedBox(height: Constants.spacingSmall),
-
               buildProviders(context),
 
               Padding(
-                padding: const EdgeInsets.all(
-                  Constants.spacingMiddle,
+                padding: const EdgeInsets.only(
+                  top: Constants.spacingExtraLarge,
+                  bottom: Constants.spacingMiddle,
+                  left: Constants.spacingMiddle,
+                  right: Constants.spacingMiddle,
                 ),
                 child: Row(
                   children: [
@@ -156,7 +166,7 @@ class SettingsClusters extends StatelessWidget {
                   int index,
                   Animation<double> animation,
                 ) {
-                  return _proxyDecorator(context, child, index, animation);
+                  return _proxyDecorator(child, index, animation);
                 },
                 itemCount: clustersRepository.clusters.length,
                 itemBuilder: (
@@ -190,7 +200,6 @@ class SettingsClusters extends StatelessWidget {
                   );
                 },
               ),
-              const SizedBox(height: Constants.spacingSmall),
             ],
           ),
         ),

--- a/lib/widgets/settings/settings_help.dart
+++ b/lib/widgets/settings/settings_help.dart
@@ -20,74 +20,80 @@ class SettingsHelp extends StatelessWidget {
   const SettingsHelp({super.key});
 
   Widget buildHelpSection(BuildContext context, int sectionIndex) {
-    return AppVertialListSimpleWidget(
-      title: help_model.Help.list[sectionIndex].title,
-      items: List.generate(
-        help_model.Help.list[sectionIndex].items.length,
-        (itemIndex) => AppVertialListSimpleModel(
-          onTap: () {
-            showModal(
-              context,
-              AppBottomSheetWidget(
-                title:
-                    help_model.Help.list[sectionIndex].items[itemIndex].title,
-                subtitle: 'Help',
-                icon: help_model.Help.list[sectionIndex].items[itemIndex].icon,
-                closePressed: () {
-                  Navigator.pop(context);
-                },
-                actionText: 'Close',
-                actionPressed: () {
-                  Navigator.pop(context);
-                },
-                actionIsLoading: false,
-                child: Markdown(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: Constants.spacingSmall,
-                  ),
-                  styleSheet: MarkdownStyleSheet(
-                    code: TextStyle(
-                      fontFamily: getMonospaceFontFamily(),
-                      color: const Color(0xffd8dee9),
-                      backgroundColor: const Color(0xff2e3440),
-                    ),
-                    codeblockDecoration: const BoxDecoration(
-                      color: Color(0xff2e3440),
-                    ),
-                  ),
-                  selectable: true,
-                  data: help_model
-                      .Help.list[sectionIndex].items[itemIndex].markdown,
-                ),
-              ),
-            );
-          },
-          children: [
-            Icon(
-              help_model.Help.list[sectionIndex].items[itemIndex].icon,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-            const SizedBox(width: Constants.spacingSmall),
-            Expanded(
-              flex: 1,
-              child: Text(
-                help_model.Help.list[sectionIndex].items[itemIndex].title,
-                style: noramlTextStyle(
+    return Column(
+      children: [
+        AppVertialListSimpleWidget(
+          title: help_model.Help.list[sectionIndex].title,
+          items: List.generate(
+            help_model.Help.list[sectionIndex].items.length,
+            (itemIndex) => AppVertialListSimpleModel(
+              onTap: () {
+                showModal(
                   context,
+                  AppBottomSheetWidget(
+                    title: help_model
+                        .Help.list[sectionIndex].items[itemIndex].title,
+                    subtitle: 'Help',
+                    icon: help_model
+                        .Help.list[sectionIndex].items[itemIndex].icon,
+                    closePressed: () {
+                      Navigator.pop(context);
+                    },
+                    actionText: 'Close',
+                    actionPressed: () {
+                      Navigator.pop(context);
+                    },
+                    actionIsLoading: false,
+                    child: Markdown(
+                      padding: const EdgeInsets.all(
+                        Constants.spacingMiddle,
+                      ),
+                      styleSheet: MarkdownStyleSheet(
+                        code: TextStyle(
+                          fontFamily: getMonospaceFontFamily(),
+                          color: const Color(0xffd8dee9),
+                          backgroundColor: const Color(0xff2e3440),
+                        ),
+                        codeblockDecoration: const BoxDecoration(
+                          color: Color(0xff2e3440),
+                        ),
+                      ),
+                      selectable: true,
+                      data: help_model
+                          .Help.list[sectionIndex].items[itemIndex].markdown,
+                    ),
+                  ),
+                );
+              },
+              children: [
+                Icon(
+                  help_model.Help.list[sectionIndex].items[itemIndex].icon,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
-              ),
+                const SizedBox(width: Constants.spacingSmall),
+                Expanded(
+                  flex: 1,
+                  child: Text(
+                    help_model.Help.list[sectionIndex].items[itemIndex].title,
+                    style: noramlTextStyle(
+                      context,
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.arrow_forward_ios,
+                  color: Theme.of(context)
+                      .extension<CustomColors>()!
+                      .textPrimary
+                      .withOpacity(Constants.opacityIcon),
+                  size: 16,
+                ),
+              ],
             ),
-            Icon(
-              Icons.arrow_forward_ios,
-              color: Theme.of(context)
-                  .extension<CustomColors>()!
-                  .textPrimary
-                  .withOpacity(Constants.opacityIcon),
-              size: 16,
-            ),
-          ],
+          ),
         ),
-      ),
+        const SizedBox(height: Constants.spacingMiddle),
+      ],
     );
   }
 
@@ -103,21 +109,10 @@ class SettingsHelp extends StatelessWidget {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: Column(
-                  children: List.generate(
-                    help_model.Help.list.length,
-                    (index) => buildHelpSection(context, index),
-                  ),
-                ),
-              ),
-              const SizedBox(height: Constants.spacingSmall),
-            ],
+            children: List.generate(
+              help_model.Help.list.length,
+              (index) => buildHelpSection(context, index),
+            ),
           ),
         ),
       ),

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -24,20 +24,29 @@ class SettingsNamespaces extends StatelessWidget {
   /// [_proxyDecorator] is used to highlight the bookmark which is currently
   /// draged by the user.
   Widget _proxyDecorator(
-    BuildContext context,
     Widget child,
     int index,
     Animation<double> animation,
   ) {
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (BuildContext context, Widget? child) {
-        return Material(
-          elevation: 0,
-          child: child,
-        );
-      },
-      child: child,
+    return Material(
+      elevation: 0,
+      color: Colors.transparent,
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: Material(
+              borderRadius: BorderRadius.circular(16),
+              elevation: 24,
+              color: Colors.transparent,
+            ),
+          ),
+          child,
+        ],
+      ),
     );
   }
 
@@ -54,8 +63,7 @@ class SettingsNamespaces extends StatelessWidget {
     return Container(
       key: Key(appRepository.settings.namespaces[index]),
       margin: const EdgeInsets.only(
-        top: Constants.spacingSmall,
-        bottom: Constants.spacingSmall,
+        bottom: Constants.spacingMiddle,
         left: Constants.spacingMiddle,
         right: Constants.spacingMiddle,
       ),
@@ -131,7 +139,7 @@ class SettingsNamespaces extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              const SizedBox(height: Constants.spacingLarge),
+              const SizedBox(height: Constants.spacingMiddle),
               ReorderableListView.builder(
                 shrinkWrap: true,
                 buildDefaultDragHandles: false,
@@ -144,7 +152,7 @@ class SettingsNamespaces extends StatelessWidget {
                   int index,
                   Animation<double> animation,
                 ) {
-                  return _proxyDecorator(context, child, index, animation);
+                  return _proxyDecorator(child, index, animation);
                 },
                 itemCount: appRepository.settings.namespaces.length,
                 itemBuilder: (
@@ -154,7 +162,6 @@ class SettingsNamespaces extends StatelessWidget {
                   return buildNamespace(context, index);
                 },
               ),
-              const SizedBox(height: Constants.spacingSmall),
             ],
           ),
         ),

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -115,7 +115,7 @@ class SettingsProviders extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              const SizedBox(height: Constants.spacingLarge),
+              const SizedBox(height: Constants.spacingMiddle),
               ListView.separated(
                 physics: const NeverScrollableScrollPhysics(),
                 shrinkWrap: true,
@@ -132,7 +132,7 @@ class SettingsProviders extends StatelessWidget {
                   clustersRepository.providers[index],
                 ),
               ),
-              const SizedBox(height: Constants.spacingSmall),
+              const SizedBox(height: Constants.spacingMiddle),
             ],
           ),
         ),

--- a/lib/widgets/shared/app_bottom_sheet_widget.dart
+++ b/lib/widgets/shared/app_bottom_sheet_widget.dart
@@ -89,119 +89,129 @@ class AppBottomSheetWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: Container(
-          padding: const EdgeInsets.only(
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Container(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Flexible(
-                      child: Row(
-                        children: [
-                          _buildIcon(context, icon),
-                          Flexible(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  title,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: primaryTextStyle(
-                                    context,
-                                    size: 18,
-                                  ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Flexible(
+                    child: Row(
+                      children: [
+                        _buildIcon(context, icon),
+                        Flexible(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                title,
+                                overflow: TextOverflow.ellipsis,
+                                style: primaryTextStyle(
+                                  context,
+                                  size: 18,
                                 ),
-                                Text(
-                                  Characters(subtitle)
-                                      .replaceAll(
-                                        Characters(''),
-                                        Characters('\u{200B}'),
-                                      )
-                                      .toString(),
-                                  overflow: TextOverflow.ellipsis,
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
+                              ),
+                              Text(
+                                Characters(subtitle)
+                                    .replaceAll(
+                                      Characters(''),
+                                      Characters('\u{200B}'),
+                                    )
+                                    .toString(),
+                                overflow: TextOverflow.ellipsis,
+                                style: secondaryTextStyle(
+                                  context,
                                 ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      icon: Icon(
-                        Icons.close_outlined,
-                        color: Theme.of(context)
-                            .extension<CustomColors>()!
-                            .textPrimary,
-                      ),
-                      onPressed: closePressed,
-                    ),
-                  ],
-                ),
-              ),
-              const Divider(
-                height: 0,
-                thickness: 1.0,
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-              Flexible(
-                child: child,
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-              const Divider(
-                height: 0,
-                thickness: 1.0,
-              ),
-              Padding(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.primary,
-                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                    minimumSize: const Size.fromHeight(40),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(
-                        Constants.sizeBorderRadius,
-                      ),
+                        ),
+                      ],
                     ),
                   ),
-                  onPressed: actionIsLoading ? null : actionPressed,
-                  child: actionIsLoading
-                      ? SizedBox(
-                          height: 24,
-                          width: 24,
-                          child: CircularProgressIndicator(
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                        )
-                      : Text(
-                          actionText,
-                          style: primaryTextStyle(
-                            context,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                ),
+                  IconButton(
+                    icon: Icon(
+                      Icons.close_outlined,
+                      color: Theme.of(context)
+                          .extension<CustomColors>()!
+                          .textPrimary,
+                    ),
+                    onPressed: closePressed,
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+            const Padding(
+              padding: EdgeInsets.only(
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: Divider(
+                height: 0,
+                thickness: 1.0,
+              ),
+            ),
+            const SizedBox(height: Constants.spacingMiddle),
+            Expanded(
+              child: child,
+            ),
+            const SizedBox(height: Constants.spacingMiddle),
+            const Padding(
+              padding: EdgeInsets.only(
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: Divider(
+                height: 0,
+                thickness: 1.0,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.primary,
+                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                  minimumSize: const Size.fromHeight(40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(
+                      Constants.sizeBorderRadius,
+                    ),
+                  ),
+                ),
+                onPressed: actionIsLoading ? null : actionPressed,
+                child: actionIsLoading
+                    ? SizedBox(
+                        height: 24,
+                        width: 24,
+                        child: CircularProgressIndicator(
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                      )
+                    : Text(
+                        actionText,
+                        style: primaryTextStyle(
+                          context,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/widgets/shared/app_clusters_widget.dart
+++ b/lib/widgets/shared/app_clusters_widget.dart
@@ -53,43 +53,49 @@ class _AppClustersWidgetState extends State<AppClustersWidget> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: ListView.separated(
-        padding: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-          left: Constants.spacingExtraSmall,
-          right: Constants.spacingExtraSmall,
-        ),
-        separatorBuilder: (context, index) => const SizedBox(
-          height: Constants.spacingMiddle,
-        ),
-        itemCount: clustersRepository.clusters.length,
-        itemBuilder: (context, index) => AppListItem(
-          onTap: () {
-            _setActiveCluster(clustersRepository.clusters[index].id);
-          },
-          child: Row(
-            children: [
-              Icon(
-                clustersRepository.clusters[index].id ==
-                        clustersRepository.activeClusterId
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                size: 24,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(width: Constants.spacingSmall),
-              Expanded(
-                flex: 1,
-                child: Text(
-                  clustersRepository.clusters[index].name,
-                  style: noramlTextStyle(
-                    context,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            separatorBuilder: (context, index) => const SizedBox(
+              height: Constants.spacingMiddle,
+            ),
+            itemCount: clustersRepository.clusters.length,
+            itemBuilder: (context, index) => AppListItem(
+              onTap: () {
+                _setActiveCluster(clustersRepository.clusters[index].id);
+              },
+              child: Row(
+                children: [
+                  Icon(
+                    clustersRepository.clusters[index].id ==
+                            clustersRepository.activeClusterId
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    size: 24,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
-                  overflow: TextOverflow.ellipsis,
-                ),
+                  const SizedBox(width: Constants.spacingSmall),
+                  Expanded(
+                    flex: 1,
+                    child: Text(
+                      clustersRepository.clusters[index].name,
+                      style: noramlTextStyle(
+                        context,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/shared/app_error_widget.dart
+++ b/lib/widgets/shared/app_error_widget.dart
@@ -24,11 +24,11 @@ class AppErrorWidget extends StatelessWidget {
   final String details;
   final dynamic icon;
 
-  /// [buildIcon] creates the icon for the error widget. The [icon] parameter
+  /// [_buildIcon] creates the icon for the error widget. The [icon] parameter
   /// for the widget could be of type `String` or `IconData` to also allow
   /// images from the assets folder as icons. If the icon is null, we use a
   /// default one.
-  Widget buildIcon(BuildContext context, dynamic icon) {
+  Widget _buildIcon(BuildContext context, dynamic icon) {
     if (icon is String) {
       return SvgPicture.asset(icon);
     } else if (icon is IconData) {
@@ -46,7 +46,7 @@ class AppErrorWidget extends StatelessWidget {
     );
   }
 
-  Widget buildReauthWidget(String details) {
+  Widget _buildReauthWidget(String details) {
     if (details.contains('aws_sso_access_token_is_expired')) {
       return const SettingsReauthenticateAWSSSO();
     }
@@ -57,10 +57,6 @@ class AppErrorWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(
-        top: Constants.spacingSmall,
-        bottom: Constants.spacingSmall,
-      ),
       decoration: BoxDecoration(
         boxShadow: [
           BoxShadow(
@@ -89,7 +85,7 @@ class AppErrorWidget extends StatelessWidget {
             height: 140,
             width: MediaQuery.of(context).size.width,
             padding: const EdgeInsets.all(Constants.spacingMiddle),
-            child: buildIcon(context, icon),
+            child: _buildIcon(context, icon),
           ),
           const SizedBox(height: Constants.spacingSmall),
           Padding(
@@ -116,7 +112,7 @@ class AppErrorWidget extends StatelessWidget {
             ),
           ),
           const SizedBox(height: Constants.spacingSmall),
-          buildReauthWidget(details),
+          _buildReauthWidget(details),
         ],
       ),
     );

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -121,111 +121,110 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
     );
 
     return [
-      Container(
-        margin: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-          left: Constants.spacingExtraSmall,
-          right: Constants.spacingExtraSmall,
-        ),
-        child: Text(
-          'Favorites',
-          style: primaryTextStyle(context, size: 18),
+      Padding(
+        padding: const EdgeInsets.only(bottom: Constants.spacingMiddle),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Favorites',
+                style: primaryTextStyle(context, size: 18),
+              ),
+            ),
+          ],
         ),
       ),
-      Container(
-        margin: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-          left: Constants.spacingExtraSmall,
-          right: Constants.spacingExtraSmall,
-        ),
-        child: AppListItem(
-          onTap: () {
-            _changeNamespace('');
-          },
-          child: Row(
-            children: [
-              Icon(
-                clustersRepository
-                            .getCluster(clustersRepository.activeClusterId)!
-                            .namespace ==
-                        ''
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                size: 24,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(width: Constants.spacingSmall),
-              Expanded(
-                flex: 1,
-                child: Text(
-                  'All Namespaces',
-                  style: noramlTextStyle(
-                    context,
-                  ),
-                  overflow: TextOverflow.ellipsis,
+      AppListItem(
+        onTap: () {
+          _changeNamespace('');
+        },
+        child: Row(
+          children: [
+            Icon(
+              clustersRepository
+                          .getCluster(clustersRepository.activeClusterId)!
+                          .namespace ==
+                      ''
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 24,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              flex: 1,
+              child: Text(
+                'All Namespaces',
+                style: noramlTextStyle(
+                  context,
                 ),
+                overflow: TextOverflow.ellipsis,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
-      ...List.generate(
-        appRepository.settings.namespaces.length,
-        (index) {
+      SizedBox(
+        height: appRepository.settings.namespaces.isEmpty
+            ? 0
+            : Constants.spacingMiddle,
+      ),
+      ListView.separated(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        separatorBuilder: (context, index) {
+          return const SizedBox(
+            height: Constants.spacingMiddle,
+          );
+        },
+        itemCount: appRepository.settings.namespaces.length,
+        itemBuilder: (context, index) {
           final name = appRepository.settings.namespaces[index];
 
-          return Container(
-            margin: const EdgeInsets.only(
-              top: Constants.spacingSmall,
-              bottom: Constants.spacingSmall,
-              left: Constants.spacingExtraSmall,
-              right: Constants.spacingExtraSmall,
-            ),
-            child: AppListItem(
-              onTap: () {
-                _changeNamespace(name);
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    name ==
-                            clustersRepository
-                                .getCluster(clustersRepository.activeClusterId)!
-                                .namespace
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      name,
-                      style: noramlTextStyle(
-                        context,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+          return AppListItem(
+            onTap: () {
+              _changeNamespace(name);
+            },
+            child: Row(
+              children: [
+                Icon(
+                  name ==
+                          clustersRepository
+                              .getCluster(clustersRepository.activeClusterId)!
+                              .namespace
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked,
+                  size: 24,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: Constants.spacingSmall),
+                Expanded(
+                  flex: 1,
+                  child: Text(
+                    name,
+                    style: noramlTextStyle(
+                      context,
                     ),
+                    overflow: TextOverflow.ellipsis,
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           );
         },
       ),
-      Container(
-        margin: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-          left: Constants.spacingExtraSmall,
-          right: Constants.spacingExtraSmall,
-        ),
-        child: Text(
-          'Namespaces',
-          style: primaryTextStyle(context, size: 18),
+      const SizedBox(height: Constants.spacingExtraLarge),
+      Padding(
+        padding: const EdgeInsets.only(bottom: Constants.spacingMiddle),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Namespaces',
+                style: primaryTextStyle(context, size: 18),
+              ),
+            ),
+          ],
         ),
       ),
     ];
@@ -258,124 +257,131 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: FutureBuilder(
-        future: _futureFetchNamespaces,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<List<IoK8sApiCoreV1Namespace>> snapshot,
-        ) {
-          switch (snapshot.connectionState) {
-            case ConnectionState.none:
-            case ConnectionState.waiting:
-              return ListView(
-                children: [
-                  ..._buildFavoriteNamespace(),
-                  Center(
-                    child: CircularProgressIndicator(
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ),
-                ],
-              );
-            default:
-              if (snapshot.hasError) {
-                return ListView(
-                  children: [
-                    ..._buildFavoriteNamespace(),
-                    Wrap(
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: FutureBuilder(
+            future: _futureFetchNamespaces,
+            builder: (
+              BuildContext context,
+              AsyncSnapshot<List<IoK8sApiCoreV1Namespace>> snapshot,
+            ) {
+              switch (snapshot.connectionState) {
+                case ConnectionState.none:
+                case ConnectionState.waiting:
+                  return ListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: [
+                      ..._buildFavoriteNamespace(),
+                      Center(
+                        child: CircularProgressIndicator(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    ],
+                  );
+                default:
+                  if (snapshot.hasError) {
+                    return ListView(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
                       children: [
-                        AppErrorWidget(
-                          message: 'Could not load Namespaces',
-                          details: snapshot.error.toString(),
-                          icon: CustomIcons.namespaces,
+                        ..._buildFavoriteNamespace(),
+                        Wrap(
+                          children: [
+                            AppErrorWidget(
+                              message: 'Could not load Namespaces',
+                              details: snapshot.error.toString(),
+                              icon: CustomIcons.namespaces,
+                            ),
+                          ],
                         ),
                       ],
-                    ),
-                  ],
-                );
-              }
+                    );
+                  }
 
-              final filteredNamespaces = _getFilteredNamespaces(snapshot.data!);
+                  final filteredNamespaces =
+                      _getFilteredNamespaces(snapshot.data!);
 
-              return ListView(
-                children: [
-                  ..._buildFavoriteNamespace(),
-                  Container(
-                    padding: const EdgeInsets.only(
-                      top: Constants.spacingSmall,
-                      bottom: Constants.spacingSmall,
-                      left: Constants.spacingExtraSmall,
-                      right: Constants.spacingExtraSmall,
-                    ),
-                    child: TextField(
-                      onChanged: (value) {
-                        setState(() {
-                          _filter = value;
-                        });
-                      },
-                      keyboardType: TextInputType.text,
-                      autocorrect: false,
-                      enableSuggestions: false,
-                      maxLines: 1,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'Filter',
+                  return Column(
+                    children: [
+                      ..._buildFavoriteNamespace(),
+                      TextField(
+                        onChanged: (value) {
+                          setState(() {
+                            _filter = value;
+                          });
+                        },
+                        keyboardType: TextInputType.text,
+                        autocorrect: false,
+                        enableSuggestions: false,
+                        maxLines: 1,
+                        decoration: const InputDecoration(
+                          border: OutlineInputBorder(),
+                          labelText: 'Filter',
+                        ),
                       ),
-                    ),
-                  ),
-                  ...List.generate(
-                    filteredNamespaces.length,
-                    (index) {
-                      final name = filteredNamespaces[index].metadata?.name;
+                      const SizedBox(height: Constants.spacingMiddle),
+                      ListView.separated(
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        separatorBuilder: (context, index) {
+                          return const SizedBox(
+                            height: Constants.spacingMiddle,
+                          );
+                        },
+                        itemCount: filteredNamespaces.length,
+                        itemBuilder: (context, index) {
+                          final name = filteredNamespaces[index].metadata?.name;
 
-                      return Container(
-                        margin: const EdgeInsets.only(
-                          top: Constants.spacingSmall,
-                          bottom: Constants.spacingSmall,
-                          left: Constants.spacingExtraSmall,
-                          right: Constants.spacingExtraSmall,
-                        ),
-                        child: AppListItem(
-                          onTap: () {
-                            _changeNamespace(name ?? 'default');
-                          },
-                          child: Row(
-                            children: [
-                              Icon(
-                                name != null &&
-                                        name ==
-                                            clustersRepository
-                                                .getCluster(
-                                                  clustersRepository
-                                                      .activeClusterId,
-                                                )!
-                                                .namespace
-                                    ? Icons.radio_button_checked
-                                    : Icons.radio_button_unchecked,
-                                size: 24,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                              const SizedBox(width: Constants.spacingSmall),
-                              Expanded(
-                                flex: 1,
-                                child: Text(
-                                  name ?? '',
-                                  style: noramlTextStyle(
-                                    context,
-                                  ),
-                                  overflow: TextOverflow.ellipsis,
+                          return AppListItem(
+                            onTap: () {
+                              _changeNamespace(name ?? 'default');
+                            },
+                            child: Row(
+                              children: [
+                                Icon(
+                                  name != null &&
+                                          name ==
+                                              clustersRepository
+                                                  .getCluster(
+                                                    clustersRepository
+                                                        .activeClusterId,
+                                                  )!
+                                                  .namespace
+                                      ? Icons.radio_button_checked
+                                      : Icons.radio_button_unchecked,
+                                  size: 24,
+                                  color: Theme.of(context).colorScheme.primary,
                                 ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ],
-              );
-          }
-        },
+                                const SizedBox(width: Constants.spacingSmall),
+                                Expanded(
+                                  flex: 1,
+                                  child: Text(
+                                    name ?? '',
+                                    style: noramlTextStyle(
+                                      context,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  );
+              }
+            },
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/shared/app_no_clusters_widget.dart
+++ b/lib/widgets/shared/app_no_clusters_widget.dart
@@ -16,83 +16,73 @@ class AppNoClustersWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.only(
-        left: Constants.spacingMiddle,
-        right: Constants.spacingMiddle,
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).extension<CustomColors>()!.shadow,
+            blurRadius: Constants.sizeBorderBlurRadius,
+            spreadRadius: Constants.sizeBorderSpreadRadius,
+            offset: const Offset(0.0, 0.0),
+          ),
+        ],
+        color: Theme.of(context).colorScheme.background,
+        borderRadius: const BorderRadius.all(
+          Radius.circular(Constants.sizeBorderRadius),
+        ),
       ),
-      child: Container(
-        margin: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-        ),
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: Theme.of(context).extension<CustomColors>()!.shadow,
-              blurRadius: Constants.sizeBorderBlurRadius,
-              spreadRadius: Constants.sizeBorderSpreadRadius,
-              offset: const Offset(0.0, 0.0),
+      child: InkWell(
+        onTap: () {
+          navigate(
+            context,
+            const SettingsClusters(),
+            Constants.pageIndexSettings,
+          );
+        },
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(Constants.sizeBorderRadius),
+                  topRight: Radius.circular(Constants.sizeBorderRadius),
+                ),
+              ),
+              height: 140,
+              width: MediaQuery.of(context).size.width,
+              child: Icon(
+                CustomIcons.clusters,
+                color: Theme.of(context).colorScheme.onPrimary,
+                size: 108,
+              ),
             ),
+            const SizedBox(height: Constants.spacingSmall),
+            Padding(
+              padding: const EdgeInsets.only(
+                left: Constants.spacingSmall,
+              ),
+              child: Text(
+                'Add a Cluster',
+                style: primaryTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            const SizedBox(height: Constants.spacingExtraSmall),
+            Padding(
+              padding: const EdgeInsets.only(
+                left: Constants.spacingSmall,
+              ),
+              child: Text(
+                'Add your first cluster and start using kubenav',
+                style: secondaryTextStyle(
+                  context,
+                ),
+              ),
+            ),
+            const SizedBox(height: Constants.spacingSmall),
           ],
-          color: Theme.of(context).colorScheme.background,
-          borderRadius: const BorderRadius.all(
-            Radius.circular(Constants.sizeBorderRadius),
-          ),
-        ),
-        child: InkWell(
-          onTap: () {
-            navigate(
-              context,
-              const SettingsClusters(),
-              Constants.pageIndexSettings,
-            );
-          },
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary,
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(Constants.sizeBorderRadius),
-                    topRight: Radius.circular(Constants.sizeBorderRadius),
-                  ),
-                ),
-                height: 140,
-                width: MediaQuery.of(context).size.width,
-                child: Icon(
-                  CustomIcons.clusters,
-                  color: Theme.of(context).colorScheme.onPrimary,
-                  size: 108,
-                ),
-              ),
-              const SizedBox(height: Constants.spacingSmall),
-              Padding(
-                padding: const EdgeInsets.only(
-                  left: Constants.spacingSmall,
-                ),
-                child: Text(
-                  'Add a Cluster',
-                  style: primaryTextStyle(
-                    context,
-                  ),
-                ),
-              ),
-              const SizedBox(height: Constants.spacingExtraSmall),
-              Padding(
-                padding: const EdgeInsets.only(
-                  left: Constants.spacingSmall,
-                ),
-                child: Text(
-                  'Add your first cluster and start using kubenav',
-                  style: secondaryTextStyle(
-                    context,
-                  ),
-                ),
-              ),
-              const SizedBox(height: Constants.spacingSmall),
-            ],
-          ),
         ),
       ),
     );

--- a/lib/widgets/shared/app_prometheus_chart_widget.dart
+++ b/lib/widgets/shared/app_prometheus_chart_widget.dart
@@ -94,58 +94,36 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: FutureBuilder(
-        future: _futureFetchMetrics,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<List<Metric>> snapshot,
-        ) {
-          switch (snapshot.connectionState) {
-            case ConnectionState.none:
-            case ConnectionState.waiting:
-              return Flex(
-                direction: Axis.vertical,
-                children: [
-                  Expanded(
-                    child: Wrap(
-                      children: [
-                        CircularProgressIndicator(
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              );
-            default:
-              if (snapshot.hasError) {
-                return Flex(
-                  direction: Axis.vertical,
-                  children: [
-                    Expanded(
-                      child: Wrap(
-                        children: [
-                          AppErrorWidget(
-                            message: 'Could not load metrics',
-                            details: snapshot.error.toString(),
-                            icon: 'assets/plugins/prometheus.svg',
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                );
-              }
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: FutureBuilder(
+            future: _futureFetchMetrics,
+            builder: (
+              BuildContext context,
+              AsyncSnapshot<List<Metric>> snapshot,
+            ) {
+              switch (snapshot.connectionState) {
+                case ConnectionState.none:
+                case ConnectionState.waiting:
+                  return CircularProgressIndicator(
+                    color: Theme.of(context).colorScheme.primary,
+                  );
+                default:
+                  if (snapshot.hasError) {
+                    return AppErrorWidget(
+                      message: 'Could not load metrics',
+                      details: snapshot.error.toString(),
+                      icon: 'assets/plugins/prometheus.svg',
+                    );
+                  }
 
-              return ListView(
-                shrinkWrap: false,
-                children: [
-                  const SizedBox(height: Constants.spacingMiddle),
-                  Container(
-                    margin: const EdgeInsets.only(
-                      left: Constants.spacingExtraSmall,
-                      right: Constants.spacingExtraSmall,
-                    ),
+                  return Container(
                     padding: const EdgeInsets.all(
                       Constants.spacingListItemContent,
                     ),
@@ -329,12 +307,11 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                         ),
                       ],
                     ),
-                  ),
-                  const SizedBox(height: Constants.spacingMiddle),
-                ],
-              );
-          }
-        },
+                  );
+              }
+            },
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/shared/app_prometheus_charts_widget.dart
+++ b/lib/widgets/shared/app_prometheus_charts_widget.dart
@@ -116,7 +116,7 @@ class _AppPrometheusChartsWidgetState extends State<AppPrometheusChartsWidget> {
       return Container();
     }
 
-    return Wrap(
+    return Column(
       children: [
         Padding(
           padding: const EdgeInsets.only(
@@ -215,6 +215,7 @@ class _AppPrometheusChartsWidgetState extends State<AppPrometheusChartsWidget> {
             ),
           ),
         ),
+        const SizedBox(height: Constants.spacingMiddle),
       ],
     );
   }

--- a/lib/widgets/shared/app_resource_actions.dart
+++ b/lib/widgets/shared/app_resource_actions.dart
@@ -37,8 +37,6 @@ class AppResourceActionsModel {
 /// - `actions`: The actions will be shown via an [AppActionsWidget]. When this
 ///   mode is selected we will call `Navigator.pop(context)` before the defined
 ///   `onTap` function of an action to close the actions menu.
-/// - `menu`: The actions will be shown via a menu which is accesable via the
-///   [AppBar].
 class AppResourceActions extends StatelessWidget {
   const AppResourceActions({
     super.key,

--- a/lib/widgets/shared/app_time_range_selector_widget.dart
+++ b/lib/widgets/shared/app_time_range_selector_widget.dart
@@ -102,44 +102,50 @@ class _AppTimeRangeSelectorWidgetState
         Navigator.pop(context);
       },
       actionIsLoading: false,
-      child: ListView.separated(
-        padding: const EdgeInsets.only(
-          top: Constants.spacingSmall,
-          bottom: Constants.spacingSmall,
-          left: Constants.spacingExtraSmall,
-          right: Constants.spacingExtraSmall,
-        ),
-        separatorBuilder: (context, index) => const SizedBox(
-          height: Constants.spacingMiddle,
-        ),
-        itemCount: times.length,
-        itemBuilder: (context, index) => AppListItem(
-          onTap: () {
-            setState(() {
-              _selectedTime = times[index];
-            });
-          },
-          child: Row(
-            children: [
-              Icon(
-                times[index] == _selectedTime
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                size: 24,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(width: Constants.spacingSmall),
-              Expanded(
-                flex: 1,
-                child: Text(
-                  times[index],
-                  style: noramlTextStyle(
-                    context,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            separatorBuilder: (context, index) => const SizedBox(
+              height: Constants.spacingMiddle,
+            ),
+            itemCount: times.length,
+            itemBuilder: (context, index) => AppListItem(
+              onTap: () {
+                setState(() {
+                  _selectedTime = times[index];
+                });
+              },
+              child: Row(
+                children: [
+                  Icon(
+                    times[index] == _selectedTime
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    size: 24,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
-                  overflow: TextOverflow.ellipsis,
-                ),
+                  const SizedBox(width: Constants.spacingSmall),
+                  Expanded(
+                    flex: 1,
+                    child: Text(
+                      times[index],
+                      style: noramlTextStyle(
+                        context,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/shared/app_vertical_list_simple_widget.dart
+++ b/lib/widgets/shared/app_vertical_list_simple_widget.dart
@@ -28,27 +28,18 @@ class AppVertialListSimpleWidget extends StatelessWidget {
     super.key,
     required this.title,
     required this.items,
-    this.smallPadding = false,
   });
 
   final String title;
   final List<AppVertialListSimpleModel> items;
-  final bool smallPadding;
 
   @override
   Widget build(BuildContext context) {
     return Wrap(
       children: [
         Padding(
-          padding: EdgeInsets.only(
-            top: Constants.spacingMiddle,
-            left: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            right: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            bottom: Constants.spacingMiddle,
+          padding: const EdgeInsets.all(
+            Constants.spacingMiddle,
           ),
           child: Row(
             children: [
@@ -62,14 +53,9 @@ class AppVertialListSimpleWidget extends StatelessWidget {
           ),
         ),
         Padding(
-          padding: EdgeInsets.only(
-            left: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            right: smallPadding
-                ? Constants.spacingExtraSmall
-                : Constants.spacingMiddle,
-            bottom: Constants.spacingMiddle,
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
           ),
           child: ListView.separated(
             physics: const NeverScrollableScrollPhysics(),


### PR DESCRIPTION
This commit contains several layout improvements:

- Improve scrolling in modal bottom sheets.
- Improve list views, by using `ListView.separated` instead of applying the padding between items manually.
- Improve the padding / margin between widgets, so that they are similar across the app.
- Improve `ReorderableListView`s, so that the items do not show the margin (white border) when they are moved around.
- Remove `X-CONTEXT-NAME` header from requests, because this header is not required anymore.

The commit also contains some other smaller fixes and improvements, we came across during refactoring of the widgets.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
