### PR TITLE
Improve Bookmarks Namespace Handling

### DIFF
--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -159,7 +159,11 @@ class ClustersRepository with ChangeNotifier {
   /// [setNamespace] sets the namespace for the cluster provided via it's
   /// [clusterId] to the provided [namespace]. If we are not able to find the
   /// cluster with the provided id, we will do nothing.
-  Future<void> setNamespace(String clusterId, String namespace) async {
+  Future<void> setNamespace(String clusterId, String? namespace) async {
+    if (namespace == null) {
+      return;
+    }
+
     for (var i = 0; i < _clusters.length; i++) {
       if (_clusters[i].id == clusterId) {
         _clusters[i].namespace = namespace;

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -79,7 +79,7 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
             .setActiveCluster(bookmarksRepository.bookmarks[index].clusterId);
         await clustersRepository.setNamespace(
           bookmarksRepository.bookmarks[index].clusterId,
-          bookmarksRepository.bookmarks[index].namespace ?? '',
+          bookmarksRepository.bookmarks[index].namespace,
         );
 
         if (mounted) {
@@ -102,7 +102,7 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
             .setActiveCluster(bookmarksRepository.bookmarks[index].clusterId);
         await clustersRepository.setNamespace(
           bookmarksRepository.bookmarks[index].clusterId,
-          bookmarksRepository.bookmarks[index].namespace ?? '',
+          bookmarksRepository.bookmarks[index].namespace,
         );
 
         if (mounted) {

--- a/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks_preview.dart
@@ -46,7 +46,7 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
             .setActiveCluster(bookmarksRepository.bookmarks[index].clusterId);
         await clustersRepository.setNamespace(
           bookmarksRepository.bookmarks[index].clusterId,
-          bookmarksRepository.bookmarks[index].namespace ?? '',
+          bookmarksRepository.bookmarks[index].namespace,
         );
 
         if (mounted) {
@@ -69,7 +69,7 @@ class _ResourcesBookmarksPreviewState extends State<ResourcesBookmarksPreview> {
             .setActiveCluster(bookmarksRepository.bookmarks[index].clusterId);
         await clustersRepository.setNamespace(
           bookmarksRepository.bookmarks[index].clusterId,
-          bookmarksRepository.bookmarks[index].namespace ?? '',
+          bookmarksRepository.bookmarks[index].namespace,
         );
 
         if (mounted) {


### PR DESCRIPTION
If a bookmark doesn't contain a namespace, we do not change the namespace anymore, so that the user can continue working in his selected namespace, after opening a bookmark. Before the user would have to reselect the namespace he was in before opening the bookmark.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
