### PR TITLE
Fix Alignment of Icon and Text in Title

### DIFF
--- a/lib/widgets/resources/details/details_item.dart
+++ b/lib/widgets/resources/details/details_item.dart
@@ -116,7 +116,7 @@ class DetailsItemWidget extends StatelessWidget {
     if (goTo != null && goToOnTap != null) {
       return InkWell(
         onTap: goToOnTap,
-        child: Wrap(
+        child: Row(
           children: [
             Text(
               goTo!,

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -138,7 +138,7 @@ class Settings extends StatelessWidget {
             onTap: () {
               navigate(context, const SettingsClusters());
             },
-            child: Wrap(
+            child: Row(
               children: [
                 Text(
                   'View all',

--- a/lib/widgets/shared/app_horizontal_list_cards_widget.dart
+++ b/lib/widgets/shared/app_horizontal_list_cards_widget.dart
@@ -60,7 +60,7 @@ class AppHorizontalListCardsWidget extends StatelessWidget {
     if (moreText != null && moreIcon != null) {
       return InkWell(
         onTap: moreOnTap,
-        child: Wrap(
+        child: Row(
           children: [
             Text(
               moreText,

--- a/lib/widgets/shared/app_prometheus_charts_widget.dart
+++ b/lib/widgets/shared/app_prometheus_charts_widget.dart
@@ -148,7 +148,7 @@ class _AppPrometheusChartsWidgetState extends State<AppPrometheusChartsWidget> {
                     ),
                   );
                 },
-                child: Wrap(
+                child: Row(
                   children: [
                     Icon(
                       Icons.schedule,


### PR DESCRIPTION
If we are using an icon and text within a title to provide an additional action / link, the icon and text wasn't aligned properly. This is now fixed so that they are both centered.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
