### PR TITLE
Fix Loading Indication for Workloads on Home Page

### DIFF
--- a/lib/widgets/home/overview/overview_workloads.dart
+++ b/lib/widgets/home/overview/overview_workloads.dart
@@ -223,6 +223,12 @@ class _OverviewWorkloadState extends State<OverviewWorkload> {
             BuildContext context,
             AsyncSnapshot<ResourceStatusCounts> snapshot,
           ) {
+            final isLoading =
+                snapshot.connectionState == ConnectionState.none ||
+                        snapshot.connectionState == ConnectionState.waiting
+                    ? true
+                    : false;
+
             return Row(
               children: [
                 Container(
@@ -258,7 +264,7 @@ class _OverviewWorkloadState extends State<OverviewWorkload> {
                       Row(
                         children: [
                           Text(
-                            'All: ${snapshot.data?.all ?? '-'}\nHealthy: ${snapshot.data?.success ?? '-'}',
+                            'All: ${isLoading ? '-' : snapshot.data?.all ?? '-'}\nHealthy: ${isLoading ? '-' : snapshot.data?.success ?? '-'}',
                             style: secondaryTextStyle(
                               context,
                             ),
@@ -267,7 +273,7 @@ class _OverviewWorkloadState extends State<OverviewWorkload> {
                           ),
                           const SizedBox(width: Constants.spacingMiddle),
                           Text(
-                            'Warning: ${snapshot.data?.warning ?? '-'}\nUnhealthy: ${snapshot.data?.danger ?? '-'}',
+                            'Warning: ${isLoading ? '-' : snapshot.data?.warning ?? '-'}\nUnhealthy: ${isLoading ? '-' : snapshot.data?.danger ?? '-'}',
                             style: secondaryTextStyle(
                               context,
                             ),


### PR DESCRIPTION
If a user switched the cluster on the home page, we were still showing the values of the former selected cluster in the workloads section. This is now fixed by showing a `-` when the new values are loaded.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
