### PR TITLE
Rework `goToReference` Function

### DIFF
--- a/lib/widgets/resources/helpers/details_item_metadata.dart
+++ b/lib/widgets/resources/helpers/details_item_metadata.dart
@@ -59,13 +59,11 @@ class DetailsItemMetadata extends StatelessWidget {
           name: 'Owner References',
           values: ownerReferences,
           onTap: (int index) {
-            final goToFunc = goToReference(
+            goToReference(
               context,
               metadata?.ownerReferences[index],
               metadata?.namespace,
             );
-
-            goToFunc();
           },
         ),
       ],

--- a/lib/widgets/resources/resources/resources_endpoints.dart
+++ b/lib/widgets/resources/resources/resources_endpoints.dart
@@ -184,13 +184,11 @@ List<Widget> _buildSubsets(
                 .toList(),
             onTap: (int index) {
               if (endpoint.subsets[i].addresses[index].targetRef != null) {
-                final goToFunc = goToReference(
+                goToReference(
                   context,
                   endpoint.subsets[i].addresses[index].targetRef,
                   endpoint.metadata?.namespace,
                 );
-
-                goToFunc();
               }
             },
           ),

--- a/lib/widgets/resources/resources/resources_events.dart
+++ b/lib/widgets/resources/resources/resources_events.dart
@@ -158,11 +158,13 @@ final resourceEvent = Resource(
         DetailsItem(
           title: 'Involved Object',
           goTo: 'View',
-          goToOnTap: goToReference(
-            context,
-            item.involvedObject,
-            null,
-          ),
+          goToOnTap: () {
+            goToReference(
+              context,
+              item.involvedObject,
+              null,
+            );
+          },
           details: [
             DetailsItemModel(
               name: 'API Version',

--- a/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
+++ b/lib/widgets/resources/resources/resources_horizontalpodautoscalers.dart
@@ -165,7 +165,7 @@ final resourceHorizontalPodAutoscaler = Resource(
               values:
                   '${item.spec?.scaleTargetRef.kind ?? '-'}/${item.spec?.scaleTargetRef.name ?? '-'}',
               onTap: (int index) {
-                final goToFunc = goToReference(
+                goToReference(
                   context,
                   IoK8sApimachineryPkgApisMetaV1OwnerReference(
                     apiVersion: item.spec?.scaleTargetRef.apiVersion ?? '',
@@ -175,8 +175,6 @@ final resourceHorizontalPodAutoscaler = Resource(
                   ),
                   item.metadata?.namespace,
                 );
-
-                goToFunc();
               },
             ),
           ],

--- a/lib/widgets/resources/resources/resources_ingressclasses.dart
+++ b/lib/widgets/resources/resources/resources_ingressclasses.dart
@@ -124,7 +124,7 @@ final resourceIngressClass = Resource(
               onTap: item.spec?.parameters == null
                   ? null
                   : (int index) {
-                      final goToFunc = goToReference(
+                      goToReference(
                         context,
                         IoK8sApiCoreV1ObjectReference(
                           apiVersion: item.spec?.parameters?.apiGroup,
@@ -134,8 +134,6 @@ final resourceIngressClass = Resource(
                         ),
                         item.spec?.parameters?.namespace,
                       );
-
-                      goToFunc();
                     },
             ),
           ],


### PR DESCRIPTION
Rework the `goToReference` function to not return a function. Instead the function directly calls the `navigate` function now.

This change can be done, because the `goToReference` function also supports CRDs since #640 and doesn't return `null` anymore.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
