### PR TITLE
Remove `onPlatformBrightnessChanged` Function

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,30 +43,8 @@ class App extends StatelessWidget {
   }
 }
 
-class AppMaterialApp extends StatefulWidget {
+class AppMaterialApp extends StatelessWidget {
   const AppMaterialApp({super.key});
-
-  @override
-  State<AppMaterialApp> createState() => _AppMaterialAppState();
-}
-
-class _AppMaterialAppState extends State<AppMaterialApp> {
-  @override
-  void initState() {
-    super.initState();
-
-    /// Here we have to listen to OS changes to the users selected theme, so
-    /// that we can notify all listeners of the [ThemeRepository] when the OS
-    /// theme is changed and the user selected the "auto" theme option.
-    final window = WidgetsBinding.instance.window;
-
-    window.onPlatformBrightnessChanged = () {
-      Provider.of<ThemeRepository>(
-        context,
-        listen: false,
-      ).notify();
-    };
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/repositories/theme_repository.dart
+++ b/lib/repositories/theme_repository.dart
@@ -107,8 +107,4 @@ class ThemeRepository with ChangeNotifier {
 
     return ThemeMode.system;
   }
-
-  void notify() {
-    notifyListeners();
-  }
 }


### PR DESCRIPTION
In the `AppMaterialApp` widget we were using the
`onPlatformBrightnessChanged` function to listen for brightness changes in the app, so we could update the theme when the user has selected the `auto` theme option.

After the rework of the theme handling in #597, this is not needed anymore, because when the `auto` option is selected, we set the theme mode to `ThemeMode.system` in the `MaterialApp` widget so that the theme is automatically selected on brightness changes.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
