### PR TITLE
Add Swipe Action for Bookmarks

### DIFF
--- a/lib/widgets/resources/bookmarks/resources_bookmark_actions.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmark_actions.dart
@@ -30,18 +30,21 @@ class ResourcesBookmarkActions extends StatelessWidget {
         AppActionsWidgetAction(
           title: 'Delete',
           color: Theme.of(context).extension<CustomColors>()!.error,
-          onTap: () {
+          onTap: () async {
             final title =
                 bookmarksRepository.bookmarks[index].type == BookmarkType.list
                     ? bookmarksRepository.bookmarks[index].resource.plural
                     : bookmarksRepository.bookmarks[index].resource.singular;
-            bookmarksRepository.removeBookmark(index);
-            showSnackbar(
-              context,
-              'Bookmark Deleted',
-              'Bookmark $title was deleted',
-            );
-            Navigator.pop(context);
+            await bookmarksRepository.removeBookmark(index);
+
+            if (context.mounted) {
+              showSnackbar(
+                context,
+                'Bookmark Deleted',
+                'Bookmark $title was deleted',
+              );
+              Navigator.pop(context);
+            }
           },
         ),
       ],

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/repositories/bookmarks_repository.dart';
@@ -176,119 +177,157 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                         left: Constants.spacingMiddle,
                         right: Constants.spacingMiddle,
                       ),
-                      child: AppListItem(
-                        onTap: () {
-                          openBookmark(index);
-                        },
-                        onLongPress: () {
-                          HapticFeedback.vibrate();
-
-                          showActions(
-                            context,
-                            ResourcesBookmarkActions(
-                              index: index,
-                            ),
-                          );
-                        },
-                        child: Column(
+                      child: Slidable(
+                        key: Key(
+                          '${bookmarksRepository.bookmarks[index].type} ${bookmarksRepository.bookmarks[index].clusterId} ${bookmarksRepository.bookmarks[index].name} ${bookmarksRepository.bookmarks[index].namespace} ${bookmarksRepository.bookmarks[index].resource}',
+                        ),
+                        endActionPane: ActionPane(
+                          motion: const DrawerMotion(),
+                          extentRatio: 0.2,
                           children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Expanded(
-                                  child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        bookmarksRepository
-                                                    .bookmarks[index].type ==
-                                                BookmarkType.list
-                                            ? bookmarksRepository
-                                                .bookmarks[index]
-                                                .resource
-                                                .plural
-                                            : bookmarksRepository
-                                                .bookmarks[index]
-                                                .resource
-                                                .singular,
-                                        style: primaryTextStyle(
-                                          context,
-                                        ),
-                                      ),
-                                      Column(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.start,
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            Characters(
-                                              'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
-                                            )
-                                                .replaceAll(
-                                                  Characters(''),
-                                                  Characters('\u{200B}'),
-                                                )
-                                                .toString(),
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                          Text(
-                                            Characters(
-                                              'Namespace: ${bookmarksRepository.bookmarks[index].namespace ?? '-'}',
-                                            )
-                                                .replaceAll(
-                                                  Characters(''),
-                                                  Characters('\u{200B}'),
-                                                )
-                                                .toString(),
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                          Text(
-                                            Characters(
-                                              'Name: ${bookmarksRepository.bookmarks[index].name ?? '-'}',
-                                            )
-                                                .replaceAll(
-                                                  Characters(''),
-                                                  Characters(
-                                                    '\u{200B}',
-                                                  ),
-                                                )
-                                                .toString(),
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ],
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                ReorderableDragStartListener(
-                                  index: index,
-                                  child: Icon(
-                                    Icons.drag_handle,
-                                    color: Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .textSecondary
-                                        .withOpacity(Constants.opacityIcon),
-                                    size: 24,
-                                  ),
-                                ),
-                              ],
+                            SlidableAction(
+                              onPressed: (BuildContext context) async {
+                                final title =
+                                    bookmarksRepository.bookmarks[index].type ==
+                                            BookmarkType.list
+                                        ? bookmarksRepository
+                                            .bookmarks[index].resource.plural
+                                        : bookmarksRepository
+                                            .bookmarks[index].resource.singular;
+                                await bookmarksRepository.removeBookmark(index);
+
+                                if (context.mounted) {
+                                  showSnackbar(
+                                    context,
+                                    'Bookmark Deleted',
+                                    'Bookmark $title was deleted',
+                                  );
+                                }
+                              },
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.error,
+                              foregroundColor:
+                                  Theme.of(context).colorScheme.onError,
+                              icon: Icons.delete,
                             ),
                           ],
+                        ),
+                        child: AppListItem(
+                          onTap: () {
+                            openBookmark(index);
+                          },
+                          onLongPress: () {
+                            HapticFeedback.vibrate();
+
+                            showActions(
+                              context,
+                              ResourcesBookmarkActions(
+                                index: index,
+                              ),
+                            );
+                          },
+                          child: Column(
+                            children: [
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Expanded(
+                                    child: Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          bookmarksRepository
+                                                      .bookmarks[index].type ==
+                                                  BookmarkType.list
+                                              ? bookmarksRepository
+                                                  .bookmarks[index]
+                                                  .resource
+                                                  .plural
+                                              : bookmarksRepository
+                                                  .bookmarks[index]
+                                                  .resource
+                                                  .singular,
+                                          style: primaryTextStyle(
+                                            context,
+                                          ),
+                                        ),
+                                        Column(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.start,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              Characters(
+                                                'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
+                                              )
+                                                  .replaceAll(
+                                                    Characters(''),
+                                                    Characters('\u{200B}'),
+                                                  )
+                                                  .toString(),
+                                              style: secondaryTextStyle(
+                                                context,
+                                              ),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                            Text(
+                                              Characters(
+                                                'Namespace: ${bookmarksRepository.bookmarks[index].namespace ?? '-'}',
+                                              )
+                                                  .replaceAll(
+                                                    Characters(''),
+                                                    Characters('\u{200B}'),
+                                                  )
+                                                  .toString(),
+                                              style: secondaryTextStyle(
+                                                context,
+                                              ),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                            Text(
+                                              Characters(
+                                                'Name: ${bookmarksRepository.bookmarks[index].name ?? '-'}',
+                                              )
+                                                  .replaceAll(
+                                                    Characters(''),
+                                                    Characters(
+                                                      '\u{200B}',
+                                                    ),
+                                                  )
+                                                  .toString(),
+                                              style: secondaryTextStyle(
+                                                context,
+                                              ),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  ReorderableDragStartListener(
+                                    index: index,
+                                    child: Icon(
+                                      Icons.drag_handle,
+                                      color: Theme.of(context)
+                                          .extension<CustomColors>()!
+                                          .textSecondary
+                                          .withOpacity(Constants.opacityIcon),
+                                      size: 24,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
The action to delete a bookmark, can now be triggered by swiping a bookmark item to the left. This is implemented as an alerternative to the long press to delete a bookmark and should make it easier for users to find the action.

This commit also changes the function to delete a bookmark to an async function so that we can await the deletion of a bookmark.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
