### PR TITLE
Add Swipe Actions for Providers

### DIFF
--- a/lib/widgets/settings/providers/settings_provider_actions.dart
+++ b/lib/widgets/settings/providers/settings_provider_actions.dart
@@ -15,12 +15,50 @@ import 'package:kubenav/widgets/settings/providers/settings_oidc_provider_config
 import 'package:kubenav/widgets/settings/providers/settings_rancher_provider_config.dart';
 import 'package:kubenav/widgets/shared/app_actions_widget.dart';
 
+/// [buildProviderModal] returns a widget which can be displayed in a modal,
+/// to modify the configuration of the provider given via the
+/// [provider] parameter.
+Widget buildProviderModal(ClusterProvider provider) {
+  switch (provider.type) {
+    case ClusterProviderType.aws:
+      return SettingsAWSProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.awssso:
+      return SettingsAWSSSOProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.azure:
+      return SettingsAzureProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.digitalocean:
+      return SettingsDigitalOceanProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.google:
+      return SettingsGoogleProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.oidc:
+      return SettingsOIDCProvider(
+        provider: provider,
+      );
+    case ClusterProviderType.rancher:
+      return SettingsRancherProvider(
+        provider: provider,
+      );
+    default:
+      return Container();
+  }
+}
+
 /// The [SettingsProviderActions] returns a list of actions to edit or delete an
 /// existing provider. If the user selects the edit item, we show a modal with
 /// the provider configuration, which can then be modified by the user. If the
 /// user selects the delete item, we remove the provider, when it is not used by
 /// a cluster.
