### PR TITLE
Fix TabBar in LiveMetrics Widget

### DIFF
--- a/lib/widgets/resources/actions/live_metrics.dart
+++ b/lib/widgets/resources/actions/live_metrics.dart
@@ -337,6 +337,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                 child: TabBar(
                   isScrollable: false,
                   tabAlignment: TabAlignment.fill,
+                  dividerHeight: 0,
                   labelColor: Theme.of(context).colorScheme.onPrimary,
                   unselectedLabelColor: Theme.of(context).colorScheme.primary,
                   labelPadding: EdgeInsets.zero,


### PR DESCRIPTION
With the last Flutter update, the TabBar widget was changed, so that a divider was rendered below the tabs. This is now fixed by setting the diver height to 0.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
