### PR TITLE
Improve Terminal Handling

### DIFF
--- a/lib/repositories/terminal_repository.dart
+++ b/lib/repositories/terminal_repository.dart
@@ -14,6 +14,22 @@ enum TerminalType {
   exec,
 }
 
+extension TerminalTypeExtension on TerminalType {
+  /// [toLocalizedString] returns a localized string for a source type.
+  String toLocalizedString() {
+    switch (this) {
+      case TerminalType.log:
+        return 'Logs';
+      case TerminalType.logstream:
+        return 'Logs Stream';
+      case TerminalType.exec:
+        return 'Terminal';
+      default:
+        return 'Invalid';
+    }
+  }
+}
+
 /// A [Terminal] represents a single terminal. A terminal can be used to show the logs of a container or to exec into a
 /// container.
 class Terminal {
@@ -190,8 +206,9 @@ class TerminalRepository with ChangeNotifier {
 
   List<Terminal> get terminals => _terminals;
 
-  /// [addTerminal] adds a new terminal to the repository.
-  void addTerminal(
+  /// [addTerminal] adds a new terminal to the repository and returns the index
+  /// of the added terminal.
+  int addTerminal(
     TerminalType type,
     String name,
     List<dynamic>? logs,
@@ -208,6 +225,7 @@ class TerminalRepository with ChangeNotifier {
       ),
     );
     notifyListeners();
+    return _terminals.length - 1;
   }
 
   /// [deleteTerminal] deletes the terminal with the provided [index]. If the

--- a/lib/widgets/resources/details/details_get_logs.dart
+++ b/lib/widgets/resources/details/details_get_logs.dart
@@ -116,13 +116,14 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
               },
             );
 
-            terminalRepository.addTerminal(
+            final terminalIndex = terminalRepository.addTerminal(
               TerminalType.logstream,
               _container,
               null,
               LogStreamBackend(channel),
               null,
             );
+
             setState(() {
               _isLoading = false;
             });
@@ -130,7 +131,9 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
               Navigator.pop(context);
               showModal(
                 context,
-                const AppTerminalsWidget(),
+                AppTerminalWidget(
+                  terminalIndex: terminalIndex,
+                ),
               );
             }
           } else {
@@ -161,24 +164,24 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
             _previous,
           );
 
-          terminalRepository.addTerminal(
+          final terminalIndex = terminalRepository.addTerminal(
             TerminalType.log,
             _container,
             logs,
             null,
             null,
           );
-        }
 
-        setState(() {
-          _isLoading = false;
-        });
-        if (mounted) {
-          Navigator.pop(context);
-          showModal(
-            context,
-            const AppTerminalsWidget(),
-          );
+          setState(() {
+            _isLoading = false;
+          });
+          if (mounted) {
+            Navigator.pop(context);
+            showModal(
+              context,
+              AppTerminalWidget(terminalIndex: terminalIndex),
+            );
+          }
         }
       } catch (err) {
         Logger.log(

--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -88,13 +88,14 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
             },
           );
 
