### PR TITLE
Show Workload Status on Home Page

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -433,11 +433,21 @@ class AppRepositorySettingsHome {
   bool useSelectedNamespace;
   bool showMetrics;
   bool showWarnings;
+  bool showWorkloadPods;
+  bool showWorkloadDeployments;
+  bool showWorkloadStatefulSets;
+  bool showWorkloadDaemonSets;
+  bool showWorkloadJobs;
 
   AppRepositorySettingsHome({
     required this.useSelectedNamespace,
     required this.showMetrics,
     required this.showWarnings,
+    required this.showWorkloadPods,
+    required this.showWorkloadDeployments,
+    required this.showWorkloadStatefulSets,
+    required this.showWorkloadDaemonSets,
+    required this.showWorkloadJobs,
   });
 
   factory AppRepositorySettingsHome.fromDefault() {
@@ -445,6 +455,11 @@ class AppRepositorySettingsHome {
       useSelectedNamespace: false,
       showMetrics: true,
       showWarnings: true,
+      showWorkloadPods: false,
+      showWorkloadDeployments: false,
+      showWorkloadStatefulSets: false,
+      showWorkloadDaemonSets: false,
+      showWorkloadJobs: false,
     );
   }
 
@@ -462,6 +477,26 @@ class AppRepositorySettingsHome {
           data.containsKey('showWarnings') && data['showWarnings'] != null
               ? data['showWarnings']
               : true,
+      showWorkloadPods: data.containsKey('showWorkloadPods') &&
+              data['showWorkloadPods'] != null
+          ? data['showWorkloadPods']
+          : true,
+      showWorkloadDeployments: data.containsKey('showWorkloadDeployments') &&
+              data['showWorkloadDeployments'] != null
+          ? data['showWorkloadDeployments']
+          : true,
+      showWorkloadStatefulSets: data.containsKey('showWorkloadStatefulSets') &&
+              data['showWorkloadStatefulSets'] != null
+          ? data['showWorkloadStatefulSets']
+          : true,
+      showWorkloadDaemonSets: data.containsKey('showWorkloadDaemonSets') &&
+              data['showWorkloadDaemonSets'] != null
+          ? data['showWorkloadDaemonSets']
+          : true,
+      showWorkloadJobs: data.containsKey('showWorkloadJobs') &&
+              data['showWorkloadJobs'] != null
+          ? data['showWorkloadJobs']
+          : true,
     );
   }
 
@@ -470,6 +505,11 @@ class AppRepositorySettingsHome {
       'useSelectedNamespace': useSelectedNamespace,
       'showMetrics': showMetrics,
       'showWarnings': showWarnings,
+      'showWorkloadPods': showWorkloadPods,
+      'showWorkloadDeployments': showWorkloadDeployments,
+      'showWorkloadStatefulSets': showWorkloadStatefulSets,
+      'showWorkloadDaemonSets': showWorkloadDaemonSets,
+      'showWorkloadJobs': showWorkloadJobs,
     };
   }
 }

--- a/lib/widgets/home/home_overview.dart
+++ b/lib/widgets/home/home_overview.dart
@@ -10,6 +10,7 @@ import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/home/overview/overview_actions.dart';
 import 'package:kubenav/widgets/home/overview/overview_events.dart';
 import 'package:kubenav/widgets/home/overview/overview_metrics.dart';
+import 'package:kubenav/widgets/home/overview/overview_workloads.dart';
 import 'package:kubenav/widgets/shared/app_bottom_navigation_bar_widget.dart';
 import 'package:kubenav/widgets/shared/app_clusters_widget.dart';
 import 'package:kubenav/widgets/shared/app_floating_action_buttons_widget.dart';
