### PR TITLE
Sort Helm Releases Alphabetical

### DIFF
--- a/cmd/kubenav/helm.go
+++ b/cmd/kubenav/helm.go
@@ -359,6 +359,10 @@ func HelmListCharts(clusterServer, clusterCertificateAuthorityData string, clust
 		releases = append(releases, release)
 	}
 
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].Name < releases[j].Name
+	})
+
 	releasesBytes, err := json.Marshal(releases)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
In the list view of the Helm plugin it could happen that the Helm releases were not sorted alphabetical. This is now fixed, so that the order of the Helm releases is always the same.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
