### PR TITLE
Add Home Page Configuration

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -277,6 +277,16 @@ class AppRepository with ChangeNotifier {
     } catch (_) {}
   }
 
+  /// [setHome] changes the users Home page configuration to the provided
+  /// [value].
+  Future<void> setHome(AppRepositorySettingsHome value) async {
+    try {
+      _settings.home = value;
+      await _save();
+      notifyListeners();
+    } catch (_) {}
+  }
+
   /// [setPrometheus] changes the users Prometheus configuration to the provided
   /// [value].
   Future<void> setPrometheus(AppRepositorySettingsPrometheus value) async {
@@ -337,6 +347,7 @@ class AppRepositorySettings {
   String proxy;
   int timeout;
   int sponsorReminder;
+  AppRepositorySettingsHome home;
   AppRepositorySettingsPrometheus prometheus;
 
   AppRepositorySettings({
@@ -347,6 +358,7 @@ class AppRepositorySettings {
     required this.proxy,
     required this.timeout,
     required this.sponsorReminder,
+    required this.home,
     required this.prometheus,
   });
 
@@ -359,6 +371,7 @@ class AppRepositorySettings {
       proxy: '',
       timeout: 0,
       sponsorReminder: 0,
+      home: AppRepositorySettingsHome.fromDefault(),
       prometheus: AppRepositorySettingsPrometheus.fromDefault(),
     );
   }
@@ -390,6 +403,9 @@ class AppRepositorySettings {
           data.containsKey('sponsorReminder') && data['sponsorReminder'] != null
               ? data['sponsorReminder']
               : 0,
+      home: data.containsKey('home') && data['home'] != null
+          ? AppRepositorySettingsHome.fromJson(data['home'])
+          : AppRepositorySettingsHome.fromDefault(),
       prometheus: data.containsKey('prometheus') && data['prometheus'] != null
           ? AppRepositorySettingsPrometheus.fromJson(data['prometheus'])
           : AppRepositorySettingsPrometheus.fromDefault(),
@@ -405,7 +421,55 @@ class AppRepositorySettings {
       'proxy': proxy,
       'timeout': timeout,
       'sponsorReminder': sponsorReminder,
+      'home': home.toJson(),
       'prometheus': prometheus.toJson(),
+    };
+  }
+}
+
+/// The [AppRepositorySettingsHome] model represents all the
+/// configurations which can be set by a user for the home page.
+class AppRepositorySettingsHome {
+  bool useSelectedNamespace;
+  bool showMetrics;
+  bool showWarnings;
+
+  AppRepositorySettingsHome({
+    required this.useSelectedNamespace,
+    required this.showMetrics,
+    required this.showWarnings,
+  });
+
+  factory AppRepositorySettingsHome.fromDefault() {
+    return AppRepositorySettingsHome(
+      useSelectedNamespace: false,
+      showMetrics: true,
+      showWarnings: true,
+    );
+  }
+
+  factory AppRepositorySettingsHome.fromJson(Map<String, dynamic> data) {
+    return AppRepositorySettingsHome(
+      useSelectedNamespace: data.containsKey('useSelectedNamespace') &&
+              data['useSelectedNamespace'] != null
+          ? data['useSelectedNamespace']
+          : false,
+      showMetrics:
+          data.containsKey('showMetrics') && data['showMetrics'] != null
+              ? data['showMetrics']
+              : true,
+      showWarnings:
+          data.containsKey('showWarnings') && data['showWarnings'] != null
+              ? data['showWarnings']
+              : true,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'useSelectedNamespace': useSelectedNamespace,
+      'showMetrics': showMetrics,
+      'showWarnings': showWarnings,
     };
   }
 }

--- a/lib/widgets/home/home_overview.dart
+++ b/lib/widgets/home/home_overview.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
 
+import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/custom_icons.dart';
@@ -22,6 +23,10 @@ class HomeOverview extends StatelessWidget {
       context,
       listen: false,
     );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
 
     if (clustersRepository.clusters.isEmpty) {
       return [
@@ -32,15 +37,21 @@ class HomeOverview extends StatelessWidget {
       ];
     }
 
-    return [
+    final List<Widget> content = [
       const OverviewActions(),
-      const OverviewMetrics(
-        nodeName: null,
-      ),
-      const SizedBox(height: Constants.spacingMiddle),
-      const OverviewEvents(),
-      const SizedBox(height: Constants.spacingMiddle),
     ];
+
+    if (appRepository.settings.home.showMetrics) {
+      content.add(const OverviewMetrics(nodeName: null));
+      content.add(const SizedBox(height: Constants.spacingMiddle));
+    }
+
+    if (appRepository.settings.home.showWarnings) {
+      content.add(const OverviewEvents());
+      content.add(const SizedBox(height: Constants.spacingMiddle));
+    }
+
+    return content;
   }
 
   @override

--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -49,8 +49,10 @@ class _OverviewEventsState extends State<OverviewEvents> {
       clustersRepository.activeClusterId,
     );
 
-    final resourcesListUrl =
-        '${Resources.map['events']!.path}/${Resources.map['events']!.resource}?fieldSelector=type=Warning';
+    final resourcesListUrl = appRepository.settings.home.useSelectedNamespace &&
+            cluster!.namespace != ''
+        ? '${Resources.map['events']!.path}/namespaces/${cluster.namespace}/${Resources.map['events']!.resource}?fieldSelector=type=Warning'
+        : '${Resources.map['events']!.path}/${Resources.map['events']!.resource}?fieldSelector=type=Warning';
 
     final resourcesList = await KubernetesService(
       cluster: cluster!,

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -12,6 +12,7 @@ import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/utils/themes.dart';
+import 'package:kubenav/widgets/settings/settings/settings_home_page.dart';
 import 'package:kubenav/widgets/settings/settings/settings_info.dart';
 import 'package:kubenav/widgets/settings/settings/settings_prometheus.dart';
 import 'package:kubenav/widgets/settings/settings/settings_proxy.dart';
@@ -484,6 +485,40 @@ class Settings extends StatelessWidget {
                             ),
                           );
                         }).toList(),
