### PR TITLE
Fix Sorting of Clusters

### DIFF
--- a/lib/models/help.dart
+++ b/lib/models/help.dart
@@ -93,7 +93,7 @@ There are multiple ways to switch between clusters:
           markdown: '''
 You can sort your clusters on the **Clusters** page (**Settings** -> **View all**), so that your the cluster which you have to access the most is always on the top.
 
-To sort the clusters you have to **press on the status icon** of the cluster and move it up or down.
+To sort the clusters you have to **press on the sort icon**. Afterwards you can move the clusters up or down.
           ''',
         ),
       ],

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -22,6 +22,7 @@ class SettingsClusterItem extends StatefulWidget {
     required this.index,
     required this.cluster,
     required this.isActiveCluster,
+    required this.isSortable,
     this.onTap,
     this.onLongPress,
   });
@@ -29,6 +30,7 @@ class SettingsClusterItem extends StatefulWidget {
   final int index;
   final Cluster cluster;
   final bool isActiveCluster;
+  final bool isSortable;
   final void Function()? onTap;
   final void Function()? onLongPress;
 
@@ -81,6 +83,34 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
         statusOk = false;
       });
     }
+  }
+
+  /// [_buildIcon] returns an icon widget, which indicates the status of the
+  /// cluster. If the [sort] argument is `true`, we return a drag handle icon,
+  /// which can be used to reorder the clusters.
+  Widget _buildIcon() {
+    if (widget.isSortable) {
+      return ReorderableDragStartListener(
+        index: widget.index,
+        child: Icon(
+          Icons.drag_handle,
+          color: Theme.of(context)
+              .extension<CustomColors>()!
+              .textPrimary
+              .withOpacity(Constants.opacityIcon),
+        ),
+      );
+    }
+
+    return Icon(
+      widget.isActiveCluster
+          ? Icons.radio_button_checked
+          : Icons.radio_button_unchecked,
+      size: 24,
+      color: statusOk
+          ? Theme.of(context).extension<CustomColors>()!.success
+          : Theme.of(context).extension<CustomColors>()!.error,
+    );
   }
 
   @override
@@ -136,18 +166,7 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
                     ],
                   ),
                 ),
-                ReorderableDragStartListener(
-                  index: widget.index,
-                  child: Icon(
-                    widget.isActiveCluster
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: statusOk
-                        ? Theme.of(context).extension<CustomColors>()!.success
-                        : Theme.of(context).extension<CustomColors>()!.error,
-                  ),
-                ),
+                _buildIcon(),
               ],
             ),
           ],

--- a/lib/widgets/settings/settings_clusters.dart
+++ b/lib/widgets/settings/settings_clusters.dart
@@ -24,8 +24,15 @@ import 'package:kubenav/widgets/shared/app_horizontal_list_cards_widget.dart';
 /// Below the list of providers we display the users added clusters. We also add
 /// the status to each cluster item, so a user sees if we are able to reach the
 /// cluster.
-class SettingsClusters extends StatelessWidget {
+class SettingsClusters extends StatefulWidget {
   const SettingsClusters({super.key});
+
+  @override
+  State<SettingsClusters> createState() => _SettingsClustersState();
+}
+
+class _SettingsClustersState extends State<SettingsClusters> {
+  bool isSortable = false;
 
   /// [_proxyDecorator] is used to highlight the bookmark which is currently
   /// draged by the user.
@@ -147,6 +154,30 @@ class SettingsClusters extends StatelessWidget {
                         style: primaryTextStyle(context, size: 18),
                       ),
                     ),
+                    InkWell(
+                      onTap: () {
+                        setState(() {
+                          isSortable = !isSortable;
+                        });
+                      },
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.sort,
+                            color: Theme.of(context).colorScheme.primary,
+                            size: 16,
+                          ),
+                          const SizedBox(width: Constants.spacingExtraSmall),
+                          Text(
+                            'Sort',
+                            style: secondaryTextStyle(
+                              context,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -184,21 +215,26 @@ class SettingsClusters extends StatelessWidget {
                       cluster: clustersRepository.clusters[index],
                       isActiveCluster: clustersRepository.clusters[index].id ==
                           clustersRepository.activeClusterId,
-                      onTap: () {
-                        clustersRepository.setActiveCluster(
-                          clustersRepository.clusters[index].id,
-                        );
-                      },
-                      onLongPress: () {
-                        HapticFeedback.vibrate();
+                      isSortable: isSortable,
+                      onTap: isSortable
+                          ? null
+                          : () {
+                              clustersRepository.setActiveCluster(
+                                clustersRepository.clusters[index].id,
+                              );
+                            },
+                      onLongPress: isSortable
+                          ? null
+                          : () {
+                              HapticFeedback.vibrate();
 
-                        showActions(
-                          context,
-                          SettingsClusterActions(
-                            cluster: clustersRepository.clusters[index],
-                          ),
-                        );
-                      },
+                              showActions(
+                                context,
+                                SettingsClusterActions(
+                                  cluster: clustersRepository.clusters[index],
+                                ),
+                              );
+                            },
                     ),
                   );
                 },


### PR DESCRIPTION
After we changed the trigger for secondary actions from double tap to a long press it was difficult to sort the clusters. This is now fixed by adding a toggle button to enable / disable sorting of the clusters.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
