### PR TITLE
Fix Rendering of Batch Delete List

### DIFF
--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -1145,7 +1145,7 @@ class _ResourcesListItemDeleteResourcesState
   /// The status can be `success`, `danger` or `warning`. The function returns
   /// an icon with the color of the status. If the status is `undefined` the
   /// function returns an empty container.
-  Widget _buildStatus(BuildContext context, ResourceStatus status) {
+  Widget? _buildStatus(BuildContext context, ResourceStatus status) {
     if (status != ResourceStatus.undefined) {
       return Wrap(
         children: [
@@ -1163,7 +1163,7 @@ class _ResourcesListItemDeleteResourcesState
       );
     }
 
-    return Container();
+    return null;
   }
 
   @override


### PR DESCRIPTION
If a resource didn't had a status, the batch delete list was broken, because we returned a `Container` widget. This is now fixed by returning `null` instead of a widget.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
