### PR TITLE
Use `kubectl.kubernetes.io/default-container` Annotation

### DIFF
--- a/lib/widgets/resources/details/details_get_logs.dart
+++ b/lib/widgets/resources/details/details_get_logs.dart
@@ -228,7 +228,23 @@ class _DetailsGetLogsState extends State<DetailsGetLogs> {
 
     if (tmpContainers.isNotEmpty) {
       _containers = tmpContainers;
-      _container = tmpContainers[0];
+
+      /// When the Pod contains a "kubectl.kubernetes.io/default-container"
+      /// annotation we use this container as initial value for the [_container]
+      /// state. If the annotation is not available we use the first container
+      /// from the list.
+      if (widget.item['metadata'].containsKey('annotations') &&
+          widget.item['metadata']['annotations']
+              .containsKey('kubectl.kubernetes.io/default-container') &&
+          tmpContainers.contains(
+            widget.item['metadata']['annotations']
+                ['kubectl.kubernetes.io/default-container'],
+          )) {
+        _container = widget.item['metadata']['annotations']
+            ['kubectl.kubernetes.io/default-container'];
+      } else {
+        _container = tmpContainers[0];
+      }
     }
   }
 

--- a/lib/widgets/resources/details/details_terminal.dart
+++ b/lib/widgets/resources/details/details_terminal.dart
@@ -168,7 +168,23 @@ class _DetailsTerminalState extends State<DetailsTerminal> {
 
     if (tmpContainers.isNotEmpty) {
       _containers = tmpContainers;
-      _container = tmpContainers[0];
+
+      /// When the Pod contains a "kubectl.kubernetes.io/default-container"
+      /// annotation we use this container as initial value for the [_container]
+      /// state. If the annotation is not available we use the first container
+      /// from the list.
+      if (widget.item['metadata'].containsKey('annotations') &&
+          widget.item['metadata']['annotations']
+              .containsKey('kubectl.kubernetes.io/default-container') &&
+          tmpContainers.contains(
+            widget.item['metadata']['annotations']
+                ['kubectl.kubernetes.io/default-container'],
+          )) {
+        _container = widget.item['metadata']['annotations']
+            ['kubectl.kubernetes.io/default-container'];
+      } else {
+        _container = tmpContainers[0];
+      }
     }
   }
 


### PR DESCRIPTION
We are now using the `kubectl.kubernetes.io/default-container` annotation of a Pod to select the initial selected container for the logs and terminal views. If a Pod doesn't contain the annotation we will use the first container from the list of containers as initial selection.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
