### PR TITLE
Add Kind to Metadata

### DIFF
--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_buckets.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_buckets.dart
@@ -115,7 +115,10 @@ final Resource fluxResourceBucket = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_gitrepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_gitrepositories.dart
@@ -116,7 +116,10 @@ final Resource fluxResourceGitRepository = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmcharts.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmcharts.dart
@@ -119,7 +119,10 @@ final Resource fluxResourceHelmChart = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmreleases.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmreleases.dart
@@ -119,7 +119,10 @@ final Resource fluxResourceHelmRelease = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmrepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_helmrepositories.dart
@@ -124,7 +124,10 @@ final Resource fluxResourceHelmRepository = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_kustomizations.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_kustomizations.dart
@@ -124,7 +124,10 @@ final Resource fluxResourceKustomization = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/plugins/flux/resources/plugin_flux_resources_ocirepositories.dart
+++ b/lib/widgets/plugins/flux/resources/plugin_flux_resources_ocirepositories.dart
@@ -121,7 +121,10 @@ final Resource fluxResourceOCIRepository = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/resources/helpers/details_item_metadata.dart
+++ b/lib/widgets/resources/helpers/details_item_metadata.dart
@@ -9,9 +9,11 @@ import 'package:kubenav/widgets/resources/helpers/details_item.dart';
 class DetailsItemMetadata extends StatelessWidget {
   const DetailsItemMetadata({
     super.key,
+    required this.kind,
     required this.metadata,
   });
 
+  final String? kind;
   final IoK8sApimachineryPkgApisMetaV1ObjectMeta? metadata;
 
   @override
@@ -25,6 +27,10 @@ class DetailsItemMetadata extends StatelessWidget {
     return DetailsItem(
       title: 'Metadata',
       details: [
+        DetailsItemModel(
+          name: 'Kind',
+          values: kind,
+        ),
         DetailsItemModel(
           name: 'Name',
           values: metadata?.name,

--- a/lib/widgets/resources/resources/resources_clusterrolebindings.dart
+++ b/lib/widgets/resources/resources/resources_clusterrolebindings.dart
@@ -109,7 +109,10 @@ final resourceClusterRoleBinding = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',

--- a/lib/widgets/resources/resources/resources_clusterroles.dart
+++ b/lib/widgets/resources/resources/resources_clusterroles.dart
@@ -106,7 +106,10 @@ final resourceClusterRole = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         AppVerticalListSimpleWidget(
           title: 'Rules',

--- a/lib/widgets/resources/resources/resources_configmaps.dart
+++ b/lib/widgets/resources/resources/resources_configmaps.dart
@@ -109,7 +109,10 @@ final resourceConfigMap = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         AppVerticalListSimpleWidget(
           title: 'Data',

--- a/lib/widgets/resources/resources/resources_cronjobs.dart
+++ b/lib/widgets/resources/resources/resources_cronjobs.dart
@@ -112,7 +112,10 @@ final resourceCronJob = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',

--- a/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
+++ b/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
@@ -128,7 +128,10 @@ final resourceCustomResourceDefinition = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',
@@ -483,7 +486,12 @@ class CustomResourceItem extends StatelessWidget {
                   color: Theme.of(context).colorScheme.primary,
                 );
               default:
-                return DetailsItemMetadata(metadata: snapshot.data);
+                return DetailsItemMetadata(
+                  kind: item != null && item.containsKey('kind')
+                      ? item['kind']
+                      : null,
+                  metadata: snapshot.data,
+                );
             }
           },
         ),

--- a/lib/widgets/resources/resources/resources_daemonsets.dart
+++ b/lib/widgets/resources/resources/resources_daemonsets.dart
@@ -141,7 +141,10 @@ final resourceDaemonSet = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_deployments.dart
+++ b/lib/widgets/resources/resources/resources_deployments.dart
@@ -119,7 +119,10 @@ final resourceDeployment = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_endpoints.dart
+++ b/lib/widgets/resources/resources/resources_endpoints.dart
@@ -120,7 +120,10 @@ final resourceEndpoint = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         ..._buildSubsets(context, item),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsResourcesPreview(

--- a/lib/widgets/resources/resources/resources_events.dart
+++ b/lib/widgets/resources/resources/resources_events.dart
@@ -106,7 +106,10 @@ final resourceEvent = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Details',

--- a/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
+++ b/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
@@ -129,7 +129,10 @@ final resourceHorizontalPodAutoscaler = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_ingresses.dart
+++ b/lib/widgets/resources/resources/resources_ingresses.dart
@@ -123,7 +123,10 @@ final resourceIngress = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',

--- a/lib/widgets/resources/resources/resources_jobs.dart
+++ b/lib/widgets/resources/resources/resources_jobs.dart
@@ -121,7 +121,10 @@ final resourceJob = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_namespaces.dart
+++ b/lib/widgets/resources/resources/resources_namespaces.dart
@@ -109,7 +109,10 @@ final resourceNamespace = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_networkpolicies.dart
+++ b/lib/widgets/resources/resources/resources_networkpolicies.dart
@@ -117,7 +117,10 @@ final resourceNetworkPolicy = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/resources/resources/resources_nodes.dart
+++ b/lib/widgets/resources/resources/resources_nodes.dart
@@ -134,7 +134,10 @@ final resourceNode = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
+++ b/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
@@ -121,7 +121,10 @@ final Resource resourcePersistentVolumeClaim = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_persistentvolumes.dart
+++ b/lib/widgets/resources/resources/resources_persistentvolumes.dart
@@ -120,7 +120,10 @@ final Resource resourcePersistentVolume = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',

--- a/lib/widgets/resources/resources/resources_poddisruptionbudgets.dart
+++ b/lib/widgets/resources/resources/resources_poddisruptionbudgets.dart
@@ -116,7 +116,10 @@ final resourcePodDisruptionBudget = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(conditions: item.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/resources/resources/resources_pods.dart
+++ b/lib/widgets/resources/resources/resources_pods.dart
@@ -269,7 +269,10 @@ class PodItem extends StatelessWidget {
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: pod.metadata),
+        DetailsItemMetadata(
+          kind: pod.kind,
+          metadata: pod.metadata,
+        ),
         DetailsItemConditions(
           conditions: pod.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_replicasets.dart
+++ b/lib/widgets/resources/resources/resources_replicasets.dart
@@ -115,7 +115,10 @@ final resourceReplicaSet = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_rolebindings.dart
+++ b/lib/widgets/resources/resources/resources_rolebindings.dart
@@ -110,7 +110,10 @@ final resourceRoleBinding = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',

--- a/lib/widgets/resources/resources/resources_roles.dart
+++ b/lib/widgets/resources/resources/resources_roles.dart
@@ -106,7 +106,10 @@ final resourceRole = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         AppVerticalListSimpleWidget(
           title: 'Rules',

--- a/lib/widgets/resources/resources/resources_secrets.dart
+++ b/lib/widgets/resources/resources/resources_secrets.dart
@@ -111,7 +111,10 @@ final resourceSecret = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         AppVerticalListSimpleWidget(
           title: 'Data',

--- a/lib/widgets/resources/resources/resources_serviceaccounts.dart
+++ b/lib/widgets/resources/resources/resources_serviceaccounts.dart
@@ -110,7 +110,10 @@ final resourceServiceAccount = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         AppVerticalListSimpleWidget(
           title: 'Secrets',

--- a/lib/widgets/resources/resources/resources_services.dart
+++ b/lib/widgets/resources/resources/resources_services.dart
@@ -216,7 +216,10 @@ class ServiceItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        DetailsItemMetadata(metadata: service.metadata),
+        DetailsItemMetadata(
+          kind: service.kind,
+          metadata: service.metadata,
+        ),
         DetailsItemConditions(conditions: service.status?.conditions),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(

--- a/lib/widgets/resources/resources/resources_statefulsets.dart
+++ b/lib/widgets/resources/resources/resources_statefulsets.dart
@@ -117,7 +117,10 @@ final resourceStatefulSet = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         DetailsItemConditions(
           conditions: item.status?.conditions
               .map(

--- a/lib/widgets/resources/resources/resources_storageclasses.dart
+++ b/lib/widgets/resources/resources/resources_storageclasses.dart
@@ -107,7 +107,10 @@ final resourceStorageClass = Resource(
 
     return Column(
       children: [
-        DetailsItemMetadata(metadata: item.metadata),
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
         const SizedBox(height: Constants.spacingMiddle),
         DetailsItem(
           title: 'Configuration',


### PR DESCRIPTION
We are now showing the `kind` of a resources in the metadata section of the details view. This was done, to make it clear which kind of resource the user is currently viewing, which can be a bit difficulte when going to references.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
