### PR TITLE
Add `tools.go` File

### DIFF
--- a/cmd/tools/tools.go
+++ b/cmd/tools/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+
+// Package tools is used to force Go modules to download and install our dependencies used for our build pipeline.
+package tools
+
+import (
+	_ "golang.org/x/mobile/cmd/gomobile"
+)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.52.2
 	github.com/wI2L/jsondiff v0.5.1
+	golang.org/x/mobile v0.0.0-20240404231514-09dbf07665ed
 	golang.org/x/oauth2 v0.19.0
 	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.3
@@ -135,7 +136,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
-	golang.org/x/mobile v0.0.0-20240404231514-09dbf07665ed // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect


### PR DESCRIPTION
The added `tools.go` file is used to keep the
`golang.org/x/mobile/cmd/gomobile` package within the `go.mod` file, when running `go mod tidy`. The dependency is required in the `go.mod` file, so that we can generate the bindings for iOS and Android.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
