### PR TITLE
Improve Spacing for Horizontal Lists

### DIFF
--- a/lib/widgets/home/overview/overview_workloads.dart
+++ b/lib/widgets/home/overview/overview_workloads.dart
@@ -87,24 +87,22 @@ class OverviewWorkloads extends StatelessWidget {
             ],
           ),
         ),
-        Container(
-          padding: const EdgeInsets.only(
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
+        SizedBox(
           height: 206,
           child: GridView.count(
             scrollDirection: Axis.horizontal,
             cacheExtent: 1024,
             crossAxisCount: 2,
             childAspectRatio: 0.30,
-            mainAxisSpacing: Constants.spacingMiddle,
             children: List.generate(
               resources.length,
               (index) {
                 return Container(
-                  margin: const EdgeInsets.all(
-                    Constants.spacingSmall,
+                  margin: const EdgeInsets.only(
+                    top: Constants.spacingSmall,
+                    bottom: Constants.spacingSmall,
+                    left: Constants.spacingMiddle,
+                    right: Constants.spacingMiddle,
                   ),
                   child: OverviewWorkload(resource: resources[index]),
                 );

--- a/lib/widgets/resources/helpers/details_item_conditions.dart
+++ b/lib/widgets/resources/helpers/details_item_conditions.dart
@@ -38,23 +38,21 @@ class DetailsItemConditions extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            padding: const EdgeInsets.only(
-              left: Constants.spacingMiddle,
-              right: Constants.spacingMiddle,
-            ),
+          SizedBox(
             height: 128,
             child: GridView.count(
               scrollDirection: Axis.horizontal,
               crossAxisCount: 2,
               childAspectRatio: 0.25,
-              mainAxisSpacing: Constants.spacingMiddle,
               children: List.generate(
                 conditions!.length,
                 (index) {
                   return Container(
-                    margin: const EdgeInsets.all(
-                      Constants.spacingSmall,
+                    margin: const EdgeInsets.only(
+                      top: Constants.spacingSmall,
+                      bottom: Constants.spacingSmall,
+                      left: Constants.spacingMiddle,
+                      right: Constants.spacingMiddle,
                     ),
                     child: AppListItem(
                       onTap: () {

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -61,17 +61,12 @@ class Settings extends StatelessWidget {
 
     int maxClusters = 6;
 
-    return Container(
-      padding: const EdgeInsets.only(
-        left: Constants.spacingMiddle,
-        right: Constants.spacingMiddle,
-      ),
+    return SizedBox(
       height: 128,
       child: GridView.count(
         scrollDirection: Axis.horizontal,
         crossAxisCount: 2,
         childAspectRatio: 0.25,
-        mainAxisSpacing: Constants.spacingMiddle,
         children: List.generate(
           clustersRepository.clusters.length <= maxClusters
               ? clustersRepository.clusters.length
@@ -81,8 +76,8 @@ class Settings extends StatelessWidget {
               margin: const EdgeInsets.only(
                 top: Constants.spacingSmall,
                 bottom: Constants.spacingSmall,
-                left: Constants.spacingSmall,
-                right: Constants.spacingSmall,
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
               ),
               child: AppListItem(
                 onTap: () {


### PR DESCRIPTION
The spacing was a bit off compared with all other widgets in the horizontal lists, like we are using them for the workload conditions, cluster view in the settings and the workloads overview.

This is now fixed, so that the lists behave similar to the other horizontal lists, with the same spacing.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