-class SettingsProviderActions extends StatefulWidget {
+class SettingsProviderActions extends StatelessWidget {
   const SettingsProviderActions({
     super.key,
     required this.provider,
@@ -28,71 +66,27 @@ class SettingsProviderActions extends StatefulWidget {
 
   final ClusterProvider provider;
 
-  @override
-  State<SettingsProviderActions> createState() =>
-      _SettingsProviderActionsState();
-}
-
-class _SettingsProviderActionsState extends State<SettingsProviderActions> {
-  /// [buildProviderModal] returns a widget which can be displayed in a modal,
-  /// to modify the configuration of the provider given via the
-  /// [widget.provider] parameter.
-  Widget buildProviderModal() {
-    switch (widget.provider.type) {
-      case ClusterProviderType.aws:
-        return SettingsAWSProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.awssso:
-        return SettingsAWSSSOProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.azure:
-        return SettingsAzureProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.digitalocean:
-        return SettingsDigitalOceanProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.google:
-        return SettingsGoogleProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.oidc:
-        return SettingsOIDCProvider(
-          provider: widget.provider,
-        );
-      case ClusterProviderType.rancher:
-        return SettingsRancherProvider(
-          provider: widget.provider,
-        );
-      default:
-        return Container();
-    }
-  }
-
-  /// [deleteProvider] deletes the given provider. For the success and the error
-  /// case we show the user an message, to inform the user about the result of
-  /// the operation.
-  Future<void> deleteProvider() async {
+  /// [_deleteProvider] deletes the given provider. For the success and the
+  /// error case we show the user an message, to inform the user about the
+  /// result of the operation.
+  Future<void> _deleteProvider(BuildContext context) async {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
     );
 
     try {
-      await clustersRepository.deleteProvider(widget.provider.id!);
-      if (mounted) {
+      await clustersRepository.deleteProvider(provider.id!);
+      if (context.mounted) {
         Navigator.pop(context);
         showSnackbar(
           context,
           'Provider Deleted',
-          'The provider ${widget.provider.name} was deleted',
+          'The provider ${provider.name} was deleted',
         );
       }
     } catch (err) {
-      if (mounted) {
+      if (context.mounted) {
         Navigator.pop(context);
         showSnackbar(
           context,
@@ -112,14 +106,14 @@ class _SettingsProviderActionsState extends State<SettingsProviderActions> {
           color: Theme.of(context).colorScheme.primary,
           onTap: () {
             Navigator.pop(context);
-            showModal(context, buildProviderModal());
+            showModal(context, buildProviderModal(provider));
           },
         ),
         AppActionsWidgetAction(
           title: 'Delete',
           color: Theme.of(context).extension<CustomColors>()!.error,
           onTap: () {
-            deleteProvider();
+            _deleteProvider(context);
           },
         ),
       ],

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 
@@ -31,80 +32,127 @@ class SettingsProviders extends StatelessWidget {
   /// [SettingsProviderActions] actions, where the user can then delete or
   /// modify the provider.
   Widget buildProvider(BuildContext context, ClusterProvider provider) {
-    return AppListItem(
-      onTap: () {
-        showActions(
-          context,
-          SettingsProviderActions(provider: provider),
-        );
-      },
-      onLongPress: () {
-        HapticFeedback.vibrate();
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
 
-        showActions(
-          context,
-          SettingsProviderActions(provider: provider),
-        );
-      },
-      child: Row(
+    return Slidable(
+      key: Key(provider.name ?? ''),
+      endActionPane: ActionPane(
+        motion: const DrawerMotion(),
+        extentRatio: 0.4,
         children: [
-          Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary,
-              borderRadius: const BorderRadius.all(
-                Radius.circular(Constants.sizeBorderRadius),
-              ),
-            ),
-            height: 54,
-            width: 54,
-            padding: const EdgeInsets.all(
-              Constants.spacingIcon54x54,
-            ),
-            child: SvgPicture.asset(provider.type!.icon()),
+          SlidableAction(
+            onPressed: (BuildContext context) {
+              showModal(context, buildProviderModal(provider));
+            },
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            icon: Icons.edit,
           ),
-          const SizedBox(width: Constants.spacingSmall),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  provider.name!,
-                  style: primaryTextStyle(
+          SlidableAction(
+            onPressed: (BuildContext context) async {
+              try {
+                await clustersRepository.deleteProvider(provider.id!);
+                if (context.mounted) {
+                  showSnackbar(
                     context,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                Text(
-                  provider.type!.title(),
-                  style: secondaryTextStyle(
+                    'Provider Deleted',
+                    'The provider ${provider.name} was deleted',
+                  );
+                }
+              } catch (err) {
+                if (context.mounted) {
+                  showSnackbar(
                     context,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                Text(
-                  provider.type!.subtitle(),
-                  style: secondaryTextStyle(
-                    context,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: Constants.spacingSmall),
-          Icon(
-            Icons.arrow_forward_ios,
-            color: Theme.of(context)
-                .extension<CustomColors>()!
-                .textSecondary
-                .withOpacity(Constants.opacityIcon),
-            size: 24,
+                    'Failed to Delete Provider',
+                    err.toString(),
+                  );
+                }
+              }
+            },
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+            icon: Icons.delete,
           ),
         ],
+      ),
+      child: AppListItem(
+        onTap: () {
+          showActions(
+            context,
+            SettingsProviderActions(provider: provider),
+          );
+        },
+        onLongPress: () {
+          HapticFeedback.vibrate();
+
+          showActions(
+            context,
+            SettingsProviderActions(provider: provider),
+          );
+        },
+        child: Row(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(Constants.sizeBorderRadius),
+                ),
+              ),
+              height: 54,
+              width: 54,
+              padding: const EdgeInsets.all(
+                Constants.spacingIcon54x54,
+              ),
+              child: SvgPicture.asset(provider.type!.icon()),
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    provider.name!,
+                    style: primaryTextStyle(
+                      context,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    provider.type!.title(),
+                    style: secondaryTextStyle(
+                      context,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    provider.type!.subtitle(),
+                    style: secondaryTextStyle(
+                      context,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: Constants.spacingSmall),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: Theme.of(context)
+                  .extension<CustomColors>()!
+                  .textSecondary
+                  .withOpacity(Constants.opacityIcon),
+              size: 24,
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The actions for providers in the settings can now be used by swiping a provider to the left. This will reveal a edit and delete action for the provider, which are the same actions as shown via the long press.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
