### PR TITLE
Allow Text Selection in Code Views

### DIFF
--- a/lib/widgets/plugins/helm/plugin_helm_details_manifest.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_manifest.dart
@@ -78,7 +78,7 @@ class _PluginHelmDetailsManifestState extends State<PluginHelmDetailsManifest> {
             ),
             child: CodeField(
               controller: _codeController,
-              enabled: false,
+              readOnly: true,
               textStyle: TextStyle(
                 fontSize: 14,
                 fontFamily: getMonospaceFontFamily(),

--- a/lib/widgets/plugins/helm/plugin_helm_details_template.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_template.dart
@@ -71,7 +71,7 @@ class _PluginHelmDetailsTemplateState extends State<PluginHelmDetailsTemplate> {
             ),
             child: CodeField(
               controller: _codeController,
-              enabled: false,
+              readOnly: true,
               textStyle: TextStyle(
                 fontSize: 14,
                 fontFamily: getMonospaceFontFamily(),

--- a/lib/widgets/plugins/helm/plugin_helm_details_values.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_values.dart
@@ -110,7 +110,7 @@ class _PluginHelmDetailsValuesState extends State<PluginHelmDetailsValues> {
             ),
             child: CodeField(
               controller: _codeController,
-              enabled: false,
+              readOnly: true,
               textStyle: TextStyle(
                 fontSize: 14,
                 fontFamily: getMonospaceFontFamily(),

--- a/lib/widgets/resources/details/details_show_yaml.dart
+++ b/lib/widgets/resources/details/details_show_yaml.dart
@@ -173,7 +173,7 @@ class _DetailsShowYamlState extends State<DetailsShowYaml> {
             ),
             child: CodeField(
               controller: _codeController,
-              enabled: false,
+              readOnly: true,
               textStyle: TextStyle(
                 fontSize: 14,
                 fontFamily: getMonospaceFontFamily(),


### PR DESCRIPTION
Until now it was not possible to select text in code views, when the text was not editable. This is now changed, by using the `readOnly` property of the `CodeView` widget instead of the `enabled` property.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
