### PR TITLE
Fix `nil dereference in field selection` Warning

### DIFF
--- a/cmd/kubenav/aws.go
+++ b/cmd/kubenav/aws.go
@@ -277,9 +277,11 @@ func AWSGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode st
 
 		var ssoRoles []string
 
-		if roles != nil || roles.RoleList != nil {
+		if roles != nil {
 			for _, role := range roles.RoleList {
-				ssoRoles = append(ssoRoles, *role.RoleName)
+				if role != nil && role.RoleName != nil {
+					ssoRoles = append(ssoRoles, *role.RoleName)
+				}
 			}
 
 		}


### PR DESCRIPTION
Fix the `nil dereference in field selection` warning and add `nil` checks for returned AWS account roles, before the are added to the `ssoRoles` slice.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
