### PR TITLE
Add Status to Flux Resources

### DIFF
--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_buckets.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_buckets.dart
@@ -32,15 +32,24 @@ final Resource fluxResourceBucket = Resource(
     final items =
         IoFluxcdToolkitSourceV1beta2BucketList.fromJson(parsed)?.items ?? [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_gitrepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_gitrepositories.dart
@@ -32,15 +32,24 @@ final Resource fluxResourceGitRepository = Resource(
     final items =
         IoFluxcdToolkitSourceV1GitRepositoryList.fromJson(parsed)?.items ?? [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmcharts.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmcharts.dart
@@ -35,15 +35,24 @@ final Resource fluxResourceHelmChart = Resource(
     final items =
         IoFluxcdToolkitSourceV1beta2HelmChartList.fromJson(parsed)?.items ?? [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmreleases.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmreleases.dart
@@ -35,15 +35,24 @@ final Resource fluxResourceHelmRelease = Resource(
     final items =
         IoFluxcdToolkitHelmV2beta2HelmReleaseList.fromJson(parsed)?.items ?? [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmrepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmrepositories.dart
@@ -34,15 +34,24 @@ final Resource fluxResourceHelmRepository = Resource(
                 ?.items ??
             [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_kustomizations.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_kustomizations.dart
@@ -36,15 +36,24 @@ final Resource fluxResourceKustomization = Resource(
         IoFluxcdToolkitKustomizeV1KustomizationList.fromJson(parsed)?.items ??
             [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_ocirepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_ocirepositories.dart
@@ -33,15 +33,24 @@ final Resource fluxResourceOCIRepository = Resource(
         IoFluxcdToolkitSourceV1beta2OCIRepositoryList.fromJson(parsed)?.items ??
             [];
 
-    return items
-        .map(
-          (e) => ResourceItem(
-            item: e,
-            metrics: null,
-            status: ResourceStatus.undefined,
-          ),
-        )
-        .toList();
+    return items.map(
+      (e) {
+        final status = e.status?.conditions != null &&
+                e.status!.conditions!.isNotEmpty
+            ? e.status!.conditions!.where((e) => e.type == 'Ready').first.status
+            : 'Unknown';
+
+        return ResourceItem(
+          item: e,
+          metrics: null,
+          status: status == 'True'
+              ? ResourceStatus.success
+              : status == 'False'
+                  ? ResourceStatus.danger
+                  : ResourceStatus.warning,
+        );
+      },
+    ).toList();
   },
   decodeList: (String data) {
     final parsed = json.decode(data);


### PR DESCRIPTION
The resources of the Flux plugin now are containing a status, so that they can be filtered by there status in the list view. This also makes it easier for users to find unhealthy Flux resources.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
