### PR TITLE
Improve Overview Metrics Layout for Tablets

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -82,3 +82,9 @@ String generateRandomString(int len) {
   const chars = 'abcdefghijklmnopqrstuvwxyz1234567890';
   return List.generate(len, (index) => chars[r.nextInt(chars.length)]).join();
 }
+
+/// [isTablet] returns `true` if the current screen size is is a table. For that
+/// we check if the width of the screen is greater than 600.
+bool isTablet(BuildContext context) {
+  return MediaQuery.of(context).size.width > 600;
+}

--- a/lib/widgets/home/overview/overview_metrics.dart
+++ b/lib/widgets/home/overview/overview_metrics.dart
@@ -112,7 +112,9 @@ class OverviewMetrics extends StatelessWidget {
             right: Constants.spacingMiddle,
           ),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisAlignment: isTablet(context)
+                ? MainAxisAlignment.spaceEvenly
+                : MainAxisAlignment.spaceBetween,
             children: [
               buildCard(
                 context,


### PR DESCRIPTION
Improve the overview metrics layout for tablets, so that the items are spaced evenly instead of between.

Note: This is not only for tablet, but for all larger screens, since we just check the screen width in the added `isTablet` function.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
