### PR TITLE
Fix Modal Bottom Sheet Width for Terminal

### DIFF
--- a/lib/utils/showmodal.dart
+++ b/lib/utils/showmodal.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/themes.dart';
 
-void showModal(BuildContext context, Widget widget) {
+void showModal(BuildContext context, Widget widget, {bool fullScreen = false}) {
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
@@ -16,6 +16,11 @@ void showModal(BuildContext context, Widget widget) {
       ),
     ),
     clipBehavior: Clip.antiAliasWithSaveLayer,
+    constraints: fullScreen == false
+        ? null
+        : BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width,
+          ),
     builder: (BuildContext context) {
       return widget;
     },

--- a/lib/widgets/resources/actions/get_logs.dart
+++ b/lib/widgets/resources/actions/get_logs.dart
@@ -135,6 +135,7 @@ class _GetLogsState extends State<GetLogs> {
                 AppTerminalWidget(
                   terminalIndex: terminalIndex,
                 ),
+                fullScreen: true,
               );
             }
           } else {
@@ -180,7 +181,10 @@ class _GetLogsState extends State<GetLogs> {
             Navigator.pop(context);
             showModal(
               context,
-              AppTerminalWidget(terminalIndex: terminalIndex),
+              AppTerminalWidget(
+                terminalIndex: terminalIndex,
+              ),
+              fullScreen: true,
             );
           }
         }

--- a/lib/widgets/resources/actions/get_terminal.dart
+++ b/lib/widgets/resources/actions/get_terminal.dart
@@ -112,7 +112,10 @@ class _GetTerminalState extends State<GetTerminal> {
             Navigator.pop(context);
             showModal(
               context,
-              AppTerminalWidget(terminalIndex: terminalIndex),
+              AppTerminalWidget(
+                terminalIndex: terminalIndex,
+              ),
+              fullScreen: true,
             );
           }
         } else {

--- a/lib/widgets/shared/app_terminals_widget.dart
+++ b/lib/widgets/shared/app_terminals_widget.dart
@@ -76,6 +76,7 @@ class AppTerminalActionsWidget extends StatelessWidget {
               AppTerminalWidget(
                 terminalIndex: terminalIndex,
               ),
+              fullScreen: true,
             );
           },
         ),


### PR DESCRIPTION
For terminals and logs the modal bottom sheet should always use the full width of the screen, but on larger screens (e.g. iPad) it wasn't using the full screen width.

This is now fixed by adding a new `fullScreen` parameter to the `showModal` function, which is `false` by default, but can be set to `true` for the terminal and logs, so that they are using the full screen width and height.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
