### PR TITLE
Add `IngressClasses` Resource

### DIFF
--- a/lib/widgets/resources/resources/resources.dart
+++ b/lib/widgets/resources/resources/resources.dart
@@ -11,6 +11,7 @@ import 'package:kubenav/widgets/resources/resources/resources_deployments.dart';
 import 'package:kubenav/widgets/resources/resources/resources_endpoints.dart';
 import 'package:kubenav/widgets/resources/resources/resources_events.dart';
 import 'package:kubenav/widgets/resources/resources/resources_horizontalpodautoscalers.dart';
+import 'package:kubenav/widgets/resources/resources/resources_ingressclasses.dart';
 import 'package:kubenav/widgets/resources/resources/resources_ingresses.dart';
 import 'package:kubenav/widgets/resources/resources/resources_jobs.dart';
 import 'package:kubenav/widgets/resources/resources/resources_limitranges.dart';
@@ -257,6 +258,7 @@ final List<Resource> resources = [
   resourceEndpoint,
   resourceHorizontalPodAutoscaler,
   resourceIngress,
+  resourceIngressClass,
   resourceNetworkPolicy,
   resourceService,
   resourceConfigMap,
@@ -292,6 +294,7 @@ final Map<String, Resource> kindToResource = {
   'Endpoint': resourceEndpoint,
   'HorizontalPodAutoscaler': resourceHorizontalPodAutoscaler,
   'Ingress': resourceIngress,
+  'IngressClass': resourceIngressClass,
   'NetworkPolicy': resourceNetworkPolicy,
   'Service': resourceService,
   'ConfigMap': resourceConfigMap,

--- a/lib/widgets/resources/resources/resources_ingressclasses.dart
+++ b/lib/widgets/resources/resources/resources_ingressclasses.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_object_reference.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress_class.dart';
+import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress_class_list.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/resources.dart';
+import 'package:kubenav/widgets/resources/helpers/details_item.dart';
+import 'package:kubenav/widgets/resources/helpers/details_item_metadata.dart';
+import 'package:kubenav/widgets/resources/helpers/details_resources_preview.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/resources/resources/resources_events.dart';
+import 'package:kubenav/widgets/resources/resources_list.dart';
+import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
+
+final resourceIngressClass = Resource(
+  category: ResourceCategories.discoveryandloadbalancing,
+  plural: 'IngressClasses',
+  singular: 'IngressClass',
+  description:
+      'Ingresses can be implemented by different controllers, often with different configuration. Each Ingress should specify a class, a reference to an IngressClass resource.',
+  path: '/apis/networking.k8s.io/v1',
+  resource: 'ingressclasses',
+  scope: ResourceScope.cluster,
+  additionalPrinterColumns: [],
+  icon: 'ingresses',
+  template: resourceDefaultTemplate,
+  decodeListData: (ResourcesListData data) {
+    final parsed = json.decode(data.list);
+    final items =
+        IoK8sApiNetworkingV1IngressClassList.fromJson(parsed)?.items ?? [];
+
+    return items.map((e) {
+      return ResourceItem(
+        item: e,
+        metrics: null,
+        status: ResourceStatus.undefined,
+      );
+    }).toList();
+  },
+  decodeList: (String data) {
+    final parsed = json.decode(data);
+    return IoK8sApiNetworkingV1IngressClassList.fromJson(parsed)?.items ?? [];
+  },
+  getName: (dynamic item) {
+    return (item as IoK8sApiNetworkingV1IngressClass).metadata?.name ?? '';
+  },
+  getNamespace: (dynamic item) {
+    return (item as IoK8sApiNetworkingV1IngressClass).metadata?.namespace;
+  },
+  decodeItem: (String data) {
+    final parsed = json.decode(data);
+    return IoK8sApiNetworkingV1IngressClass.fromJson(parsed);
+  },
+  encodeItem: (dynamic item) {
+    JsonEncoder encoder = const JsonEncoder.withIndent('  ');
+    return encoder.convert(item);
+  },
+  toJson: (dynamic item) {
+    return json.decode(json.encode(item));
+  },
+  listItemBuilder: (
+    BuildContext context,
+    Resource resource,
+    ResourceItem listItem,
+  ) {
+    final item = listItem.item as IoK8sApiNetworkingV1IngressClass;
+    final status = listItem.status;
+
+    return ResourcesListItem(
+      name: item.metadata?.name ?? '',
+      namespace: item.metadata?.namespace,
+      resource: resource,
+      item: item,
+      status: status,
+      details: [
+        'Namespace: ${item.metadata?.namespace ?? '-'}',
+        'Controller: ${item.spec?.controller ?? '-'}',
+        'Parameters: ${item.spec?.parameters != null ? '${item.spec?.parameters?.namespace != null ? '${item.spec?.parameters?.namespace}/' : ''}${item.spec?.parameters?.name}' : '-'}',
+        'Age: ${getAge(item.metadata?.creationTimestamp)}',
+      ],
+    );
+  },
+  previewItemBuilder: (
+    dynamic listItem,
+  ) {
+    final item = listItem as IoK8sApiNetworkingV1IngressClass;
+
+    return [
+      'Namespace: ${item.metadata?.namespace ?? '-'}',
+      'Controller: ${item.spec?.controller ?? '-'}',
+      'Parameters: ${item.spec?.parameters != null ? '${item.spec?.parameters?.namespace != null ? '${item.spec?.parameters?.namespace}/' : ''}${item.spec?.parameters?.name}' : '-'}',
+      'Age: ${getAge(item.metadata?.creationTimestamp)}',
+    ];
+  },
+  detailsItemBuilder: (
+    BuildContext context,
+    Resource resource,
+    dynamic detailsItem,
+  ) {
+    final item = detailsItem as IoK8sApiNetworkingV1IngressClass;
+
+    return Column(
+      children: [
+        DetailsItemMetadata(
+          kind: item.kind,
+          metadata: item.metadata,
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+        DetailsItem(
+          title: 'Configuration',
+          details: [
+            DetailsItemModel(
+              name: 'Controller',
+              values: item.spec?.controller,
+            ),
+            DetailsItemModel(
+              name: 'Parameters',
+              values: item.spec?.parameters == null
+                  ? null
+                  : '${item.spec?.parameters?.kind} (${item.spec?.parameters?.namespace != null ? '${item.spec?.parameters?.namespace}/' : ''}${item.spec?.parameters?.name})',
+              onTap: item.spec?.parameters == null
+                  ? null
+                  : (int index) {
+                      final goToFunc = goToReference(
+                        context,
+                        IoK8sApiCoreV1ObjectReference(
+                          apiVersion: item.spec?.parameters?.apiGroup,
+                          kind: item.spec?.parameters?.kind,
+                          name: item.spec?.parameters?.name,
+                          namespace: item.spec?.parameters?.namespace,
+                        ),
+                        item.spec?.parameters?.namespace,
+                      );
+
+                      goToFunc();
+                    },
+            ),
+          ],
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+        DetailsResourcesPreview(
+          resource: resourceEvent,
+          namespace: item.metadata?.namespace,
+          selector:
+              'fieldSelector=involvedObject.name=${item.metadata?.name ?? ''}',
+          filter: null,
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
+        AppPrometheusChartsWidget(
+          item: item,
+          toJson: resource.toJson,
+          defaultCharts: const [],
+        ),
+      ],
+    );
+  },
+);

--- a/lib/widgets/resources/resources/resources_ingresses.dart
+++ b/lib/widgets/resources/resources/resources_ingresses.dart
@@ -5,12 +5,15 @@ import 'package:flutter/material.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress_list.dart';
 import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/resources.dart';
 import 'package:kubenav/widgets/resources/helpers/details_item.dart';
 import 'package:kubenav/widgets/resources/helpers/details_item_metadata.dart';
 import 'package:kubenav/widgets/resources/helpers/details_resources_preview.dart';
 import 'package:kubenav/widgets/resources/resources/resources.dart';
 import 'package:kubenav/widgets/resources/resources/resources_events.dart';
+import 'package:kubenav/widgets/resources/resources/resources_ingressclasses.dart';
+import 'package:kubenav/widgets/resources/resources_details.dart';
 import 'package:kubenav/widgets/resources/resources_list.dart';
 import 'package:kubenav/widgets/shared/app_prometheus_charts_widget.dart';
 
@@ -138,6 +141,18 @@ final resourceIngress = Resource(
             DetailsItemModel(
               name: 'Ingress Class',
               values: item.spec?.ingressClassName,
+              onTap: item.spec?.ingressClassName == null
+                  ? null
+                  : (int index) {
+                      navigate(
+                        context,
+                        ResourcesDetails(
+                          name: item.spec!.ingressClassName!,
+                          namespace: null,
+                          resource: resourceIngressClass,
+                        ),
+                      );
+                    },
             ),
             DetailsItemModel(
               name: 'Address',


### PR DESCRIPTION
This commit adds support for the `IngressClasses` resource. This means that users can view `IngressClasses` within the app and that it is now possible to view / go to an `IngressClass` from an `Ingress` resource.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
