### PR TITLE
Add Cordon / Uncordon Actions for Nodes

### DIFF
--- a/lib/widgets/resources/actions/node_cordon.dart
+++ b/lib/widgets/resources/actions/node_cordon.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_node.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+class NodeCordon extends StatefulWidget {
+  const NodeCordon({
+    super.key,
+    required this.name,
+    required this.node,
+    required this.resource,
+  });
+
+  final String name;
+  final IoK8sApiCoreV1Node node;
+  final Resource resource;
+
+  @override
+  State<NodeCordon> createState() => _NodeCordonState();
+}
+
+class _NodeCordonState extends State<NodeCordon> {
+  bool _isLoading = false;
+
+  Future<void> _cordon() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final String body = widget.node.spec?.unschedulable == null
+          ? '[{"op":"add","path":"/spec/unschedulable","value":true}]'
+          : '[{"op":"replace","path":"/spec/unschedulable","value":true}]';
+
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+      final url =
+          '${widget.resource.path}/${widget.resource.resource}/${widget.name}';
+
+      await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).patchRequest(url, body);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          '${widget.resource.singular} Cordoned',
+          'The ${widget.resource.singular} ${widget.name} was cordoned',
+        );
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      Logger.log(
+        'NodeCordon _cordon',
+        'Failed to Cordon ${widget.resource.singular}',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Failed to Cordon ${widget.resource.singular}',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Cordon',
+      subtitle: widget.name,
+      icon: Icons.stop,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Cordon',
+      actionPressed: () {
+        _cordon();
+      },
+      actionIsLoading: _isLoading,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to cordon the ${widget.resource.singular} ${widget.name}?',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/actions/node_uncordon.dart
+++ b/lib/widgets/resources/actions/node_uncordon.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_node.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+class NodeUncordon extends StatefulWidget {
+  const NodeUncordon({
+    super.key,
+    required this.name,
+    required this.node,
+    required this.resource,
+  });
+
+  final String name;
+  final IoK8sApiCoreV1Node node;
+  final Resource resource;
+
+  @override
+  State<NodeUncordon> createState() => _NodeUncordonState();
+}
+
+class _NodeUncordonState extends State<NodeUncordon> {
+  bool _isLoading = false;
+
+  Future<void> _uncordon() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final String body = widget.node.spec?.unschedulable == null
+          ? '[{"op":"add","path":"/spec/unschedulable","value":false}]'
+          : '[{"op":"replace","path":"/spec/unschedulable","value":false}]';
+
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+      final url =
+          '${widget.resource.path}/${widget.resource.resource}/${widget.name}';
+
+      await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).patchRequest(url, body);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          '${widget.resource.singular} Uncordoned',
+          'The ${widget.resource.singular} ${widget.name} was uncordoned',
+        );
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      Logger.log(
+        'NodeUncordon _uncordon',
+        'Failed to Uncordon ${widget.resource.singular}',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Failed to Uncordon ${widget.resource.singular}',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Uncordon',
+      subtitle: widget.name,
+      icon: Icons.play_arrow,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Uncordon',
+      actionPressed: () {
+        _uncordon();
+      },
+      actionIsLoading: _isLoading,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to uncordon the ${widget.resource.singular} ${widget.name}?',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/resources/resources_ingressclasses.dart
+++ b/lib/widgets/resources/resources/resources_ingressclasses.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_object_reference.dart';
 
+import 'package:kubenav/models/kubernetes/io_k8s_api_core_v1_object_reference.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress_class.dart';
 import 'package:kubenav/models/kubernetes/io_k8s_api_networking_v1_ingress_class_list.dart';
 import 'package:kubenav/utils/constants.dart';

--- a/lib/widgets/resources/resources_details.dart
+++ b/lib/widgets/resources/resources_details.dart
@@ -20,6 +20,8 @@ import 'package:kubenav/widgets/resources/actions/get_logs.dart';
 import 'package:kubenav/widgets/resources/actions/get_logs_pods.dart';
 import 'package:kubenav/widgets/resources/actions/get_terminal.dart';
 import 'package:kubenav/widgets/resources/actions/live_metrics.dart';
+import 'package:kubenav/widgets/resources/actions/node_cordon.dart';
+import 'package:kubenav/widgets/resources/actions/node_uncordon.dart';
 import 'package:kubenav/widgets/resources/actions/restart_resource.dart';
 import 'package:kubenav/widgets/resources/actions/scale_resource.dart';
 import 'package:kubenav/widgets/resources/actions/show_yaml.dart';
@@ -29,6 +31,7 @@ import 'package:kubenav/widgets/resources/resources/resources_cronjobs.dart';
 import 'package:kubenav/widgets/resources/resources/resources_daemonsets.dart';
 import 'package:kubenav/widgets/resources/resources/resources_deployments.dart';
 import 'package:kubenav/widgets/resources/resources/resources_namespaces.dart';
+import 'package:kubenav/widgets/resources/resources/resources_nodes.dart';
 import 'package:kubenav/widgets/resources/resources/resources_pods.dart';
 import 'package:kubenav/widgets/resources/resources/resources_statefulsets.dart';
 import 'package:kubenav/widgets/shared/app_bottom_navigation_bar_widget.dart';
@@ -388,6 +391,42 @@ List<AppResourceActionsModel> resourceDetailsActions(
             CSRDeny(
               name: name,
               csr: item,
+              resource: resource,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  if (resource.resource == resourceNode.resource &&
+      resource.path == resourceNode.path) {
+    actions.add(
+      AppResourceActionsModel(
+        title: 'Cordon',
+        icon: Icons.stop,
+        onTap: () {
+          showModal(
+            context,
+            NodeCordon(
+              name: name,
+              node: item,
+              resource: resource,
+            ),
+          );
+        },
+      ),
+    );
+    actions.add(
+      AppResourceActionsModel(
+        title: 'Uncordon',
+        icon: Icons.play_arrow,
+        onTap: () {
+          showModal(
+            context,
+            NodeUncordon(
+              name: name,
+              node: item,
               resource: resource,
             ),
           );


### PR DESCRIPTION
It is now possible to cordon / uncordon nodes within the app. For this two new actions were added, which can be used by the user to disable / enable scheduling for a node.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
