### PR TITLE
Improve Events Handling on Home Page

### DIFF
--- a/lib/widgets/home/overview/overview_events.dart
+++ b/lib/widgets/home/overview/overview_events.dart
@@ -24,26 +24,17 @@ List<IoK8sApiCoreV1Event> _decodeResult(String result) {
   final parsed = json.decode(result);
   final events = IoK8sApiCoreV1EventList.fromJson(parsed)?.items ?? [];
 
-  /// Filter all events to only proceed with events, which are having a
-  /// `lastTimestamp` set. If we have less than 25 events, we return all events,
-  /// sorted by their `creationTimestamp`.
-  final filteredEvents = events.where((e) => e.lastTimestamp != null).toList();
-  if (filteredEvents.length <= 25) {
-    events.sort(
-      (a, b) => b.metadata.creationTimestamp!
-          .compareTo(a.metadata.creationTimestamp!),
-    );
-    return events;
-  }
+  events.sort(
+    (a, b) => (b.lastTimestamp ?? b.eventTime ?? b.metadata.creationTimestamp)!
+        .compareTo(
+      (a.lastTimestamp ?? a.eventTime ?? a.metadata.creationTimestamp)!,
+    ),
+  );
 
-  /// If we have more than 25 events, we sort the events by their
-  /// `lastTimestamp` and return the first 25 events.
-  filteredEvents.sort((a, b) => b.lastTimestamp!.compareTo(a.lastTimestamp!));
-
-  if (filteredEvents.length > 25) {
-    return filteredEvents.sublist(0, 25);
+  if (events.length > 25) {
+    return events.sublist(0, 25);
   } else {
-    return filteredEvents;
+    return events;
   }
 }
 
@@ -179,6 +170,29 @@ class _OverviewEventsState extends State<OverviewEvents> {
                           child: AppErrorWidget(
                             message: 'Failed to Load ${resourceEvent.plural}',
                             details: snapshot.error.toString(),
+                            icon: 'assets/resources/${resourceEvent.icon}.svg',
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }
+
+                if (snapshot.data == null || snapshot.data!.isEmpty) {
+                  return Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Flexible(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            left: Constants.spacingMiddle,
+                            right: Constants.spacingMiddle,
+                          ),
+                          child: AppErrorWidget(
+                            message: 'No ${resourceEvent.plural} Found',
+                            details:
+                                'No warnings were found in the current context.',
                             icon: 'assets/resources/${resourceEvent.icon}.svg',
                           ),
                         ),

--- a/lib/widgets/resources/resources/resources_events.dart
+++ b/lib/widgets/resources/resources/resources_events.dart
@@ -76,7 +76,8 @@ final resourceEvent = Resource(
       item: item,
       status: status,
       details: [
-        'Last Seen: ${getAge(item.lastTimestamp)}',
+        'Namespace: ${item.metadata.namespace ?? '-'}',
+        'Last Seen: ${getAge(item.lastTimestamp ?? item.eventTime ?? item.metadata.creationTimestamp)}',
         'Type: ${item.type ?? '-'}',
         'Reason: ${item.reason ?? '-'}',
         'Object: ${item.involvedObject.kind ?? '-'}/${item.involvedObject.name ?? '-'}',
@@ -90,7 +91,8 @@ final resourceEvent = Resource(
     final item = listItem as IoK8sApiCoreV1Event;
 
     return [
-      'Last Seen: ${getAge(item.lastTimestamp)}',
+      'Namespace: ${item.metadata.namespace ?? '-'}',
+      'Last Seen: ${getAge(item.lastTimestamp ?? item.eventTime ?? item.metadata.creationTimestamp)}',
       'Type: ${item.type ?? '-'}',
       'Reason: ${item.reason ?? '-'}',
       'Object: ${item.involvedObject.kind ?? '-'}/${item.involvedObject.name ?? '-'}',
@@ -125,6 +127,10 @@ final resourceEvent = Resource(
             DetailsItemModel(
               name: 'Message',
               values: item.message,
+            ),
+            DetailsItemModel(
+              name: 'Event Time',
+              values: getAge(item.eventTime),
             ),
             DetailsItemModel(
               name: 'Last Seen',


### PR DESCRIPTION
This commit improves the soring of events on the home page. We are now using the `lastTimestamp`, `eventTime` or `creationTimestamp` for sorting the returned events.

The list and preview items for events now also contain the Namespace, where the event is comming from and for the "Last Seen" field we are using the fields mentioned above.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
