### PR TITLE
Improve Charts

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -13,10 +13,12 @@ TextStyle noramlTextStyle(
   BuildContext context, {
   double? size,
   Color? color,
+  TextDecoration? decoration,
 }) {
   return TextStyle(
     fontSize: size ?? Constants.sizeTextPrimary,
     color: color ?? Theme.of(context).extension<CustomColors>()!.textPrimary,
+    decoration: decoration,
   );
 }
 
@@ -25,11 +27,13 @@ TextStyle primaryTextStyle(
   BuildContext context, {
   double? size,
   Color? color,
+  TextDecoration? decoration,
 }) {
   return TextStyle(
     fontSize: size ?? Constants.sizeTextPrimary,
     color: color ?? Theme.of(context).extension<CustomColors>()!.textPrimary,
     fontWeight: FontWeight.bold,
+    decoration: decoration,
   );
 }
 
@@ -38,11 +42,13 @@ TextStyle secondaryTextStyle(
   BuildContext context, {
   double? size,
   Color? color,
+  TextDecoration? decoration,
 }) {
   return TextStyle(
     fontSize: size ?? Constants.sizeTextSecondary,
     color: color ?? Theme.of(context).extension<CustomColors>()!.textSecondary,
     fontWeight: FontWeight.normal,
+    decoration: decoration,
   );
 }
 

