### PR TITLE
Add SSH Action for Nodes

### DIFF
--- a/lib/widgets/resources/resources_details.dart
+++ b/lib/widgets/resources/resources_details.dart
@@ -13,6 +13,7 @@ import 'package:kubenav/widgets/plugins/cert-manager/resources/plugin_cert_manag
 import 'package:kubenav/widgets/plugins/flux/resources/plugin_flux_resources.dart';
 import 'package:kubenav/widgets/resources/actions/create_debug_container.dart';
 import 'package:kubenav/widgets/resources/actions/create_job.dart';
+import 'package:kubenav/widgets/resources/actions/create_ssh_pod.dart';
 import 'package:kubenav/widgets/resources/actions/csr_approve.dart';
 import 'package:kubenav/widgets/resources/actions/csr_deny.dart';
 import 'package:kubenav/widgets/resources/actions/delete_resource.dart';
@@ -426,6 +427,22 @@ List<AppResourceActionsModel> resourceDetailsActions(
           showModal(
             context,
             NodeUncordon(
+              name: name,
+              node: item,
+              resource: resource,
+            ),
+          );
+        },
+      ),
+    );
+    actions.add(
+      AppResourceActionsModel(
+        title: 'SSH',
+        icon: Icons.terminal,
+        onTap: () {
+          showModal(
+            context,
+            CreateSSHPod(
               name: name,
               node: item,
               resource: resource,


### PR DESCRIPTION
The new SSH action for Nodes can be used to create a privileged Pod on the selected node, with similar rights as a user would connect via SSH to the node.

The action will create the Pod on the selected Node, afterwards a user can view the Pod and can create a new terminal, to view all the processes and files running on the Node.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
