### PR TITLE
Add Missing API Declaration

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		55972CD62A01A6D700E3E942 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55972CD52A01A6C000E3E942 /* libresolv.tbd */; };
 		559DC63327C8D7020018E78E /* Kubenav.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559DC63127C8D6D50018E78E /* Kubenav.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
 		55C4E37827C952630039D04B /* KubenavPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C4E37727C952630039D04B /* KubenavPlugin.swift */; };
+		55D0B2982BD6CA5100B5C641 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 55D0B2972BD6CA5100B5C641 /* PrivacyInfo.xcprivacy */; };
 		57B7696AAFE673571F3BDBEA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F980B2BF4402CFBF648A1A8 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -30,6 +31,7 @@
 		55972CD52A01A6C000E3E942 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		559DC63127C8D6D50018E78E /* Kubenav.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Kubenav.xcframework; sourceTree = "<group>"; };
 		55C4E37727C952630039D04B /* KubenavPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubenavPlugin.swift; sourceTree = "<group>"; };
+		55D0B2972BD6CA5100B5C641 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		6F980B2BF4402CFBF648A1A8 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				55D0B2972BD6CA5100B5C641 /* PrivacyInfo.xcprivacy */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -202,6 +205,7 @@
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
+				55D0B2982BD6CA5100B5C641 /* PrivacyInfo.xcprivacy in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 4.3.0+91
+version: 4.3.0+93
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
Within the last Apple Testflight submissions we received a message that some API declarations are missing. The missing API declarations were:

- NSPrivacyAccessedAPICategoryFileTimestamp
- NSPrivacyAccessedAPICategorySystemBootTime

To add the missing API declarations we added a new `PrivacyInfo.xcprivacy`.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