--- a/lib/widgets/resources/actions/live_metrics.dart
+++ b/lib/widgets/resources/actions/live_metrics.dart
@@ -392,8 +392,36 @@ class _LiveMetricsState extends State<LiveMetrics> {
                             child: LineChart(
                               LineChartData(
                                 minY: 0,
-                                lineTouchData:
-                                    const LineTouchData(enabled: false),
+                                lineTouchData: LineTouchData(
+                                  enabled: true,
+                                  handleBuiltInTouches: true,
+                                  touchTooltipData: LineTouchTooltipData(
+                                    fitInsideHorizontally: true,
+                                    fitInsideVertically: true,
+                                    maxContentWidth:
+                                        MediaQuery.of(context).size.width,
+                                    getTooltipColor: (LineBarSpot touchedSpot) {
+                                      return Theme.of(context)
+                                          .extension<CustomColors>()!
+                                          .message;
+                                    },
+                                    getTooltipItems: (touchedSpots) {
+                                      return touchedSpots
+                                          .map((LineBarSpot touchedSpot) {
+                                        return LineTooltipItem(
+                                          '${_containerMetrics.keys.elementAt(touchedSpot.barIndex)}: ${touchedSpot.y > 1000000000 ? formatCpuMetric(touchedSpot.y) : formatCpuMetric(touchedSpot.y, 0)}',
+                                          TextStyle(
+                                            color: Theme.of(context)
+                                                .extension<CustomColors>()!
+                                                .onMessage,
+                                            fontWeight: FontWeight.normal,
+                                            fontSize: 14,
+                                          ),
+                                        );
+                                      }).toList();
+                                    },
+                                  ),
+                                ),
                                 clipData: const FlClipData.all(),
                                 lineBarsData: _containerMetrics.entries
                                     .map(
@@ -433,7 +461,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   leftTitles: AxisTitles(
                                     sideTitles: SideTitles(
                                       showTitles: true,
-                                      reservedSize: 42,
+                                      reservedSize: 64,
                                       getTitlesWidget: (
                                         double value,
                                         TitleMeta meta,
@@ -508,11 +536,19 @@ class _LiveMetricsState extends State<LiveMetrics> {
                             (e) => Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
-                                Text(
-                                  e.key,
-                                  style: noramlTextStyle(
-                                    context,
-                                    size: Constants.sizeTextSecondary,
+                                Flexible(
+                                  child: Text(
+                                    Characters(e.key)
+                                        .replaceAll(
+                                          Characters(''),
+                                          Characters('\u{200B}'),
+                                        )
+                                        .toString(),
+                                    style: noramlTextStyle(
+                                      context,
+                                      size: Constants.sizeTextSecondary,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                                 Text(
@@ -565,8 +601,36 @@ class _LiveMetricsState extends State<LiveMetrics> {
                             child: LineChart(
                               LineChartData(
                                 minY: 0,
-                                lineTouchData:
-                                    const LineTouchData(enabled: false),
+                                lineTouchData: LineTouchData(
+                                  enabled: true,
+                                  handleBuiltInTouches: true,
+                                  touchTooltipData: LineTouchTooltipData(
+                                    fitInsideHorizontally: true,
+                                    fitInsideVertically: true,
+                                    maxContentWidth:
+                                        MediaQuery.of(context).size.width,
+                                    getTooltipColor: (LineBarSpot touchedSpot) {
+                                      return Theme.of(context)
+                                          .extension<CustomColors>()!
+                                          .message;
+                                    },
+                                    getTooltipItems: (touchedSpots) {
+                                      return touchedSpots
+                                          .map((LineBarSpot touchedSpot) {
+                                        return LineTooltipItem(
+                                          '${_containerMetrics.keys.elementAt(touchedSpot.barIndex)}: ${touchedSpot.y > 1048576 ? formatMemoryMetric(touchedSpot.y, 2) : formatMemoryMetric(touchedSpot.y, 0)}',
+                                          TextStyle(
+                                            color: Theme.of(context)
+                                                .extension<CustomColors>()!
+                                                .onMessage,
+                                            fontWeight: FontWeight.normal,
+                                            fontSize: 14,
+                                          ),
+                                        );
+                                      }).toList();
+                                    },
+                                  ),
+                                ),
                                 clipData: const FlClipData.all(),
                                 lineBarsData: _containerMetrics.entries
                                     .map(
@@ -606,7 +670,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   leftTitles: AxisTitles(
                                     sideTitles: SideTitles(
                                       showTitles: true,
-                                      reservedSize: 42,
+                                      reservedSize: 64,
                                       getTitlesWidget: (
                                         double value,
                                         TitleMeta meta,
@@ -681,11 +745,19 @@ class _LiveMetricsState extends State<LiveMetrics> {
                             (e) => Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
-                                Text(
-                                  e.key,
-                                  style: noramlTextStyle(
-                                    context,
-                                    size: Constants.sizeTextSecondary,
+                                Flexible(
+                                  child: Text(
+                                    Characters(e.key)
+                                        .replaceAll(
+                                          Characters(''),
+                                          Characters('\u{200B}'),
+                                        )
+                                        .toString(),
+                                    style: noramlTextStyle(
+                                      context,
+                                      size: Constants.sizeTextSecondary,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                                 Text(

--- a/lib/widgets/resources/resources/resources_namespaces.dart
+++ b/lib/widgets/resources/resources/resources_namespaces.dart
@@ -180,21 +180,21 @@ final resourceNamespace = Resource(
           defaultCharts: [
             Chart(
               title: 'Total CPU Usage',
-              unit: 'Cores',
+              unit: 'm',
               queries: [
                 Query(
                   query:
-                      'sum(rate(container_cpu_usage_seconds_total{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m]))',
+                      'sum(rate(container_cpu_usage_seconds_total{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m])) * 1000',
                   label: 'Usage',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_requests{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"})',
+                      'sum(kube_pod_container_resource_requests{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) * 1000',
                   label: 'Requests',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_limits{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"})',
+                      'sum(kube_pod_container_resource_limits{namespace="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) * 1000',
                   label: 'Limits',
                 ),
               ],

--- a/lib/widgets/resources/resources/resources_nodes.dart
+++ b/lib/widgets/resources/resources/resources_nodes.dart
@@ -271,26 +271,26 @@ final resourceNode = Resource(
           defaultCharts: [
             Chart(
               title: 'CPU Usage',
-              unit: 'Cores',
+              unit: 'm',
               queries: [
                 Query(
                   query:
-                      'sum(rate(container_cpu_usage_seconds_total{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m]))',
+                      'sum(rate(container_cpu_usage_seconds_total{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m])) * 1000',
                   label: 'Usage',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_requests{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"})',
+                      'sum(kube_pod_container_resource_requests{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) * 1000',
                   label: 'Requests',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_limits{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"})',
+                      'sum(kube_pod_container_resource_limits{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) * 1000',
                   label: 'Limits',
                 ),
                 Query(
                   query:
-                      'sum(kube_node_status_allocatable{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu"})',
+                      'sum(kube_node_status_allocatable{node="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu"}) * 1000',
                   label: 'Allocatable',
                 ),
               ],

--- a/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
+++ b/lib/widgets/resources/resources/resources_persistentvolumeclaims.dart
@@ -228,7 +228,7 @@ final Resource resourcePersistentVolumeClaim = Resource(
           defaultCharts: [
             Chart(
               title: 'Volume Space Usage',
-              unit: '',
+              unit: 'GiB',
               queries: [
                 Query(
                   query:

--- a/lib/widgets/resources/resources/resources_pods.dart
+++ b/lib/widgets/resources/resources/resources_pods.dart
@@ -413,21 +413,21 @@ class PodItem extends StatelessWidget {
           defaultCharts: [
             Chart(
               title: 'CPU Usage',
-              unit: 'Cores',
+              unit: 'm',
               queries: [
                 Query(
                   query:
-                      'sum(rate(container_cpu_usage_seconds_total{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m])) by (container)',
+                      '(sum(rate(container_cpu_usage_seconds_total{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", container!="", container!="POD"}[2m])) by (container)) * 1000',
                   label: 'Usage {{ .container }}',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_requests{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) by (container)',
+                      '(sum(kube_pod_container_resource_requests{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) by (container)) * 1000',
                   label: 'Requests {{ .container }}',
                 ),
                 Query(
                   query:
-                      'sum(kube_pod_container_resource_limits{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) by (container)',
+                      '(sum(kube_pod_container_resource_limits{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="cpu", container!="", container!="POD"}) by (container)) * 1000',
                   label: 'Limits {{ .container }}',
                 ),
               ],
@@ -464,7 +464,7 @@ class PodItem extends StatelessWidget {
                 ),
                 Query(
                   query:
-                      'sum(rate(container_network_transmit_bytes_total{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}"}[2m])) by (pod) / 1024 / 1024',
+                      '-sum(rate(container_network_transmit_bytes_total{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", pod="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}"}[2m])) by (pod) / 1024 / 1024',
                   label: 'Transmitted',
                 ),
               ],

--- a/lib/widgets/resources/resources/resources_resourcequotas.dart
+++ b/lib/widgets/resources/resources/resources_resourcequotas.dart
@@ -132,19 +132,22 @@ final resourceResourceQuota = Resource(
         AppPrometheusChartsWidget(
           item: item,
           toJson: resource.toJson,
-          defaultCharts: [
-            Chart(
-              title: 'Quotas',
-              unit: '',
-              queries: [
-                Query(
-                  query:
-                      'sum(kube_resourcequota{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", resourcequota="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}"}) by (resource, type)',
-                  label: '{{ .resource }} - {{ .type }}',
-                ),
-              ],
-            ),
-          ],
+          defaultCharts: item.status?.hard.keys
+                  .map(
+                    (e) => Chart(
+                      title: e,
+                      unit: '',
+                      queries: [
+                        Query(
+                          query:
+                              'sum(kube_resourcequota{namespace="{{with .metadata}}{{with .namespace}}{{.}}{{end}}{{end}}", resourcequota="{{with .metadata}}{{with .name}}{{.}}{{end}}{{end}}", resource="$e"}) by (resource, type)',
+                          label: '{{ .type }}',
+                        ),
+                      ],
+                    ),
+                  )
+                  .toList() ??
+              [],
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -385,7 +385,7 @@ packages:
     source: hosted
     version: "0.3.14"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   highlight: ^0.7.0
   http: ^1.1.0
   in_app_purchase: ^3.1.1
+  intl: ^0.19.0
   json_path: ^0.7.1
   jwt_decode: ^0.3.1
   local_auth: ^2.1.2


### PR DESCRIPTION
This commit contains several improvements to the charts used within the app:

- The charts used for `ResourceQuotas` and `LimitRanges` are now splitted, so that different metrics are not mixed anymore
- Charts which are related to CPU cores are now using `m` instead of `Cores` as unit.
- The live metrics charts are now containing a tooltip.
- The legend in the live metrics charts are now better formatted, so that the text doesn't overflow anymore, when the name of a container is very long.
- The x axis in the Prometheus charts is now better formatted, so that the overlap of labels is minimized.
- The values in the Prometheus charts are now better formatted by using the `NumberFormat.compact(locale: "en_US").format()` function.
- In the Prometheus charts it is now possible to select a single metric in the legend, which should be shown in the chart.

We also added a new `decoration` parameter to all text styling functions, so that a text can be underlined, which is used to indicate the selected metric in the Prometheus charts legend.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
