### PR TITLE
Add Swipe Actions for Resources

### DIFF
--- a/lib/widgets/plugins/helm/plugin_helm_list.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/models/plugins/helm.dart';
@@ -68,136 +69,160 @@ class _PluginHelmListState extends State<PluginHelmList> {
   /// of releases. When the user clicks on the release he will be redirected to
   /// the [PluginHelmDetails] screen.
   Widget _buildItem(Release release) {
-    return AppListItem(
-      onTap: () {
-        navigate(
-          context,
-          PluginHelmDetails(
-            name: release.name!,
-            namespace: release.namespace!,
-            version: release.version!,
-          ),
-        );
-      },
-      onLongPress: () {
-        HapticFeedback.vibrate();
-
-        showActions(
-          context,
-          PluginHelmListItemActions(
-            release: release,
-          ),
-        );
-      },
-      child: Row(
+    return Slidable(
+      key: Key('${release.namespace}-${release.name}-${release.version}'),
+      endActionPane: ActionPane(
+        motion: const DrawerMotion(),
+        extentRatio: 0.2,
         children: [
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  Characters(release.name ?? '')
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: primaryTextStyle(
-                    context,
-                  ),
+          SlidableAction(
+            onPressed: (BuildContext context) {
+              showActions(
+                context,
+                PluginHelmListItemActions(
+                  release: release,
                 ),
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      Characters('Namespace: ${release.namespace}')
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
-                      ),
+              );
+            },
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            icon: Icons.more_horiz,
+          ),
+        ],
+      ),
+      child: AppListItem(
+        onTap: () {
+          navigate(
+            context,
+            PluginHelmDetails(
+              name: release.name!,
+              namespace: release.namespace!,
+              version: release.version!,
+            ),
+          );
+        },
+        onLongPress: () {
+          HapticFeedback.vibrate();
+
+          showActions(
+            context,
+            PluginHelmListItemActions(
+              release: release,
+            ),
+          );
+        },
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    Characters(release.name ?? '')
+                        .replaceAll(Characters(''), Characters('\u{200B}'))
+                        .toString(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: primaryTextStyle(
+                      context,
                     ),
-                    Text(
-                      Characters('Revision: ${release.version}')
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
+                  ),
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        Characters('Namespace: ${release.namespace}')
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
                       ),
-                    ),
-                    Text(
-                      Characters(
-                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
+                      Text(
+                        Characters('Revision: ${release.version}')
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
                       ),
-                    ),
-                    Text(
-                      Characters('Status: ${release.info?.status ?? '-'}')
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
+                      Text(
+                        Characters(
+                          'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
+                        )
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
                       ),
-                    ),
-                    Text(
-                      Characters(
-                        'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
+                      Text(
+                        Characters('Status: ${release.info?.status ?? '-'}')
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
                       ),
-                    ),
-                    Text(
-                      Characters(
-                        'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
-                      )
-                          .replaceAll(Characters(''), Characters('\u{200B}'))
-                          .toString(),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      style: secondaryTextStyle(
-                        context,
+                      Text(
+                        Characters(
+                          'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
+                        )
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
                       ),
-                    ),
-                  ],
+                      Text(
+                        Characters(
+                          'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
+                        )
+                            .replaceAll(Characters(''), Characters('\u{200B}'))
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Wrap(
+              children: [
+                const SizedBox(width: Constants.spacingSmall),
+                Icon(
+                  Icons.radio_button_checked,
+                  size: 24,
+                  color: release.info?.status == 'deployed' ||
+                          release.info?.status == 'superseded' ||
+                          release.info?.status == 'uninstalled'
+                      ? Theme.of(context).extension<CustomColors>()!.success
+                      : release.info?.status == 'failed'
+                          ? Theme.of(context).extension<CustomColors>()!.error
+                          : Theme.of(context)
+                              .extension<CustomColors>()!
+                              .warning,
                 ),
               ],
             ),
-          ),
-          Wrap(
-            children: [
-              const SizedBox(width: Constants.spacingSmall),
-              Icon(
-                Icons.radio_button_checked,
-                size: 24,
-                color: release.info?.status == 'deployed' ||
-                        release.info?.status == 'superseded' ||
-                        release.info?.status == 'uninstalled'
-                    ? Theme.of(context).extension<CustomColors>()!.success
-                    : release.info?.status == 'failed'
-                        ? Theme.of(context).extension<CustomColors>()!.error
-                        : Theme.of(context).extension<CustomColors>()!.warning,
-              ),
-            ],
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:code_text_field/code_text_field.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:highlight/languages/json.dart' as highlight_json;
 import 'package:highlight/languages/yaml.dart' as highlight_yaml;
 import 'package:provider/provider.dart';
@@ -718,73 +719,101 @@ class ResourcesListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AppListItem(
-      onTap: () {
-        navigate(
-          context,
-          ResourcesDetails(
-            name: name,
-            namespace: namespace,
-            resource: resource,
-          ),
-        );
-      },
-      onLongPress: () {
-        HapticFeedback.vibrate();
-
-        showActions(
-          context,
-          ResourcesListItemActions(
-            name: name,
-            namespace: namespace,
-            resource: resource,
-            item: item,
-          ),
-        );
-      },
-      child: Row(
+    return Slidable(
+      key: Key('$namespace-$name'),
+      endActionPane: ActionPane(
+        motion: const DrawerMotion(),
+        extentRatio: 0.2,
         children: [
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  Characters(name)
-                      .replaceAll(Characters(''), Characters('\u{200B}'))
-                      .toString(),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: primaryTextStyle(
-                    context,
-                  ),
+          SlidableAction(
+            onPressed: (BuildContext context) {
+              showActions(
+                context,
+                ResourcesListItemActions(
+                  name: name,
+                  namespace: namespace,
+                  resource: resource,
+                  item: item,
                 ),
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: List.generate(
-                    details.length,
-                    (index) {
-                      return Text(
-                        Characters(
-                          details[index],
-                        )
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
+              );
+            },
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            icon: Icons.more_horiz,
           ),
-          _buildStatus(context, status),
         ],
+      ),
+      child: AppListItem(
+        onTap: () {
+          navigate(
+            context,
+            ResourcesDetails(
+              name: name,
+              namespace: namespace,
+              resource: resource,
+            ),
+          );
+        },
+        onLongPress: () {
+          HapticFeedback.vibrate();
+
+          showActions(
+            context,
+            ResourcesListItemActions(
+              name: name,
+              namespace: namespace,
+              resource: resource,
+              item: item,
+            ),
+          );
+        },
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    Characters(name)
+                        .replaceAll(Characters(''), Characters('\u{200B}'))
+                        .toString(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: primaryTextStyle(
+                      context,
+                    ),
+                  ),
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: List.generate(
+                      details.length,
+                      (index) {
+                        return Text(
+                          Characters(
+                            details[index],
+                          )
+                              .replaceAll(
+                                Characters(''),
+                                Characters('\u{200B}'),
+                              )
+                              .toString(),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                          style: secondaryTextStyle(
+                            context,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            _buildStatus(context, status),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The actions for Kubernetes resources and plugin resources can now be accessed by swiping a item to the left in the list view. This was added as alternative to the long press to make it easier for users to find these actions.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
