### PR TITLE
Adjust `KubernetesService().getRequest()` Function

### DIFF
--- a/lib/services/kubernetes_service.dart
+++ b/lib/services/kubernetes_service.dart
@@ -106,7 +106,7 @@ class KubernetesService {
   /// cluster. For that a user can pass in the [url], which should be called,
   /// the function then returns an error or a json object of the response from
   /// the Kubernetes API.
-  Future<Map<String, dynamic>> getRequest(String url) async {
+  Future<String> getRequest(String url) async {
     try {
       final result = await kubernetesRequest(
         cluster,
@@ -116,7 +116,7 @@ class KubernetesService {
         url,
         '',
       );
-      return json.decode(result);
+      return result;
     } catch (err) {
       Logger.log(
         'KubernetesService getRequest',

--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -54,11 +56,12 @@ class _OverviewEventsState extends State<OverviewEvents> {
         ? '${Resources.map['events']!.path}/namespaces/${cluster.namespace}/${Resources.map['events']!.resource}?fieldSelector=type=Warning'
         : '${Resources.map['events']!.path}/${Resources.map['events']!.resource}?fieldSelector=type=Warning';
 
-    final resourcesList = await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(resourcesListUrl);
+    final resourcesList = json.decode(result);
 
     Logger.log(
       'OverviewEventsRepository _fetchEvents',

--- a/lib/widgets/home/overview/overview_metric.dart
+++ b/lib/widgets/home/overview/overview_metric.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:fl_chart/fl_chart.dart';
@@ -130,7 +132,9 @@ class _OverviewMetricState extends State<OverviewMetric> {
       '/api/v1/nodes${widget.nodeName != null ? '?fieldSelector=metadata.name=${widget.nodeName}' : ''}',
     );
     final nodesList = IoK8sApiCoreV1NodeList.fromJson(
-      nodesData,
+      json.decode(
+        nodesData,
+      ),
     );
 
     final podsData = await KubernetesService(
@@ -141,7 +145,9 @@ class _OverviewMetricState extends State<OverviewMetric> {
       '/api/v1/pods${widget.nodeName != null ? '?fieldSelector=spec.nodeName=${widget.nodeName}' : ''}',
     );
     final podsList = IoK8sApiCoreV1PodList.fromJson(
-      podsData,
+      json.decode(
+        podsData,
+      ),
     );
 
     final nodeMetricsData = await KubernetesService(
@@ -152,7 +158,9 @@ class _OverviewMetricState extends State<OverviewMetric> {
       '/apis/metrics.k8s.io/v1beta1/nodes${widget.nodeName != null ? '?fieldSelector=metadata.name=${widget.nodeName}' : ''}',
     );
     final nodeMetricsList = ApisMetricsV1beta1NodeMetricsList.fromJson(
-      nodeMetricsData,
+      json.decode(
+        nodeMetricsData,
+      ),
     );
 
     var cpuAllocatable = 0.0;

--- a/lib/widgets/plugins/flux/plugin_flux_details.dart
+++ b/lib/widgets/plugins/flux/plugin_flux_details.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
@@ -139,11 +141,12 @@ class _PluginFluxDetailsState extends State<PluginFluxDetails> {
     final url =
         '${widget.resource.api.path}/namespaces/${widget.namespace}/${widget.resource.api.resource}/${widget.name}';
 
-    return await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(url);
+    return json.decode(result);
   }
 
   /// [_buildDetails] is responsible for showing the correct details item for

--- a/lib/widgets/plugins/flux/plugin_flux_list.dart
+++ b/lib/widgets/plugins/flux/plugin_flux_list.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart' as provider;
@@ -55,11 +57,12 @@ class _PluginFluxListState extends State<PluginFluxList> {
     final url =
         '${widget.resource.api.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource.api.resource}';
 
-    final data = await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(url);
+    final data = json.decode(result);
 
     return data['items'];
   }

--- a/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
+++ b/lib/widgets/plugins/prometheus/plugin_prometheus_details.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -64,7 +66,7 @@ class _PluginPrometheusDetailsState extends State<PluginPrometheusDetails> {
       timeout: appRepository.settings.timeout,
     ).getRequest(url);
 
-    final configMap = IoK8sApiCoreV1ConfigMap.fromJson(result);
+    final configMap = IoK8sApiCoreV1ConfigMap.fromJson(json.decode(result));
 
     if (configMap != null &&
         configMap.metadata != null &&

--- a/lib/widgets/plugins/prometheus/plugin_prometheus_list.dart
+++ b/lib/widgets/plugins/prometheus/plugin_prometheus_list.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -62,7 +64,8 @@ class _PluginPrometheusListState extends State<PluginPrometheusList> {
       timeout: appRepository.settings.timeout,
     ).getRequest(url);
 
-    final configMapsList = IoK8sApiCoreV1ConfigMapList.fromJson(result);
+    final configMapsList =
+        IoK8sApiCoreV1ConfigMapList.fromJson(json.decode(result));
 
     Logger.log(
       'PluginPrometheusListRepository fetchDashboards',

--- a/lib/widgets/resources/details/details_get_logs_pods.dart
+++ b/lib/widgets/resources/details/details_get_logs_pods.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -76,11 +78,13 @@ class _DetailsGetLogsPodsState extends State<DetailsGetLogsPods> {
         '/api/v1/namespaces/${widget.namespace}/pods?${getSelector(IoK8sApimachineryPkgApisMetaV1LabelSelector.fromJson(widget.item['spec']['selector']))}',
       );
 
+      final data = json.decode(result);
+
       setState(() {
         _isLoading = false;
-        _pods = IoK8sApiCoreV1PodList.fromJson(result)!.items;
-        if (result['items'].isNotEmpty) {
-          _podSpec = result['items'][0];
+        _pods = IoK8sApiCoreV1PodList.fromJson(data)!.items;
+        if (data['items'].isNotEmpty) {
+          _podSpec = data['items'][0];
         }
       });
     } catch (err) {

--- a/lib/widgets/resources/details/details_live_metrics.dart
+++ b/lib/widgets/resources/details/details_live_metrics.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 
@@ -101,11 +102,13 @@ class _DetailsLiveMetricsState extends State<DetailsLiveMetrics> {
       final url =
           '/apis/metrics.k8s.io/v1beta1/namespaces/${widget.namespace}/pods/${widget.name}';
 
-      final metricsData = await KubernetesService(
+      final result = await KubernetesService(
         cluster: cluster!,
         proxy: appRepository.settings.proxy,
         timeout: appRepository.settings.timeout,
       ).getRequest(url);
+
+      final metricsData = json.decode(result);
 
       Logger.log(
         'DetailsLiveMetricsRepository _fetchMetrics',

--- a/lib/widgets/resources/details/details_resources_preview.dart
+++ b/lib/widgets/resources/details/details_resources_preview.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -83,11 +85,13 @@ class _DetailsResourcesPreviewState extends State<DetailsResourcesPreview> {
         ? '${widget.path}/namespaces/${widget.namespace}/${widget.resource}?limit=5&${widget.selector}'
         : '${widget.path}/${widget.resource}?limit=5&${widget.selector}';
 
-    final resourcesList = await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(resourcesListUrl);
+
+    final resourcesList = json.decode(result);
 
     if (widget.filter != null) {
       return widget.filter!(resourcesList['items']);

--- a/lib/widgets/resources/details/pod_details_item.dart
+++ b/lib/widgets/resources/details/pod_details_item.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -59,11 +61,13 @@ class _PodDetailsItemState extends State<PodDetailsItem> {
       final url =
           '/apis/metrics.k8s.io/v1beta1/namespaces/${pod!.metadata!.namespace}/pods/${pod.metadata!.name}';
 
-      final metricsData = await KubernetesService(
+      final result = await KubernetesService(
         cluster: cluster!,
         proxy: appRepository.settings.proxy,
         timeout: appRepository.settings.timeout,
       ).getRequest(url);
+
+      final metricsData = json.decode(result);
 
       Logger.log(
         'PodDetailsItem _fetchMetrics',

--- a/lib/widgets/resources/resource_details.dart
+++ b/lib/widgets/resources/resource_details.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -417,11 +419,12 @@ class _ResourcesDetailsState extends State<ResourcesDetails> {
         ? '${widget.path}/${widget.resource}/${widget.name}'
         : '${widget.path}/namespaces/${widget.namespace}/${widget.resource}/${widget.name}';
 
-    return await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(resourcesDetailsUrl);
+    return json.decode(result);
   }
 
   /// [_buildDetailsItem] is responsible for showing the correct details item for

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -93,11 +95,13 @@ class _ResourcesListState extends State<ResourcesList> {
                 ? '${widget.path}/${widget.resource}?${widget.selector ?? ''}'
                 : '${widget.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource}?${widget.selector ?? ''}';
 
-    final resourcesList = await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(resourcesListUrl);
+
+    final resourcesList = json.decode(result);
 
     Logger.log(
       'ResourcesListRepository _init',

--- a/lib/widgets/resources/resources_list_crds.dart
+++ b/lib/widgets/resources/resources_list_crds.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -49,11 +51,13 @@ class _ResourcesListCRDsState extends State<ResourcesListCRDs> {
     final resourcesListUrl =
         '${Resources.map['customresourcedefinitions']!.path}/${Resources.map['customresourcedefinitions']!.resource}';
 
-    final resourcesList = await KubernetesService(
+    final result = await KubernetesService(
       cluster: cluster!,
       proxy: appRepository.settings.proxy,
       timeout: appRepository.settings.timeout,
     ).getRequest(resourcesListUrl);
+
+    final resourcesList = json.decode(result);
 
     Logger.log(
       'ResourcesListCRDsRepository _fetchItems',

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -55,7 +57,7 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
       timeout: appRepository.settings.timeout,
     ).getRequest('/api/v1/namespaces');
 
-    return IoK8sApiCoreV1NamespaceList.fromJson(result)!.items;
+    return IoK8sApiCoreV1NamespaceList.fromJson(json.decode(result))!.items;
   }
 
   /// [_getFilteredNamespaces] filters the given list of [namespaces] by the


### PR DESCRIPTION
Adjust the `KubernetesService().getRequest()` function, to return a `String` instead of a `Map<String, dynamic>`. Because of this adjustment we have to run `json.decode` always afer we are using the function, but this will allow us to run the decode and parsing function in it's own Isolate in the future to improve the perfromance.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
