### PR TITLE
Fix Alignment and Selection in Secrets and ConfigMaps

### DIFF
--- a/lib/widgets/resources/resources/resources_configmaps.dart
+++ b/lib/widgets/resources/resources/resources_configmaps.dart
@@ -234,10 +234,14 @@ Widget _buildBottomSheet(
           left: Constants.spacingMiddle,
           right: Constants.spacingMiddle,
         ),
-        child: Text(
-          value,
-          style: TextStyle(
-            fontFamily: getMonospaceFontFamily(),
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: SelectableText(
+            value,
+            textAlign: TextAlign.left,
+            style: TextStyle(
+              fontFamily: getMonospaceFontFamily(),
+            ),
           ),
         ),
       ),

--- a/lib/widgets/resources/resources/resources_secrets.dart
+++ b/lib/widgets/resources/resources/resources_secrets.dart
@@ -234,10 +234,14 @@ Widget _buildBottomSheet(
           left: Constants.spacingMiddle,
           right: Constants.spacingMiddle,
         ),
-        child: Text(
-          utf8.fuse(base64).decode(value),
-          style: TextStyle(
-            fontFamily: getMonospaceFontFamily(),
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: SelectableText(
+            utf8.fuse(base64).decode(value),
+            textAlign: TextAlign.left,
+            style: TextStyle(
+              fontFamily: getMonospaceFontFamily(),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
The values which can be shown in a Secret and ConfigMap in an modal bottom sheet are now aligned on the left side and can be selected.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
