### PR TITLE
Adjust Resource Categories

### DIFF
--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -24,7 +24,7 @@ class Resources extends StatelessWidget {
 
   List<AppVerticalListSimpleModel> _buildItems(
     BuildContext context,
-    ResourceCategory resourceCategory,
+    String resourceCategory,
   ) {
     final resourcesForCategory =
         resources.where((e) => e.category == resourceCategory).toList();
@@ -118,13 +118,13 @@ class Resources extends StatelessWidget {
     return [
       const ResourcesBookmarksPreview(),
       ...List.generate(
-        ResourceCategory.values.length,
+        resourceCategories.length,
         (index) {
-          final resourceCategory = ResourceCategory.values[index];
+          final resourceCategory = resourceCategories[index];
           return Column(
             children: [
               AppVerticalListSimpleWidget(
-                title: resourceCategory.toLocalizedString(),
+                title: resourceCategory,
                 items: _buildItems(context, resourceCategory),
               ),
               const SizedBox(height: Constants.spacingMiddle),

--- a/lib/widgets/resources/resources/resources.dart
+++ b/lib/widgets/resources/resources/resources.dart
@@ -29,35 +29,23 @@ import 'package:kubenav/widgets/resources/resources/resources_statefulsets.dart'
 import 'package:kubenav/widgets/resources/resources/resources_storageclasses.dart';
 import 'package:kubenav/widgets/resources/resources_list.dart';
 
-/// [ResourceCategory] is a `enum`, which defines the different categories of
-/// Kubernetes resources. The categories are used to group the resources within
-/// the UI.
-enum ResourceCategory {
-  workload,
-  discoveryandloadbalancing,
-  configandstorage,
-  rbac,
-  cluster,
+/// [ResourceCategories] defines the different categories of Kubernetes
+/// resources. The categories are used to group the resources within the UI.
+class ResourceCategories {
+  static const workload = 'Workloads';
+  static const discoveryandloadbalancing = 'Discovery and Load Balancing';
+  static const configAndStorage = 'Config and Storage';
+  static const rbac = 'RBAC';
+  static const cluster = 'Cluster';
 }
 
-extension ResourceCategoryExtension on ResourceCategory {
-  /// [toLocalizedString] returns a string for the Kubernetes resource category,
-  /// which can be used in the UI.
-  String toLocalizedString() {
-    switch (this) {
-      case ResourceCategory.workload:
-        return 'Workloads';
-      case ResourceCategory.discoveryandloadbalancing:
-        return 'Discovery and Load Balancing';
-      case ResourceCategory.configandstorage:
-        return 'Config and Storage';
-      case ResourceCategory.rbac:
-        return 'RBAC';
-      case ResourceCategory.cluster:
-        return 'Cluster';
-    }
-  }
-}
+final List<String> resourceCategories = [
+  ResourceCategories.workload,
+  ResourceCategories.discoveryandloadbalancing,
+  ResourceCategories.configAndStorage,
+  ResourceCategories.rbac,
+  ResourceCategories.cluster,
+];
 
 /// [ResourceScope] is a `enum` for the scope of the Kubernetes resource. A
 /// Kubernetes resource can be `namespaced` (e.g. Pods, Deployments, etc.) or
@@ -90,7 +78,7 @@ ResourceScope getResourceScopeFromString(String? scope) {
 /// The [Resource] model represents a single Kubernetes resource, with all the
 /// information we need to get and display the resource.
 class Resource {
-  ResourceCategory category;
+  String category;
   String plural;
   String singular;
   String description;

--- a/lib/widgets/resources/resources/resources_clusterrolebindings.dart
+++ b/lib/widgets/resources/resources/resources_clusterrolebindings.dart
@@ -23,7 +23,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceClusterRoleBinding = Resource(
-  category: ResourceCategory.rbac,
+  category: ResourceCategories.rbac,
   plural: 'ClusterRoleBindings',
   singular: 'ClusterRoleBinding',
   description:

--- a/lib/widgets/resources/resources/resources_clusterroles.dart
+++ b/lib/widgets/resources/resources/resources_clusterroles.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceClusterRole = Resource(
-  category: ResourceCategory.rbac,
+  category: ResourceCategories.rbac,
   plural: 'ClusterRoles',
   singular: 'ClusterRole',
   description:

--- a/lib/widgets/resources/resources/resources_configmaps.dart
+++ b/lib/widgets/resources/resources/resources_configmaps.dart
@@ -22,7 +22,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceConfigMap = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'ConfigMaps',
   singular: 'ConfigMap',
   description:

--- a/lib/widgets/resources/resources/resources_cronjobs.dart
+++ b/lib/widgets/resources/resources/resources_cronjobs.dart
@@ -17,7 +17,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceCronJob = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'CronJobs',
   singular: 'CronJob',
   description: 'A CronJob creates Jobs on a repeating schedule.',

--- a/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
+++ b/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
@@ -25,7 +25,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceCustomResourceDefinition = Resource(
-  category: ResourceCategory.cluster,
+  category: ResourceCategories.cluster,
   plural: 'CustomResourceDefinitions',
   singular: 'CustomResourceDefinition',
   description: 'Custom resources are extensions of the Kubernetes API.',
@@ -271,7 +271,7 @@ Resource buildCustomResource(
   List<AdditionalPrinterColumns> additionalPrinterColumns,
 ) {
   return Resource(
-    category: ResourceCategory.cluster,
+    category: ResourceCategories.cluster,
     plural: plural,
     singular: singular,
     description: description,

--- a/lib/widgets/resources/resources/resources_daemonsets.dart
+++ b/lib/widgets/resources/resources/resources_daemonsets.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceDaemonSet = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'DaemonSets',
   singular: 'DaemonSet',
   description:

--- a/lib/widgets/resources/resources/resources_deployments.dart
+++ b/lib/widgets/resources/resources/resources_deployments.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceDeployment = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'Deployments',
   singular: 'Deployment',
   description:

--- a/lib/widgets/resources/resources/resources_endpoints.dart
+++ b/lib/widgets/resources/resources/resources_endpoints.dart
@@ -17,7 +17,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceEndpoint = Resource(
-  category: ResourceCategory.discoveryandloadbalancing,
+  category: ResourceCategories.discoveryandloadbalancing,
   plural: 'Endpoints',
   singular: 'Endpoint',
   description:

--- a/lib/widgets/resources/resources/resources_events.dart
+++ b/lib/widgets/resources/resources/resources_events.dart
@@ -13,7 +13,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceEvent = Resource(
-  category: ResourceCategory.cluster,
+  category: ResourceCategories.cluster,
   plural: 'Events',
   singular: 'Event',
   description:

--- a/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
+++ b/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
@@ -18,7 +18,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceHorizontalPodAutoscaler = Resource(
-  category: ResourceCategory.discoveryandloadbalancing,
+  category: ResourceCategories.discoveryandloadbalancing,
   plural: 'HorizontalPodAutoscalers',
   singular: 'HorizontalPodAutoscaler',
   description:

--- a/lib/widgets/resources/resources/resources_ingresses.dart
+++ b/lib/widgets/resources/resources/resources_ingresses.dart
@@ -15,7 +15,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceIngress = Resource(
-  category: ResourceCategory.discoveryandloadbalancing,
+  category: ResourceCategories.discoveryandloadbalancing,
   plural: 'Ingresses',
   singular: 'Ingress',
   description:

--- a/lib/widgets/resources/resources/resources_jobs.dart
+++ b/lib/widgets/resources/resources/resources_jobs.dart
@@ -18,7 +18,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceJob = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'Jobs',
   singular: 'Job',
   description:

--- a/lib/widgets/resources/resources/resources_namespaces.dart
+++ b/lib/widgets/resources/resources/resources_namespaces.dart
@@ -22,7 +22,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceNamespace = Resource(
-  category: ResourceCategory.cluster,
+  category: ResourceCategories.cluster,
   plural: 'Namespaces',
   singular: 'Namespace',
   description:

--- a/lib/widgets/resources/resources/resources_networkpolicies.dart
+++ b/lib/widgets/resources/resources/resources_networkpolicies.dart
@@ -17,7 +17,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceNetworkPolicy = Resource(
-  category: ResourceCategory.discoveryandloadbalancing,
+  category: ResourceCategories.discoveryandloadbalancing,
   plural: 'NetworkPolicies',
   singular: 'NetworkPolicy',
   description:

--- a/lib/widgets/resources/resources/resources_nodes.dart
+++ b/lib/widgets/resources/resources/resources_nodes.dart
@@ -23,7 +23,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceNode = Resource(
-  category: ResourceCategory.cluster,
+  category: ResourceCategories.cluster,
   plural: 'Nodes',
   singular: 'Node',
   description:

--- a/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
+++ b/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
@@ -22,7 +22,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final Resource resourcePersistentVolumeClaim = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'PersistentVolumeClaims',
   singular: 'PersistentVolumeClaim',
   description:

--- a/lib/widgets/resources/resources/resources_persistentvolumes.dart
+++ b/lib/widgets/resources/resources/resources_persistentvolumes.dart
@@ -20,7 +20,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final Resource resourcePersistentVolume = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'PersistentVolumes',
   singular: 'PersistentVolume',
   description:

--- a/lib/widgets/resources/resources/resources_poddisruptionbudgets.dart
+++ b/lib/widgets/resources/resources/resources_poddisruptionbudgets.dart
@@ -18,7 +18,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourcePodDisruptionBudget = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'PodDisruptionBudgets',
   singular: 'PodDisruptionBudget',
   description:

--- a/lib/widgets/resources/resources/resources_pods.dart
+++ b/lib/widgets/resources/resources/resources_pods.dart
@@ -42,7 +42,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourcePod = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'Pods',
   singular: 'Pod',
   description:

--- a/lib/widgets/resources/resources/resources_replicasets.dart
+++ b/lib/widgets/resources/resources/resources_replicasets.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceReplicaSet = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'ReplicaSets',
   singular: 'ReplicaSet',
   description:

--- a/lib/widgets/resources/resources/resources_rolebindings.dart
+++ b/lib/widgets/resources/resources/resources_rolebindings.dart
@@ -24,7 +24,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceRoleBinding = Resource(
-  category: ResourceCategory.rbac,
+  category: ResourceCategories.rbac,
   plural: 'RoleBindings',
   singular: 'RoleBinding',
   description:

--- a/lib/widgets/resources/resources/resources_roles.dart
+++ b/lib/widgets/resources/resources/resources_roles.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceRole = Resource(
-  category: ResourceCategory.rbac,
+  category: ResourceCategories.rbac,
   plural: 'Roles',
   singular: 'Role',
   description:

--- a/lib/widgets/resources/resources/resources_secrets.dart
+++ b/lib/widgets/resources/resources/resources_secrets.dart
@@ -22,7 +22,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceSecret = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'Secrets',
   singular: 'Secret',
   description:

--- a/lib/widgets/resources/resources/resources_serviceaccounts.dart
+++ b/lib/widgets/resources/resources/resources_serviceaccounts.dart
@@ -22,7 +22,7 @@ import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 
 final resourceServiceAccount = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'ServiceAccounts',
   singular: 'ServiceAccount',
   description:

--- a/lib/widgets/resources/resources/resources_services.dart
+++ b/lib/widgets/resources/resources/resources_services.dart
@@ -23,7 +23,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceService = Resource(
-  category: ResourceCategory.discoveryandloadbalancing,
+  category: ResourceCategories.discoveryandloadbalancing,
   plural: 'Services',
   singular: 'Service',
   description:

--- a/lib/widgets/resources/resources/resources_statefulsets.dart
+++ b/lib/widgets/resources/resources/resources_statefulsets.dart
@@ -19,7 +19,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceStatefulSet = Resource(
-  category: ResourceCategory.workload,
+  category: ResourceCategories.workload,
   plural: 'StatefulSets',
   singular: 'StatefulSet',
   description:

--- a/lib/widgets/resources/resources/resources_storageclasses.dart
+++ b/lib/widgets/resources/resources/resources_storageclasses.dart
@@ -15,7 +15,7 @@ import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
 final resourceStorageClass = Resource(
-  category: ResourceCategory.configandstorage,
+  category: ResourceCategories.configAndStorage,
   plural: 'StorageClasses',
   singular: 'StorageClass',
   description:


### PR DESCRIPTION
Adjust the resource categories, to use a `String` instead of an `Enum`, so that we can reuse the `Resources` class for other plugins, where we want to define other categories.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