-          terminalRepository.addTerminal(
+          final terminalIndex = terminalRepository.addTerminal(
             TerminalType.exec,
             _container,
             null,
             null,
             TerminalBackend(channel),
           );
+
           setState(() {
             _isLoading = false;
           });
@@ -102,7 +103,7 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
             Navigator.pop(context);
             showModal(
               context,
-              const AppTerminalsWidget(),
+              AppTerminalWidget(terminalIndex: terminalIndex),
             );
           }
         } else {

--- a/lib/widgets/shared/app_floating_action_buttons_widget.dart
+++ b/lib/widgets/shared/app_floating_action_buttons_widget.dart
@@ -93,9 +93,9 @@ class _AppFloatingActionButtonsWidgetState
           heroTag: 'terminal',
           backgroundColor: Theme.of(context).colorScheme.primary,
           onPressed: () {
-            showModal(
+            showActions(
               context,
-              const AppTerminalsWidget(),
+              const AppTerminalsActionsWidget(),
             );
           },
           child: Icon(

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/shared/app_actions_widget.dart';
 
 import 'package:provider/provider.dart';
 import 'package:xterm/ui.dart' as xtermui;
@@ -15,8 +17,224 @@ Color getColor(int index, List<Color> colors) {
   return colors[index % colors.length];
 }
 
-class AppTerminalsWidget extends StatelessWidget {
-  const AppTerminalsWidget({super.key});
+class AppTerminalsActionsWidget extends StatelessWidget {
+  const AppTerminalsActionsWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
+      context,
+      listen: true,
+    );
+
+    return AppActionsWidget(
+      actions: List.generate(
+        terminalRepository.terminals.length,
+        (index) => AppActionsWidgetAction(
+          title:
+              '${terminalRepository.terminals[index].type.toLocalizedString()}: ${terminalRepository.terminals[index].name}',
+          color: Theme.of(context).colorScheme.primary,
+          onTap: () {
+            Navigator.pop(context);
+            showActions(
+              context,
+              AppTerminalActionsWidget(
+                terminalIndex: index,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class AppTerminalActionsWidget extends StatelessWidget {
+  const AppTerminalActionsWidget({
+    super.key,
+    required this.terminalIndex,
+  });
+
+  final int terminalIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
+      context,
+      listen: true,
+    );
+
+    return AppActionsWidget(
+      actions: [
+        AppActionsWidgetAction(
+          title: 'Open',
+          color: Theme.of(context).colorScheme.primary,
+          onTap: () {
+            Navigator.pop(context);
+            showModal(
+              context,
+              AppTerminalWidget(
+                terminalIndex: terminalIndex,
+              ),
+            );
+          },
+        ),
+        AppActionsWidgetAction(
+          title: 'Delete',
+          color: Theme.of(context).extension<CustomColors>()!.error,
+          onTap: () {
+            terminalRepository.deleteTerminal(terminalIndex);
+            Navigator.pop(context);
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class AppTerminalWidget extends StatelessWidget {
+  const AppTerminalWidget({
+    super.key,
+    required this.terminalIndex,
+  });
+
+  final int terminalIndex;
+
+  /// [_buildContent] returns the content for the terminal, depending on the
+  /// [TerminalType].
+  Widget _buildContent(BuildContext context) {
+    TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
+      context,
+      listen: false,
+    );
+
+    if (terminalRepository.terminals[terminalIndex].type == TerminalType.exec) {
+      if (terminalRepository.terminals[terminalIndex].terminal != null) {
+        return Padding(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: xtermui.TerminalView(
+            terminalRepository.terminals[terminalIndex].terminal!.terminal,
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingSmall,
+              right: Constants.spacingSmall,
+            ),
+            theme: Theme.of(context).extension<TerminalColors>()!.getTheme(),
+            textStyle: xterm.TerminalStyle(
+              fontSize: 14,
+              fontFamily: getMonospaceFontFamily(),
+            ),
+          ),
+        );
+      }
+
+      return Container();
+    }
+
+    if (terminalRepository.terminals[terminalIndex].type ==
+        TerminalType.logstream) {
+      if (terminalRepository.terminals[terminalIndex].logstream != null) {
+        return Padding(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: xtermui.TerminalView(
+            terminalRepository.terminals[terminalIndex].logstream!.terminal,
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingSmall,
+              right: Constants.spacingSmall,
+            ),
+            theme: Theme.of(context).extension<TerminalColors>()!.getTheme(),
+            textStyle: xterm.TerminalStyle(
+              fontSize: 14,
+              fontFamily: getMonospaceFontFamily(),
+            ),
+          ),
+        );
+      }
+
+      return Container();
+    }
+
+    if (terminalRepository.terminals[terminalIndex].type == TerminalType.log) {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Container(
+            padding: const EdgeInsets.all(Constants.spacingSmall),
+            color: Theme.of(context).extension<TerminalColors>()!.background,
+            child: Wrap(
+              children: terminalRepository.terminals[terminalIndex].logs == null
+                  ? []
+                  : terminalRepository.terminals[terminalIndex].logs!
+                      .asMap()
+                      .entries
+                      .map(
+                        (e) => SelectableText(
+                          e.value.join('\n\n'),
+                          style: TextStyle(
+                            color: getColor(
+                              e.key,
+                              Theme.of(context)
+                                  .extension<LogColors>()!
+                                  .getTheme(),
+                            ),
+                            fontSize: 14,
+                            fontFamily: getMonospaceFontFamily(),
+                          ),
+                        ),
+                      )
+                      .toList(),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container();
+  }
+
+  /// [_buildIcon] return the icon for the terminal, if the [TerminalType] is
+  /// `log` or `logstream` the icon for logs is returned. If the [TerminalType]
+  /// is `exec` the icon for a terminal is returned.
+  Widget _buildIcon(BuildContext context) {
+    TerminalRepository terminalRepository = Provider.of<TerminalRepository>(
+      context,
+      listen: false,
+    );
+
+    if (terminalRepository.terminals[terminalIndex].type == TerminalType.exec) {
+      return Icon(
+        Icons.list,
+        color: Theme.of(context).colorScheme.onPrimary,
+        size: 36,
+      );
+    }
+
+    if (terminalRepository.terminals[terminalIndex].type == TerminalType.log ||
+        terminalRepository.terminals[terminalIndex].type ==
+            TerminalType.logstream) {
+      return Icon(
+        Icons.subject,
+        color: Theme.of(context).colorScheme.onPrimary,
+        size: 36,
+      );
+    }
+
+    return Container();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -27,226 +245,104 @@ class AppTerminalsWidget extends StatelessWidget {
 
     return Scaffold(
       body: SafeArea(
-        child: Container(
-          padding: const EdgeInsets.only(
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Container(
-                padding: const EdgeInsets.only(
-                  top: Constants.spacingMiddle,
-                  bottom: Constants.spacingMiddle,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Flexible(
-                      child: Row(
-                        children: [
-                          Container(
-                            margin: const EdgeInsets.only(
-                              right: Constants.spacingMiddle,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              padding: const EdgeInsets.only(
+                top: Constants.spacingMiddle,
+                bottom: Constants.spacingMiddle,
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Flexible(
+                    child: Row(
+                      children: [
+                        Container(
+                          margin: const EdgeInsets.only(
+                            right: Constants.spacingMiddle,
+                          ),
+                          padding: const EdgeInsets.all(
+                            Constants.spacingExtraSmall,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primary,
+                            borderRadius: const BorderRadius.all(
+                              Radius.circular(Constants.sizeBorderRadius),
                             ),
-                            padding: const EdgeInsets.all(
-                              Constants.spacingExtraSmall,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Theme.of(context).colorScheme.primary,
-                              borderRadius: const BorderRadius.all(
-                                Radius.circular(
-                                  Constants.sizeBorderRadius,
+                          ),
+                          height: 54,
+                          width: 54,
+                          child: _buildIcon(context),
+                        ),
+                        Flexible(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                terminalRepository.terminals[terminalIndex].type
+                                    .toLocalizedString(),
+                                overflow: TextOverflow.ellipsis,
+                                style: primaryTextStyle(
+                                  context,
+                                  size: 18,
                                 ),
                               ),
-                            ),
-                            height: 54,
-                            width: 54,
-                            child: Icon(
-                              Icons.terminal,
-                              color: Theme.of(context).colorScheme.onPrimary,
-                              size: 36,
-                            ),
-                          ),
-                          Flexible(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Terminals',
-                                  overflow: TextOverflow.ellipsis,
-                                  style: primaryTextStyle(
-                                    context,
-                                    size: 18,
-                                  ),
+                              Text(
+                                Characters(
+                                  terminalRepository
+                                      .terminals[terminalIndex].name,
+                                )
+                                    .replaceAll(
+                                      Characters(''),
+                                      Characters('\u{200B}'),
+                                    )
+                                    .toString(),
+                                overflow: TextOverflow.ellipsis,
+                                style: secondaryTextStyle(
+                                  context,
                                 ),
-                                Text(
-                                  Characters(
-                                    'You have ${terminalRepository.terminals.length} Terminals open',
-                                  )
-                                      .replaceAll(
-                                        Characters(''),
-                                        Characters('\u{200B}'),
-                                      )
-                                      .toString(),
-                                  overflow: TextOverflow.ellipsis,
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
-                                ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                    IconButton(
-                      icon: const Icon(
-                        Icons.close_outlined,
-                      ),
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
+                  ),
+                  IconButton(
+                    icon: Icon(
+                      Icons.close_outlined,
+                      color: Theme.of(context)
+                          .extension<CustomColors>()!
+                          .textPrimary,
                     ),
-                  ],
-                ),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                ],
               ),
-              const Divider(
+            ),
+            const Padding(
+              padding: EdgeInsets.only(
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              child: Divider(
                 height: 0,
                 thickness: 1.0,
               ),
-              const SizedBox(height: Constants.spacingMiddle),
-              Flexible(
-                child: DefaultTabController(
-                  length: terminalRepository.terminals.length,
-                  child: Column(
-                    children: [
-                      SizedBox(
-                        height: 32,
-                        child: TabBar(
-                          isScrollable: true,
-                          tabAlignment: TabAlignment.center,
-                          labelColor: Theme.of(context).colorScheme.onPrimary,
-                          unselectedLabelColor:
-                              Theme.of(context).colorScheme.primary,
-                          indicatorPadding:
-                              const EdgeInsets.symmetric(horizontal: 5),
-                          indicatorSize: TabBarIndicatorSize.tab,
-                          indicator: BoxDecoration(
-                            borderRadius: BorderRadius.circular(
-                              Constants.sizeBorderRadius,
-                            ),
-                            color: Theme.of(context).colorScheme.primary,
-                          ),
-                          tabs:
-                              terminalRepository.terminals.asMap().entries.map(
-                            (terminal) {
-                              return Tab(
-                                child: GestureDetector(
-                                  onDoubleTap: () {
-                                    terminalRepository.deleteTerminal(
-                                      terminal.key,
-                                    );
-                                    if (terminalRepository.terminals.isEmpty) {
-                                      Navigator.pop(context);
-                                    }
-                                  },
-                                  child: Text(
-                                    terminal.value.name,
-                                  ),
-                                ),
-                              );
-                            },
-                          ).toList(),
-                        ),
-                      ),
-                      const SizedBox(height: Constants.spacingMiddle),
-                      Expanded(
-                        child: TabBarView(
-                          children:
-                              terminalRepository.terminals.asMap().entries.map(
-                            (terminal) {
-                              return terminal.value.type == TerminalType.exec
-                                  ? terminal.value.terminal != null
-                                      ? xtermui.TerminalView(
-                                          terminal.value.terminal!.terminal,
-                                          theme: Theme.of(context)
-                                              .extension<TerminalColors>()!
-                                              .getTheme(),
-                                          textStyle: xterm.TerminalStyle(
-                                            fontSize: 14,
-                                            fontFamily:
-                                                getMonospaceFontFamily(),
-                                          ),
-                                        )
-                                      : Container()
-                                  : terminal.value.type ==
-                                          TerminalType.logstream
-                                      ? terminal.value.logstream != null
-                                          ? xtermui.TerminalView(
-                                              terminal
-                                                  .value.logstream!.terminal,
-                                              theme: Theme.of(context)
-                                                  .extension<TerminalColors>()!
-                                                  .getTheme(),
-                                              textStyle: xterm.TerminalStyle(
-                                                fontSize: 14,
-                                                fontFamily:
-                                                    getMonospaceFontFamily(),
-                                              ),
-                                            )
-                                          : Container()
-                                      : SingleChildScrollView(
-                                          physics:
-                                              const ClampingScrollPhysics(),
-                                          child: Container(
-                                            padding: const EdgeInsets.all(
-                                              Constants.spacingSmall,
-                                            ),
-                                            color: Theme.of(context)
-                                                .extension<TerminalColors>()!
-                                                .background,
-                                            child: Wrap(
-                                              children: terminal.value.logs ==
-                                                      null
-                                                  ? []
-                                                  : terminal.value.logs!
-                                                      .asMap()
-                                                      .entries
-                                                      .map(
-                                                        (e) => SelectableText(
-                                                          e.value.join('\n\n'),
-                                                          style: TextStyle(
-                                                            color: getColor(
-                                                              e.key,
-                                                              Theme.of(context)
-                                                                  .extension<
-                                                                      LogColors>()!
-                                                                  .getTheme(),
-                                                            ),
-                                                            fontSize: 14,
-                                                            fontFamily:
-                                                                getMonospaceFontFamily(),
-                                                          ),
-                                                        ),
-                                                      )
-                                                      .toList(),
-                                            ),
-                                          ),
-                                        );
-                            },
-                          ).toList(),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: Constants.spacingMiddle),
-            ],
-          ),
+            ),
+            const SizedBox(height: Constants.spacingMiddle),
+            Expanded(
+              child: _buildContent(context),
+            ),
+            const SizedBox(height: Constants.spacingMiddle),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Instead of using tabs to show multiple terminals within one view, we are now using a similar logic as for the port forwarding. This means that a user can select the terminal he wants to view via the floating action button, after that we show the list of terminals as actions, were the user can select the terminal. Once a terminal was select the user can open or close the terminal. When the terminal is opened we only show the selected terminal.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
