### PR TITLE
Fix Unnecessary Rerenderings when Using Bookmark Action

### DIFF
--- a/lib/widgets/plugins/helm/plugin_helm_details.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details.dart
@@ -29,9 +29,9 @@ import 'package:kubenav/widgets/shared/app_vertical_list_simple_widget.dart';
 List<AppResourceActionsModel> helmDetailsActions(
   BuildContext context,
   Release release,
-  List<AppResourceActionsModel> additionalActions,
+  void Function()? refresh,
 ) {
-  return [
+  final actions = [
     AppResourceActionsModel(
       title: 'Values',
       icon: Icons.description,
@@ -87,8 +87,19 @@ List<AppResourceActionsModel> helmDetailsActions(
         );
       },
     ),
-    ...additionalActions,
   ];
+
+  if (refresh != null) {
+    actions.add(
+      AppResourceActionsModel(
+        title: 'Refresh',
+        icon: Icons.refresh,
+        onTap: refresh,
+      ),
+    );
+  }
+
+  return actions;
 }
 
 /// The [PluginHelmDetails] widget can be used to show the details of a Helm
@@ -327,19 +338,12 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                             actions: helmDetailsActions(
                               context,
                               release,
-                              [
-                                AppResourceActionsModel(
-                                  title: 'Refresh',
-                                  icon: Icons.refresh,
-                                  onTap: () {
-                                    setState(() {
-                                      _futureFetchHelmRelease =
-                                          _fetchHelmRelease();
-                                      _futureFetchHistory = _fetchHistory();
-                                    });
-                                  },
-                                ),
-                              ],
+                              () {
+                                setState(() {
+                                  _futureFetchHelmRelease = _fetchHelmRelease();
+                                  _futureFetchHistory = _fetchHistory();
+                                });
+                              },
                             ),
                           ),
                           DetailsItem(

--- a/lib/widgets/plugins/helm/plugin_helm_list_item_actions.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list_item_actions.dart
@@ -28,7 +28,7 @@ class _PluginHelmListItemActionsState extends State<PluginHelmListItemActions> {
       actions: helmDetailsActions(
         context,
         widget.release,
-        [],
+        null,
       ),
     );
   }

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -353,12 +353,6 @@ class _ResourcesListState extends State<ResourcesList> {
                         );
                       }
 
-                      BookmarksRepository bookmarksRepository =
-                          Provider.of<BookmarksRepository>(
-                        context,
-                        listen: true,
-                      );
-
                       final filteredItems = _getFilteredItems(snapshot.data!);
 
                       return Wrap(
@@ -439,93 +433,13 @@ class _ResourcesListState extends State<ResourcesList> {
                               ],
                             ),
                           ),
