### PR TITLE
Add Missing Space Before Volume Mounts

### DIFF
--- a/lib/widgets/resources/details/details_container.dart
+++ b/lib/widgets/resources/details/details_container.dart
@@ -284,6 +284,7 @@ class DetailsContainer extends StatelessWidget {
                     )
                     .toList(),
               ),
+              const SizedBox(height: Constants.spacingMiddle),
               AppVertialListSimpleWidget(
                 title: 'Volume Mounts',
                 items: container.volumeMounts


### PR DESCRIPTION
Add missing space before volume mounts in container view.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
