### PR TITLE
Add Status Indication for Helm Releases

### DIFF
--- a/lib/widgets/plugins/helm/plugin_helm_details.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details.dart
@@ -13,6 +13,7 @@ import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/resources.dart';
 import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_manifest.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_rollback.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_template.dart';
@@ -453,7 +454,7 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                                     ),
                                                     Text(
                                                       Characters(
-                                                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? ''))}',
+                                                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
                                                       )
                                                           .replaceAll(
                                                             Characters(''),
@@ -471,7 +472,7 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                                     ),
                                                     Text(
                                                       Characters(
-                                                        'Status: ${release.info?.status}',
+                                                        'Status: ${release.info?.status ?? '-'}',
                                                       )
                                                           .replaceAll(
                                                             Characters(''),
@@ -489,7 +490,7 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                                     ),
                                                     Text(
                                                       Characters(
-                                                        'Chart Version: ${release.chart?.metadata?.version}',
+                                                        'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
                                                       )
                                                           .replaceAll(
                                                             Characters(''),
@@ -507,7 +508,7 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                                     ),
                                                     Text(
                                                       Characters(
-                                                        'App Version: ${release.chart?.metadata?.appVersion}',
+                                                        'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
                                                       )
                                                           .replaceAll(
                                                             Characters(''),
@@ -525,6 +526,42 @@ class _PluginHelmDetailsState extends State<PluginHelmDetails> {
                                                     ),
                                                   ],
                                                 ),
+                                              ),
+                                              Wrap(
+                                                children: [
+                                                  const SizedBox(
+                                                    width:
+                                                        Constants.spacingSmall,
+                                                  ),
+                                                  Icon(
+                                                    Icons.radio_button_checked,
+                                                    size: 24,
+                                                    color: release.info
+                                                                    ?.status ==
+                                                                'deployed' ||
+                                                            release.info
+                                                                    ?.status ==
+                                                                'superseded' ||
+                                                            release.info
+                                                                    ?.status ==
+                                                                'uninstalled'
+                                                        ? Theme.of(context)
+                                                            .extension<
+                                                                CustomColors>()!
+                                                            .success
+                                                        : release.info
+                                                                    ?.status ==
+                                                                'failed'
+                                                            ? Theme.of(context)
+                                                                .extension<
+                                                                    CustomColors>()!
+                                                                .error
+                                                            : Theme.of(context)
+                                                                .extension<
+                                                                    CustomColors>()!
+                                                                .warning,
+                                                  ),
+                                                ],
                                               ),
                                             ],
                                           ),

--- a/lib/widgets/plugins/helm/plugin_helm_list.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list.dart
@@ -13,6 +13,7 @@ import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/navigate.dart';
 import 'package:kubenav/utils/resources.dart';
 import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_list_item_actions.dart';
 import 'package:kubenav/widgets/shared/app_bottom_navigation_bar_widget.dart';
@@ -131,7 +132,7 @@ class _PluginHelmListState extends State<PluginHelmList> {
                     ),
                     Text(
                       Characters(
-                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? ''))}',
+                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
                       )
                           .replaceAll(Characters(''), Characters('\u{200B}'))
                           .toString(),
@@ -142,7 +143,7 @@ class _PluginHelmListState extends State<PluginHelmList> {
                       ),
                     ),
                     Text(
-                      Characters('Status: ${release.info?.status}')
+                      Characters('Status: ${release.info?.status ?? '-'}')
                           .replaceAll(Characters(''), Characters('\u{200B}'))
                           .toString(),
                       overflow: TextOverflow.ellipsis,
@@ -153,7 +154,7 @@ class _PluginHelmListState extends State<PluginHelmList> {
                     ),
                     Text(
                       Characters(
-                        'Chart Version: ${release.chart?.metadata?.version}',
+                        'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
                       )
                           .replaceAll(Characters(''), Characters('\u{200B}'))
                           .toString(),
@@ -165,7 +166,7 @@ class _PluginHelmListState extends State<PluginHelmList> {
                     ),
                     Text(
                       Characters(
-                        'App Version: ${release.chart?.metadata?.appVersion}',
+                        'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
                       )
                           .replaceAll(Characters(''), Characters('\u{200B}'))
                           .toString(),
@@ -179,6 +180,22 @@ class _PluginHelmListState extends State<PluginHelmList> {
                 ),
               ],
             ),
+          ),
+          Wrap(
+            children: [
+              const SizedBox(width: Constants.spacingSmall),
+              Icon(
+                Icons.radio_button_checked,
+                size: 24,
+                color: release.info?.status == 'deployed' ||
+                        release.info?.status == 'superseded' ||
+                        release.info?.status == 'uninstalled'
+                    ? Theme.of(context).extension<CustomColors>()!.success
+                    : release.info?.status == 'failed'
+                        ? Theme.of(context).extension<CustomColors>()!.error
+                        : Theme.of(context).extension<CustomColors>()!.warning,
+              ),
+            ],
           ),
         ],
       ),


### PR DESCRIPTION
This commit adds a status indicator to the Helm releases, similar how it is done for other resources, so that a user can find failed Helm releases easier.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