-                          AppResourceActions(
-                            mode: AppResourceActionsMode.header,
-                            actions: [
-                              AppResourceActionsModel(
-                                title: 'Create',
-                                icon: Icons.create,
-                                onTap: () {
-                                  showModal(
-                                    context,
-                                    ResourcesListItemCreateResource(
-                                      resource: widget.resource,
-                                    ),
-                                  );
-                                },
-                              ),
-                              AppResourceActionsModel(
-                                title: 'Refresh',
-                                icon: Icons.refresh,
-                                onTap: () {
-                                  setState(() {
-                                    _futureFetchItems = _fetchItems();
-                                  });
-                                },
-                              ),
-                              AppResourceActionsModel(
-                                title: bookmarksRepository.isBookmarked(
-                                          BookmarkType.list,
-                                          clustersRepository.activeClusterId,
-                                          null,
-                                          clustersRepository
-                                              .getCluster(
-                                                clustersRepository
-                                                    .activeClusterId,
-                                              )
-                                              ?.namespace,
-                                          widget.resource,
-                                        ) >
-                                        -1
-                                    ? 'Remove Bookmark'
-                                    : 'Add Bookmark',
-                                icon: bookmarksRepository.isBookmarked(
-                                          BookmarkType.list,
-                                          clustersRepository.activeClusterId,
-                                          null,
-                                          clustersRepository
-                                              .getCluster(
-                                                clustersRepository
-                                                    .activeClusterId,
-                                              )
-                                              ?.namespace,
-                                          widget.resource,
-                                        ) >
-                                        -1
-                                    ? Icons.bookmark
-                                    : Icons.bookmark_border,
-                                onTap: () {
-                                  final bookmarkIndex =
-                                      bookmarksRepository.isBookmarked(
-                                    BookmarkType.list,
-                                    clustersRepository.activeClusterId,
-                                    null,
-                                    clustersRepository
-                                        .getCluster(
-                                          clustersRepository.activeClusterId,
-                                        )
-                                        ?.namespace,
-                                    widget.resource,
-                                  );
-                                  if (bookmarkIndex > -1) {
-                                    bookmarksRepository
-                                        .removeBookmark(bookmarkIndex);
-                                  } else {
-                                    bookmarksRepository.addBookmark(
-                                      BookmarkType.list,
-                                      clustersRepository.activeClusterId,
-                                      null,
-                                      clustersRepository
-                                          .getCluster(
-                                            clustersRepository.activeClusterId,
-                                          )
-                                          ?.namespace,
-                                      widget.resource,
-                                    );
-                                  }
-                                },
-                              ),
-                            ],
+                          ResourcesListActions(
+                            resource: widget.resource,
+                            refresh: () {
+                              setState(() {
+                                _futureFetchItems = _fetchItems();
+                              });
+                            },
                           ),
                           Container(
                             padding: const EdgeInsets.only(
@@ -562,6 +476,113 @@ class _ResourcesListState extends State<ResourcesList> {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// The [ResourcesListActions] widget is used to render the actions for the
+/// resources in the list view. The [ResourcesListActions] widget is used in the
+/// [ResourcesList] widget.
+class ResourcesListActions extends StatelessWidget {
+  const ResourcesListActions({
+    super.key,
+    required this.resource,
+    required this.refresh,
+  });
+
+  final Resource resource;
+  final void Function() refresh;
+
+  @override
+  Widget build(BuildContext context) {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
+    BookmarksRepository bookmarksRepository = Provider.of<BookmarksRepository>(
+      context,
+      listen: true,
+    );
+
+    return AppResourceActions(
+      mode: AppResourceActionsMode.header,
+      actions: [
+        AppResourceActionsModel(
+          title: 'Create',
+          icon: Icons.create,
+          onTap: () {
+            showModal(
+              context,
+              ResourcesListItemCreateResource(
+                resource: resource,
+              ),
+            );
+          },
+        ),
+        AppResourceActionsModel(
+          title: 'Refresh',
+          icon: Icons.refresh,
+          onTap: refresh,
+        ),
+        AppResourceActionsModel(
+          title: bookmarksRepository.isBookmarked(
+                    BookmarkType.list,
+                    clustersRepository.activeClusterId,
+                    null,
+                    clustersRepository
+                        .getCluster(
+                          clustersRepository.activeClusterId,
+                        )
+                        ?.namespace,
+                    resource,
+                  ) >
+                  -1
+              ? 'Remove Bookmark'
+              : 'Add Bookmark',
+          icon: bookmarksRepository.isBookmarked(
+                    BookmarkType.list,
+                    clustersRepository.activeClusterId,
+                    null,
+                    clustersRepository
+                        .getCluster(
+                          clustersRepository.activeClusterId,
+                        )
+                        ?.namespace,
+                    resource,
+                  ) >
+                  -1
+              ? Icons.bookmark
+              : Icons.bookmark_border,
+          onTap: () {
+            final bookmarkIndex = bookmarksRepository.isBookmarked(
+              BookmarkType.list,
+              clustersRepository.activeClusterId,
+              null,
+              clustersRepository
+                  .getCluster(
+                    clustersRepository.activeClusterId,
+                  )
+                  ?.namespace,
+              resource,
+            );
+            if (bookmarkIndex > -1) {
+              bookmarksRepository.removeBookmark(bookmarkIndex);
+            } else {
+              bookmarksRepository.addBookmark(
+                BookmarkType.list,
+                clustersRepository.activeClusterId,
+                null,
+                clustersRepository
+                    .getCluster(
+                      clustersRepository.activeClusterId,
+                    )
+                    ?.namespace,
+                resource,
+              );
+            }
+          },
+        ),
+      ],
     );
   }
 }
@@ -773,7 +794,7 @@ class ResourcesListItemActions<T> extends StatelessWidget {
         namespace,
         resource,
         item,
-        [],
+        null,
       ),
     );
   }


### PR DESCRIPTION
When a user bookmarked a list of resources or a single resource in the details view, the whole page was rerendered, because we have to listen for updates on the `BookmarksRepository`. To avoid that the whole view is rerendered we moved the actions to a seperate widget and only listen there for changes of the `BookmarksRepository`.

We also changed the `additionalActions` property, to not except a list of actions, but only a `refresh` function, which can be defined in the details view and which can be `null` in the list view.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