+                      ),
+                    ],
+                  ),
+                  AppVertialListSimpleModel(
+                    onTap: () {
+                      showModal(
+                        context,
+                        SettingsHomePage(
+                          currentHome: appRepository.settings.home,
+                        ),
+                      );
+                    },
+                    children: [
+                      Icon(
+                        Icons.home,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          'Home Page',
+                          style: noramlTextStyle(
+                            context,
+                          ),
+                        ),
+                      ),
+                      Icon(
+                        Icons.arrow_forward_ios,
+                        color: Theme.of(context)
+                            .extension<CustomColors>()!
+                            .textPrimary
+                            .withOpacity(Constants.opacityIcon),
+                        size: 16,
                       ),
                     ],
                   ),

--- a/lib/widgets/settings/settings/settings_home_page.dart
+++ b/lib/widgets/settings/settings/settings_home_page.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [SettingsHomePage] widget can be used to configure the home page of the
+/// application.
+class SettingsHomePage extends StatefulWidget {
+  const SettingsHomePage({
+    super.key,
+    required this.currentHome,
+  });
+
+  final AppRepositorySettingsHome currentHome;
+
+  @override
+  State<SettingsHomePage> createState() => _SettingsHomePageState();
+}
+
+class _SettingsHomePageState extends State<SettingsHomePage> {
+  final _homeFormKey = GlobalKey<FormState>();
+  bool _useSelectedNamespace = false;
+  bool _showMetrics = false;
+  bool _showWarnings = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _useSelectedNamespace = widget.currentHome.useSelectedNamespace;
+    _showMetrics = widget.currentHome.showMetrics;
+    _showWarnings = widget.currentHome.showWarnings;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    return AppBottomSheetWidget(
+      title: 'Home Page',
+      subtitle: 'Home Page Configuration',
+      icon: Icons.home,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Save',
+      actionPressed: () {
+        if (_homeFormKey.currentState != null &&
+            _homeFormKey.currentState!.validate()) {
+          appRepository.setHome(
+            AppRepositorySettingsHome(
+              useSelectedNamespace: _useSelectedNamespace,
+              showMetrics: _showMetrics,
+              showWarnings: _showWarnings,
+            ),
+          );
+          Navigator.pop(context);
+        }
+      },
+      actionIsLoading: false,
+      child: Form(
+        key: _homeFormKey,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
+            ),
+            child: Column(
+              children: [
+                const Text(
+                  'The following options can be used to configure the home page of the app. You can enable or disable the different components of the home page and you can select the scope for the different components. If you do not have the permissions to list resources in all namespaces of the cluster, you should enable the "Use Selected Namespace" option.',
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Use Selected Namespace'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _useSelectedNamespace = !_useSelectedNamespace;
+                        });
+                      },
+                      value: _useSelectedNamespace,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingExtraLarge),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                    Text(
+                      'Components',
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show Metrics'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showMetrics = !_showMetrics;
+                        });
+                      },
+                      value: _showMetrics,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show Warnings'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWarnings = !_showWarnings;
+                        });
+                      },
+                      value: _showWarnings,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
The home page of the app can now be configured by the user. It is possible to enable and disable the metrics and warnings component and it is possible to select the scope for the warnings component. This means that when a user doesn't have the permissions to show the warnings from all namespaces he can select the "Use Selected Namespace" options to only show the warnings from his currently selected namespace.

This also allows us to add more components to the home page in the future, e.g. to show unhealthy workloads, which can then be enabled / disabled by the user.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
