### PR TITLE
Use Long Press Instead of Double Tap for Actions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/lib/models/help.dart
+++ b/lib/models/help.dart
@@ -47,7 +47,7 @@ On the following page you can select one of the cluster providers on the top, to
           title: 'Edit a Cluster',
           icon: CustomIcons.clusters,
           markdown: '''
-To edit a cluster you have to go to **Clusters** page (**Settings** -> **View all**). Then **double tap** on the cluster name and select **Edit** from the opened modal.
+To edit a cluster you have to go to **Clusters** page (**Settings** -> **View all**). Then **long tap** on the cluster name and select **Edit** from the opened modal.
 
 ![Edit a Cluster](resource:assets/help/clusters-options-cluster-1.png)
 
@@ -69,7 +69,7 @@ You can edit the following properties of a cluster:
           title: 'Delete a Cluster',
           icon: CustomIcons.clusters,
           markdown: '''
-To edit a cluster you have to go to **Clusters** page (**Settings** -> **View all**). Then **double tap** on the cluster name and select **Delete** from the opened modal.
+To edit a cluster you have to go to **Clusters** page (**Settings** -> **View all**). Then **long tap** on the cluster name and select **Delete** from the opened modal.
 
 ![Delete a Cluster](resource:assets/help/clusters-options-cluster-1.png)
           ''',
@@ -386,7 +386,7 @@ Bookmarks can be deleted from a resources list or details page, by clicking on t
 
 ![Delete a Bookmark](resource:assets/help/bookmarks-delete-bookmark-2.png)
 
-You can also delete bookmarks by click on **View all** in the **Bookmarks** section. On the bookmarks page you can then **double tap** on a bookmark. In the opened modal click on **Delete**.
+You can also delete bookmarks by click on **View all** in the **Bookmarks** section. On the bookmarks page you can then **long tap** on a bookmark. In the opened modal click on **Delete**.
 
 ![Delete a Bookmark](resource:assets/help/bookmarks-delete-bookmark-3.png)
           ''',
@@ -417,7 +417,7 @@ In the opened modal select the container and the time range for which you want t
 
 ![Logs](resource:assets/help/logs-2.png)
 
-To close the opened terminal with the logs you have to **double tap** on the terminal tab.
+To close the opened terminal with the logs you have to **long tap** on the terminal tab.
 
 ![Logs](resource:assets/help/logs-3.png)
           ''',
@@ -434,7 +434,7 @@ In the opened modal select the container and the shell and click on **Get Termin
 
 ![Terminals](resource:assets/help/terminals-2.png)
 
-To close the opened terminal you have to **double tap** on the terminal tab.
+To close the opened terminal you have to **long tap** on the terminal tab.
 
 ![Terminals](resource:assets/help/terminals-3.png)
 

--- a/lib/widgets/plugins/helm/plugin_helm_list.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -77,7 +78,9 @@ class _PluginHelmListState extends State<PluginHelmList> {
           ),
         );
       },
-      onDoubleTap: () {
+      onLongPress: () {
+        HapticFeedback.vibrate();
+
         showActions(
           context,
           PluginHelmListItemActions(

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -179,7 +180,9 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                         onTap: () {
                           openBookmark(index);
                         },
-                        onDoubleTap: () {
+                        onLongPress: () {
+                          HapticFeedback.vibrate();
+
                           showActions(
                             context,
                             ResourcesBookmarkActions(

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:code_text_field/code_text_field.dart';
 import 'package:highlight/languages/json.dart' as highlight_json;
@@ -712,7 +713,9 @@ class ResourcesListItem extends StatelessWidget {
           ),
         );
       },
-      onDoubleTap: () {
+      onLongPress: () {
+        HapticFeedback.vibrate();
+
         showActions(
           context,
           ResourcesListItemActions(

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -23,14 +23,14 @@ class SettingsClusterItem extends StatefulWidget {
     required this.cluster,
     required this.isActiveCluster,
     this.onTap,
-    this.onDoubleTap,
+    this.onLongPress,
   });
 
   final int index;
   final Cluster cluster;
   final bool isActiveCluster;
   final void Function()? onTap;
-  final void Function()? onDoubleTap;
+  final void Function()? onLongPress;
 
   @override
   State<SettingsClusterItem> createState() => _SettingsClusterItemState();
@@ -99,7 +99,7 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
       ),
       child: AppListItem(
         onTap: widget.onTap,
-        onDoubleTap: widget.onDoubleTap,
+        onLongPress: widget.onLongPress,
         child: Column(
           children: [
             Row(

--- a/lib/widgets/settings/settings_clusters.dart
+++ b/lib/widgets/settings/settings_clusters.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -188,7 +189,9 @@ class SettingsClusters extends StatelessWidget {
                           clustersRepository.clusters[index].id,
                         );
                       },
-                      onDoubleTap: () {
+                      onLongPress: () {
+                        HapticFeedback.vibrate();
+
                         showActions(
                           context,
                           SettingsClusterActions(

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -69,6 +70,16 @@ class SettingsNamespaces extends StatelessWidget {
       ),
       child: AppListItem(
         onTap: () {
+          showActions(
+            context,
+            SettingsDeleteNamespace(
+              namespace: appRepository.settings.namespaces[index],
+            ),
+          );
+        },
+        onLongPress: () {
+          HapticFeedback.vibrate();
+
           showActions(
             context,
             SettingsDeleteNamespace(

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
@@ -32,7 +33,18 @@ class SettingsProviders extends StatelessWidget {
   Widget buildProvider(BuildContext context, ClusterProvider provider) {
     return AppListItem(
       onTap: () {
-        showActions(context, SettingsProviderActions(provider: provider));
+        showActions(
+          context,
+          SettingsProviderActions(provider: provider),
+        );
+      },
+      onLongPress: () {
+        HapticFeedback.vibrate();
+
+        showActions(
+          context,
+          SettingsProviderActions(provider: provider),
+        );
       },
       child: Row(
         children: [

--- a/lib/widgets/shared/app_list_item.dart
+++ b/lib/widgets/shared/app_list_item.dart
@@ -8,19 +8,19 @@ class AppListItem extends StatelessWidget {
   const AppListItem({
     super.key,
     this.onTap,
-    this.onDoubleTap,
+    this.onLongPress,
     required this.child,
   });
 
   final void Function()? onTap;
-  final void Function()? onDoubleTap;
+  final void Function()? onLongPress;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      onDoubleTap: onDoubleTap,
+      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.all(Constants.spacingListItemContent),
         decoration: BoxDecoration(


### PR DESCRIPTION
The secondary actions for various items in the app can now be triggered via a long press instead of a double tap. We decided to go with the long presse, because most of the other apps are also using a long press instead of a double tap.

When the user long presses a item, the user will now also get some haptic feedback, to make sure that a secondary action is supported by the item.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
