### PR TITLE
Add Support for Debug Containers

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+import 'dart:math' show Random;
 
 import 'package:flutter/material.dart';
 
@@ -65,4 +66,13 @@ String getMonospaceFontFamily() {
   }
 
   return 'monospace';
+}
+
+/// [generateRandomString] generates a random string with the given [len]
+/// length. The generated string contains only lowercase letters and numbers,
+/// so it can be used within Kubernetes resource names.
+String generateRandomString(int len) {
+  var r = Random();
+  const chars = 'abcdefghijklmnopqrstuvwxyz1234567890';
+  return List.generate(len, (index) => chars[r.nextInt(chars.length)]).join();
 }

--- a/lib/widgets/resources/details/details_debug_pod.dart
+++ b/lib/widgets/resources/details/details_debug_pod.dart
@@ -19,13 +19,35 @@ import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 
-/// The [DetailsEditResource] widget displays the provided [item] in a code
-/// editor, so that the user can modify the yaml / json manifest depending on
-/// the users settings. When the user has modified the manifest he can save his
-/// changes and we create a json patch based on the users modification and make
-/// a Kubernetes API call to update the manifest of the resource.
-class DetailsEditResource extends StatefulWidget {
-  const DetailsEditResource({
+/// [debugTemplate] returns a template for a debug container in yaml or json
+/// format. The template is used to create a new debug container for a pod.
+String debugTemplate(String editorFormat) {
+  if (editorFormat == 'json') {
+    return '''{
+  "name": "debugger-${generateRandomString(6)}",
+  "image": "busybox",
+  "command": [
+    "sh"
+  ],
+  "terminationMessagePolicy": "File",
+  "imagePullPolicy": "IfNotPresent",
+  "stdin": true,
+  "tty": true
+}''';
+  }
+
+  return '''name: debugger-${generateRandomString(6)}
+image: busybox
+command:
+  - sh
+terminationMessagePolicy: File
+imagePullPolicy: IfNotPresent
+stdin: true
+tty: true''';
+}
+
+class DetailsDebugPod extends StatefulWidget {
+  const DetailsDebugPod({
     super.key,
     required this.resource,
     required this.path,
@@ -41,16 +63,16 @@ class DetailsEditResource extends StatefulWidget {
   final dynamic item;
 
   @override
-  State<DetailsEditResource> createState() => _DetailsEditResourceState();
+  State<DetailsDebugPod> createState() => _DetailsDebugPodState();
 }
 
-class _DetailsEditResourceState extends State<DetailsEditResource> {
+class _DetailsDebugPodState extends State<DetailsDebugPod> {
   CodeController _codeController = CodeController();
   bool _isLoading = false;
 
   /// [_init] is called when the widget is initialized. Within the [_init]
-  /// function we prettify the provided [widget.item] and convert it to
-  /// either a json document or a yaml document depending on the users settings.
+  /// function we set the template for the debug container which should be
+  /// created.
   Future<void> _init() async {
     AppRepository appRepository = Provider.of<AppRepository>(
       context,
@@ -58,35 +80,20 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
     );
 
     _codeController = CodeController(
-      text: '',
+      text: debugTemplate(appRepository.settings.editorFormat),
       language: appRepository.settings.editorFormat == 'json'
           ? highlight_json.json
           : highlight_yaml.yaml,
     );
-
-    try {
-      if (appRepository.settings.editorFormat == 'json') {
-        JsonEncoder encoder = const JsonEncoder.withIndent('  ');
-        _codeController.text = encoder.convert(widget.item);
-      } else {
-        final data = await HelpersService().prettifyYAML(widget.item);
-        _codeController.text = data;
-      }
-    } catch (err) {
-      Logger.log(
-        'DetailsEditResource _init',
-        'An error was returned while prettyfing template',
-        err,
-      );
-    }
   }
 
-  /// [_save] creates a json patch based on the users [widget.item]
-  /// modifications he made in the code editor. The json patch is then send to
-  /// the Kubernetes API server to update the resource. When the API call
-  /// succeeds we display a snackbar with the success message and close the
-  /// widget. If the API call fails we only show a snackbar with the error.
-  Future<void> _save() async {
+  /// [_create] creates a new ephemeral container for the Pod. For that we
+  /// create a copy of the [widget.item] and add the new container to the
+  /// spec. We then create a json patch and send it to the Kubernetes API
+  /// server. When the API call succeeds we display a snackbar with the success
+  /// message and close the widget. If the API call fails we only show a
+  /// snackbar with the error.
+  Future<void> _create() async {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
@@ -100,11 +107,27 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
       setState(() {
         _isLoading = true;
       });
+      final copy = json.decode(json.encode(widget.item));
+
+      if (copy['spec'].containsKey('ephemeralContainers') &&
+          copy['spec']['ephemeralContainers'] != null &&
+          copy['spec']['ephemeralContainers'].length > 0) {
+        copy['spec']['ephemeralContainers'].add(
+          appRepository.settings.editorFormat == 'json'
+              ? json.decode(_codeController.text)
+              : loadYaml(_codeController.text),
+        );
+      } else {
+        copy['spec']['ephemeralContainers'] = [
+          appRepository.settings.editorFormat == 'json'
+              ? json.decode(_codeController.text)
+              : loadYaml(_codeController.text),
+        ];
+      }
+
       final jsonPatch = await HelpersService().createJSONPatch(
         widget.item,
-        appRepository.settings.editorFormat == 'json'
-            ? json.decode(_codeController.text)
-            : loadYaml(_codeController.text),
+        copy,
       );
 
       if (jsonPatch == '') {
@@ -117,12 +140,11 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
       final cluster = await clustersRepository.getClusterWithCredentials(
         clustersRepository.activeClusterId,
       );
-      final url = widget.namespace == null
-          ? '${widget.path}/${widget.resource}/${widget.name}'
-          : '${widget.path}/namespaces/${widget.namespace}/${widget.resource}/${widget.name}';
+      final url =
+          '${widget.path}/namespaces/${widget.namespace}/${widget.resource}/${widget.name}/ephemeralcontainers';
 
       Logger.log(
-        'DetailsEditResourceController save',
+        'DetailsDebugPodController _create',
         'Apply json patch for $url',
         jsonPatchBody,
       );
@@ -139,17 +161,15 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
       if (mounted) {
         showSnackbar(
           context,
-          'Resource was saved',
-          widget.namespace == null
-              ? 'The changes for the resource ${widget.name} are saved'
-              : 'The changes for the resource ${widget.name} in namespace ${widget.namespace} are saved',
+          'Debug container was created',
+          'You can now exec into the debug container.',
         );
         Navigator.pop(context);
       }
     } catch (err) {
       Logger.log(
-        'DetailsEditResourceController save',
-        'An error was returned while prettyfing yaml',
+        'DetailsDebugPodController _create',
+        'Failed to create debug container',
         err,
       );
       setState(() {
@@ -158,7 +178,7 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
       if (mounted) {
         showSnackbar(
           context,
-          'Could not save resource',
+          'Failed to create debug container',
           err.toString(),
         );
       }
@@ -180,15 +200,15 @@ class _DetailsEditResourceState extends State<DetailsEditResource> {
   @override
   Widget build(BuildContext context) {
     return AppBottomSheetWidget(
-      title: 'Edit',
+      title: 'Debug',
       subtitle: widget.item['metadata']['name'] ?? '',
-      icon: Icons.edit,
+      icon: Icons.bug_report,
       closePressed: () {
         Navigator.pop(context);
       },
-      actionText: 'Save',
+      actionText: 'Create Debug Container',
       actionPressed: () {
-        _save();
+        _create();
       },
       actionIsLoading: _isLoading,
       child: SingleChildScrollView(

--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -157,6 +157,13 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
           tmpContainers.add(container['name']);
         }
       }
+
+      if (widget.item['spec']['ephemeralContainers'] != null) {
+        for (var ephemeralContainer in widget.item['spec']
+            ['ephemeralContainers']) {
+          tmpContainers.add(ephemeralContainer['name']);
+        }
+      }
     }
 
     if (tmpContainers.isNotEmpty) {

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -11,6 +11,7 @@ import 'package:kubenav/services/kubernetes_service.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/resources/details/details_create_job.dart';
+import 'package:kubenav/widgets/resources/details/details_debug_pod.dart';
 import 'package:kubenav/widgets/resources/details/details_delete_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_edit_resource.dart';
 import 'package:kubenav/widgets/resources/details/details_get_logs.dart';
@@ -287,6 +288,28 @@ List<AppResourceActionsModel> resourceDetailsActions(
             DetailsTerminal(
               name: name,
               namespace: namespace ?? '',
+              item: item,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  if (Resources.map['pods']!.resource == resource &&
+      Resources.map['pods']!.path == path) {
+    actions.add(
+      AppResourceActionsModel(
+        title: 'Debug',
+        icon: Icons.bug_report,
+        onTap: () {
+          showModal(
+            context,
+            DetailsDebugPod(
+              resource: resource,
+              path: path,
+              name: name,
+              namespace: namespace,
               item: item,
             ),
           );


### PR DESCRIPTION
It is now possible to create debug containers for Pods, similar to the `kubectl debug` command. The new debug action creates an ephemeral container, which can then be used to get a terminal for a Pod.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
