### PR TITLE
Fix Unnecessary Rerendering

### DIFF
--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -450,10 +450,6 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
 
   @override
   Widget build(BuildContext context) {
-    Provider.of<AppRepository>(
-      context,
-      listen: true,
-    );
     Provider.of<ClustersRepository>(
       context,
       listen: true,
@@ -543,6 +539,10 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
                         );
                       }
 
+                      Provider.of<AppRepository>(
+                        context,
+                        listen: true,
+                      );
                       Provider.of<BookmarksRepository>(
                         context,
                         listen: true,

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -208,10 +208,6 @@ class _ResourcesListState extends State<ResourcesList> {
 
   @override
   Widget build(BuildContext context) {
-    Provider.of<AppRepository>(
-      context,
-      listen: true,
-    );
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: true,


### PR DESCRIPTION
In the list and details view we were listening on changes in the `AppRepository`, which caused unnecessary rerenderings and reloadings when a user marked a namespaces as his favorite. Since we do not have to listen for changes in the `AppRepository`, we removed it.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