@@ -40,6 +41,8 @@ class HomeOverview extends StatelessWidget {
     final List<Widget> content = [
       const OverviewActions(),
     ];
+
+    content.add(const OverviewWorkloads());
 
     if (appRepository.settings.home.showMetrics) {
       content.add(const OverviewMetrics(nodeName: null));

--- a/lib/widgets/home/overview/overview_workloads.dart
+++ b/lib/widgets/home/overview/overview_workloads.dart
@@ -1,0 +1,351 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/navigate.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/utils/themes.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/resources/resources/resources_daemonsets.dart';
+import 'package:kubenav/widgets/resources/resources/resources_deployments.dart';
+import 'package:kubenav/widgets/resources/resources/resources_jobs.dart';
+import 'package:kubenav/widgets/resources/resources/resources_pods.dart';
+import 'package:kubenav/widgets/resources/resources/resources_statefulsets.dart';
+import 'package:kubenav/widgets/resources/resources_list.dart';
+import 'package:kubenav/widgets/shared/app_resource_actions.dart';
+
+/// The [ResourceStatusCounts] class is used to store the counts for all
+/// [ResourceStatus] types and is used as the return type for the [_fetchItems]
+/// method in the [OverviewWorkload] widget.
+class ResourceStatusCounts {
+  final int all;
+  final int success;
+  final int warning;
+  final int danger;
+
+  const ResourceStatusCounts({
+    required this.all,
+    required this.success,
+    required this.warning,
+    required this.danger,
+  });
+}
+
+/// The [OverviewWorkloads] widget is used to display the workloads on the
+/// overview screen. Depending on the activated workloads in the settings, the
+/// widget will show the pods, deployments, statefulsets, daemonsets and jobs.
+class OverviewWorkloads extends StatelessWidget {
+  const OverviewWorkloads({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: true,
+    );
+
+    final List<Resource> resources = [];
+    if (appRepository.settings.home.showWorkloadPods) {
+      resources.add(resourcePod);
+    }
+    if (appRepository.settings.home.showWorkloadDeployments) {
+      resources.add(resourceDeployment);
+    }
+    if (appRepository.settings.home.showWorkloadStatefulSets) {
+      resources.add(resourceStatefulSet);
+    }
+    if (appRepository.settings.home.showWorkloadDaemonSets) {
+      resources.add(resourceDaemonSet);
+    }
+    if (appRepository.settings.home.showWorkloadJobs) {
+      resources.add(resourceJob);
+    }
+
+    if (resources.isEmpty) {
+      return Container();
+    }
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(Constants.spacingMiddle),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Workloads',
+                  style: primaryTextStyle(context, size: 18),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.only(
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          height: 206,
+          child: GridView.count(
+            scrollDirection: Axis.horizontal,
+            cacheExtent: 1024,
+            crossAxisCount: 2,
+            childAspectRatio: 0.30,
+            mainAxisSpacing: Constants.spacingMiddle,
+            children: List.generate(
+              resources.length,
+              (index) {
+                return Container(
+                  margin: const EdgeInsets.all(
+                    Constants.spacingSmall,
+                  ),
+                  child: OverviewWorkload(resource: resources[index]),
+                );
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+      ],
+    );
+  }
+}
+
+/// The [OverviewWorkload] widget is used to display the counts for a specific
+/// workload on the overview screen. The widget will show the icon, the name of
+/// the workload and the counts for all, healthy, warning and unhealthy
+/// resources.
+class OverviewWorkload extends StatefulWidget {
+  const OverviewWorkload({
+    super.key,
+    required this.resource,
+  });
+
+  final Resource resource;
+
+  @override
+  State<OverviewWorkload> createState() => _OverviewWorkloadState();
+}
+
+class _OverviewWorkloadState extends State<OverviewWorkload> {
+  late Future<ResourceStatusCounts> _futureFetchItems;
+
+  Future<ResourceStatusCounts> _fetchItems() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    final cluster = await clustersRepository.getClusterWithCredentials(
+      clustersRepository.activeClusterId,
+    );
+
+    final url = appRepository.settings.home.useSelectedNamespace &&
+            cluster!.namespace != ''
+        ? '${widget.resource.path}/namespaces/${cluster.namespace}/${widget.resource.resource}'
+        : '${widget.resource.path}/${widget.resource.resource}';
+
+    final result = await KubernetesService(
+      cluster: cluster!,
+      proxy: appRepository.settings.proxy,
+      timeout: appRepository.settings.timeout,
+    ).getRequest(url);
+
+    final data = await compute(
+      widget.resource.decodeListData,
+      ResourcesListData(
+        list: result,
+        metrics: null,
+      ),
+    );
+
+    return ResourceStatusCounts(
+      all: data.length,
+      success: data.where((e) => e.status == ResourceStatus.success).length,
+      warning: data.where((e) => e.status == ResourceStatus.warning).length,
+      danger: data.where((e) => e.status == ResourceStatus.danger).length,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    setState(() {
+      _futureFetchItems = _fetchItems();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Provider.of<ClustersRepository>(
+      context,
+      listen: true,
+    );
+
+    return InkWell(
+      onTap: () {
+        showActions(
+          context,
+          OverviewWorkloadActions(
+            resource: widget.resource,
+          ),
+        );
+      },
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(Constants.spacingListItemContent),
+        decoration: BoxDecoration(
+          boxShadow: [
+            BoxShadow(
+              color: Theme.of(context).extension<CustomColors>()!.shadow,
+              blurRadius: Constants.sizeBorderBlurRadius,
+              spreadRadius: Constants.sizeBorderSpreadRadius,
+              offset: const Offset(0.0, 0.0),
+            ),
+          ],
+          color: Theme.of(context).colorScheme.background,
+          borderRadius: const BorderRadius.all(
+            Radius.circular(Constants.sizeBorderRadius),
+          ),
+        ),
+        child: FutureBuilder(
+          future: _futureFetchItems,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<ResourceStatusCounts> snapshot,
+          ) {
+            return Row(
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    borderRadius: const BorderRadius.all(
+                      Radius.circular(Constants.sizeBorderRadius),
+                    ),
+                  ),
+                  height: 54,
+                  width: 54,
+                  padding: const EdgeInsets.all(
+                    Constants.spacingIcon54x54,
+                  ),
+                  child: SvgPicture.asset(
+                    'assets/resources/${widget.resource.icon}.svg',
+                  ),
+                ),
+                const SizedBox(width: Constants.spacingSmall),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.resource.plural,
+                        style: primaryTextStyle(
+                          context,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Row(
+                        children: [
+                          Text(
+                            'All: ${snapshot.data?.all ?? 0}\nHealthy: ${snapshot.data?.success ?? 0}',
+                            style: secondaryTextStyle(
+                              context,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          const SizedBox(width: Constants.spacingMiddle),
+                          Text(
+                            'Warning: ${snapshot.data?.warning ?? 0}\nUnhealthy: ${snapshot.data?.danger ?? 0}',
+                            style: secondaryTextStyle(
+                              context,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// The [OverviewWorkloadActions] widget is used to display the actions for a
+/// specific workload on the overview screen. The widget will show the actions
+/// for all, healthy, warning and unhealthy resources. When an action is tapped,
+/// the [ResourcesList] widget will be opened with the selected status.
+class OverviewWorkloadActions extends StatelessWidget {
+  const OverviewWorkloadActions({
+    super.key,
+    required this.resource,
+  });
+
+  final Resource resource;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppResourceActions(
+      mode: AppResourceActionsMode.actions,
+      actions: List.generate(
+        ResourceStatus.values.length,
+        (index) {
+          return AppResourceActionsModel(
+            title: ResourceStatus.values[index].toLocalizedString(),
+            icon: Icons.list,
+            onTap: () async {
+              ClustersRepository clustersRepository =
+                  Provider.of<ClustersRepository>(
+                context,
+                listen: false,
+              );
+              AppRepository appRepository = Provider.of<AppRepository>(
+                context,
+                listen: false,
+              );
+
+              try {
+                if (!appRepository.settings.home.useSelectedNamespace) {
+                  await clustersRepository.setNamespace(
+                    clustersRepository.activeClusterId,
+                    '',
+                  );
+                }
+                if (context.mounted) {
+                  navigate(
+                    context,
+                    ResourcesList(
+                      resource: resource,
+                      namespace: null,
+                      selector: null,
+                      status: ResourceStatus.values[index],
+                    ),
+                  );
+                }
+              } catch (_) {}
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -57,8 +57,7 @@ class Resources extends StatelessWidget {
               padding: const EdgeInsets.all(
                 Constants.spacingIcon54x54,
               ),
-              child:
-                  SvgPicture.asset('assets/resources/${resource.resource}.svg'),
+              child: SvgPicture.asset('assets/resources/${resource.icon}.svg'),
             ),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -59,11 +59,13 @@ class ResourcesList extends StatefulWidget {
     required this.resource,
     required this.namespace,
     required this.selector,
+    this.status = ResourceStatus.undefined,
   });
 
   final Resource resource;
   final String? namespace;
   final String? selector;
+  final ResourceStatus status;
 
   @override
   State<ResourcesList> createState() => _ResourcesListState();
@@ -187,10 +189,12 @@ class _ResourcesListState extends State<ResourcesList> {
 
   @override
   void initState() {
+    super.initState();
+
     _filterController.addListener(() {
       setState(() {});
     });
-    super.initState();
+    _status = widget.status;
   }
 
   @override
@@ -770,7 +774,7 @@ class ResourcesListItem extends StatelessWidget {
 /// The [ResourcesListItemActions] widget is used to display the actions for a
 /// [ResourcesListItem]. It reuses the [resourceDetailsActions] function to
 /// generate the actions for the provided [item].
-class ResourcesListItemActions<T> extends StatelessWidget {
+class ResourcesListItemActions extends StatelessWidget {
   const ResourcesListItemActions({
     super.key,
     required this.name,
@@ -782,7 +786,7 @@ class ResourcesListItemActions<T> extends StatelessWidget {
   final String name;
   final String? namespace;
   final Resource resource;
-  final T item;
+  final dynamic item;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/settings/settings/settings_home_page.dart
+++ b/lib/widgets/settings/settings/settings_home_page.dart
@@ -26,6 +26,11 @@ class _SettingsHomePageState extends State<SettingsHomePage> {
   bool _useSelectedNamespace = false;
   bool _showMetrics = false;
   bool _showWarnings = false;
+  bool _showWorkloadPods = false;
+  bool _showWorkloadDeployments = false;
+  bool _showWorkloadStatefulSets = false;
+  bool _showWorkloadDaemonSets = false;
+  bool _showWorkloadJobs = false;
 
   @override
   void initState() {
@@ -33,6 +38,11 @@ class _SettingsHomePageState extends State<SettingsHomePage> {
     _useSelectedNamespace = widget.currentHome.useSelectedNamespace;
     _showMetrics = widget.currentHome.showMetrics;
     _showWarnings = widget.currentHome.showWarnings;
+    _showWorkloadPods = widget.currentHome.showWorkloadPods;
+    _showWorkloadDeployments = widget.currentHome.showWorkloadDeployments;
+    _showWorkloadStatefulSets = widget.currentHome.showWorkloadStatefulSets;
+    _showWorkloadDaemonSets = widget.currentHome.showWorkloadDaemonSets;
+    _showWorkloadJobs = widget.currentHome.showWorkloadJobs;
   }
 
   @override
@@ -58,6 +68,11 @@ class _SettingsHomePageState extends State<SettingsHomePage> {
               useSelectedNamespace: _useSelectedNamespace,
               showMetrics: _showMetrics,
               showWarnings: _showWarnings,
+              showWorkloadPods: _showWorkloadPods,
+              showWorkloadDeployments: _showWorkloadDeployments,
+              showWorkloadStatefulSets: _showWorkloadStatefulSets,
+              showWorkloadDaemonSets: _showWorkloadDaemonSets,
+              showWorkloadJobs: _showWorkloadJobs,
             ),
           );
           Navigator.pop(context);
@@ -150,6 +165,115 @@ class _SettingsHomePageState extends State<SettingsHomePage> {
                         });
                       },
                       value: _showWarnings,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingExtraLarge),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                    Text(
+                      'Workloads',
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    const Expanded(
+                      child: Divider(
+                        height: 0,
+                        thickness: 1.0,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show Pods'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWorkloadPods = !_showWorkloadPods;
+                        });
+                      },
+                      value: _showWorkloadPods,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show Deployments'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWorkloadDeployments = !_showWorkloadDeployments;
+                        });
+                      },
+                      value: _showWorkloadDeployments,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show StatefulSets'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWorkloadStatefulSets =
+                              !_showWorkloadStatefulSets;
+                        });
+                      },
+                      value: _showWorkloadStatefulSets,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show DaemonSets'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWorkloadDaemonSets = !_showWorkloadDaemonSets;
+                        });
+                      },
+                      value: _showWorkloadDaemonSets,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Show Jobs'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _showWorkloadJobs = !_showWorkloadJobs;
+                        });
+                      },
+                      value: _showWorkloadJobs,
                     ),
                   ],
                 ),


### PR DESCRIPTION
It is now possible to show the status for Pods, Deployments, StatefulSets, DaemonSets and Jobs on the home page. This feature can be enabled seperatly for each workload in the home page settings.

When enabled we display for each workload the total number of resources and the count for each resource status. When a user click on the workload, he can directly view all the resources with the selected status.

For this the `ResourcesList` widget now contains a `status` parameter, which is set to the user selected status to filter the resources accordingly.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
