### PR TITLE
Improve Design of `Slidable` Widget

### DIFF
--- a/lib/widgets/plugins/helm/plugin_helm_list.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_list.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/models/plugins/helm.dart';
@@ -69,160 +68,152 @@ class _PluginHelmListState extends State<PluginHelmList> {
   /// of releases. When the user clicks on the release he will be redirected to
   /// the [PluginHelmDetails] screen.
   Widget _buildItem(Release release) {
-    return Slidable(
-      key: Key('${release.namespace}-${release.name}-${release.version}'),
-      endActionPane: ActionPane(
-        motion: const DrawerMotion(),
-        extentRatio: 0.2,
-        children: [
-          SlidableAction(
-            onPressed: (BuildContext context) {
-              showActions(
-                context,
-                PluginHelmListItemActions(
-                  release: release,
-                ),
-              );
-            },
-            backgroundColor: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            icon: Icons.more_horiz,
+    return AppListItem(
+      onTap: () {
+        navigate(
+          context,
+          PluginHelmDetails(
+            name: release.name!,
+            namespace: release.namespace!,
+            version: release.version!,
           ),
-        ],
-      ),
-      child: AppListItem(
-        onTap: () {
-          navigate(
-            context,
-            PluginHelmDetails(
-              name: release.name!,
-              namespace: release.namespace!,
-              version: release.version!,
-            ),
-          );
-        },
-        onLongPress: () {
-          HapticFeedback.vibrate();
+        );
+      },
+      onLongPress: () {
+        HapticFeedback.vibrate();
 
-          showActions(
-            context,
-            PluginHelmListItemActions(
-              release: release,
-            ),
-          );
-        },
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    Characters(release.name ?? '')
-                        .replaceAll(Characters(''), Characters('\u{200B}'))
-                        .toString(),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: primaryTextStyle(
-                      context,
-                    ),
-                  ),
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        Characters('Namespace: ${release.namespace}')
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        Characters('Revision: ${release.version}')
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        Characters(
-                          'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
-                        )
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        Characters('Status: ${release.info?.status ?? '-'}')
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        Characters(
-                          'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
-                        )
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        Characters(
-                          'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
-                        )
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
+        showActions(
+          context,
+          PluginHelmListItemActions(
+            release: release,
+          ),
+        );
+      },
+      slidableActions: [
+        AppListItemSlidableAction(
+          icon: Icons.more_horiz,
+          label: 'More',
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          foregroundColor: Theme.of(context).colorScheme.onPrimary,
+          onTap: (BuildContext context) {
+            showActions(
+              context,
+              PluginHelmListItemActions(
+                release: release,
               ),
-            ),
-            Wrap(
+            );
+          },
+        ),
+      ],
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const SizedBox(width: Constants.spacingSmall),
-                Icon(
-                  Icons.radio_button_checked,
-                  size: 24,
-                  color: release.info?.status == 'deployed' ||
-                          release.info?.status == 'superseded' ||
-                          release.info?.status == 'uninstalled'
-                      ? Theme.of(context).extension<CustomColors>()!.success
-                      : release.info?.status == 'failed'
-                          ? Theme.of(context).extension<CustomColors>()!.error
-                          : Theme.of(context)
-                              .extension<CustomColors>()!
-                              .warning,
+                Text(
+                  Characters(release.name ?? '')
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: primaryTextStyle(
+                    context,
+                  ),
+                ),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      Characters('Namespace: ${release.namespace}')
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      Characters('Revision: ${release.version}')
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      Characters(
+                        'Updated: ${formatTime(DateTime.parse(release.info?.lastDeployed ?? '-'))}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      Characters('Status: ${release.info?.status ?? '-'}')
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      Characters(
+                        'Chart Version: ${release.chart?.metadata?.version ?? '-'}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      Characters(
+                        'App Version: ${release.chart?.metadata?.appVersion ?? '-'}',
+                      )
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(
+                        context,
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          Wrap(
+            children: [
+              const SizedBox(width: Constants.spacingSmall),
+              Icon(
+                Icons.radio_button_checked,
+                size: 24,
+                color: release.info?.status == 'deployed' ||
+                        release.info?.status == 'superseded' ||
+                        release.info?.status == 'uninstalled'
+                    ? Theme.of(context).extension<CustomColors>()!.success
+                    : release.info?.status == 'failed'
+                        ? Theme.of(context).extension<CustomColors>()!.error
+                        : Theme.of(context).extension<CustomColors>()!.warning,
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/repositories/bookmarks_repository.dart';
@@ -177,157 +176,147 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                         left: Constants.spacingMiddle,
                         right: Constants.spacingMiddle,
                       ),
-                      child: Slidable(
-                        key: Key(
-                          '${bookmarksRepository.bookmarks[index].type} ${bookmarksRepository.bookmarks[index].clusterId} ${bookmarksRepository.bookmarks[index].name} ${bookmarksRepository.bookmarks[index].namespace} ${bookmarksRepository.bookmarks[index].resource}',
-                        ),
-                        endActionPane: ActionPane(
-                          motion: const DrawerMotion(),
-                          extentRatio: 0.2,
-                          children: [
-                            SlidableAction(
-                              onPressed: (BuildContext context) async {
-                                final title =
-                                    bookmarksRepository.bookmarks[index].type ==
-                                            BookmarkType.list
-                                        ? bookmarksRepository
-                                            .bookmarks[index].resource.plural
-                                        : bookmarksRepository
-                                            .bookmarks[index].resource.singular;
-                                await bookmarksRepository.removeBookmark(index);
+                      child: AppListItem(
+                        onTap: () {
+                          openBookmark(index);
+                        },
+                        onLongPress: () {
+                          HapticFeedback.vibrate();
 
-                                if (context.mounted) {
-                                  showSnackbar(
-                                    context,
-                                    'Bookmark Deleted',
-                                    'Bookmark $title was deleted',
-                                  );
-                                }
-                              },
-                              backgroundColor:
-                                  Theme.of(context).colorScheme.error,
-                              foregroundColor:
-                                  Theme.of(context).colorScheme.onError,
-                              icon: Icons.delete,
+                          showActions(
+                            context,
+                            ResourcesBookmarkActions(
+                              index: index,
+                            ),
+                          );
+                        },
+                        slidableActions: [
+                          AppListItemSlidableAction(
+                            icon: Icons.delete,
+                            label: 'Delete',
+                            backgroundColor:
+                                Theme.of(context).colorScheme.error,
+                            foregroundColor:
+                                Theme.of(context).colorScheme.onError,
+                            onTap: (BuildContext context) async {
+                              final title =
+                                  bookmarksRepository.bookmarks[index].type ==
+                                          BookmarkType.list
+                                      ? bookmarksRepository
+                                          .bookmarks[index].resource.plural
+                                      : bookmarksRepository
+                                          .bookmarks[index].resource.singular;
+                              await bookmarksRepository.removeBookmark(index);
+
+                              if (context.mounted) {
+                                showSnackbar(
+                                  context,
+                                  'Bookmark Deleted',
+                                  'Bookmark $title was deleted',
+                                );
+                              }
+                            },
+                          ),
+                        ],
+                        child: Column(
+                          children: [
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Expanded(
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        bookmarksRepository
+                                                    .bookmarks[index].type ==
+                                                BookmarkType.list
+                                            ? bookmarksRepository
+                                                .bookmarks[index]
+                                                .resource
+                                                .plural
+                                            : bookmarksRepository
+                                                .bookmarks[index]
+                                                .resource
+                                                .singular,
+                                        style: primaryTextStyle(
+                                          context,
+                                        ),
+                                      ),
+                                      Column(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.start,
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            Characters(
+                                              'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
+                                            )
+                                                .replaceAll(
+                                                  Characters(''),
+                                                  Characters('\u{200B}'),
+                                                )
+                                                .toString(),
+                                            style: secondaryTextStyle(
+                                              context,
+                                            ),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                          Text(
+                                            Characters(
+                                              'Namespace: ${bookmarksRepository.bookmarks[index].namespace ?? '-'}',
+                                            )
+                                                .replaceAll(
+                                                  Characters(''),
+                                                  Characters('\u{200B}'),
+                                                )
+                                                .toString(),
+                                            style: secondaryTextStyle(
+                                              context,
+                                            ),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                          Text(
+                                            Characters(
+                                              'Name: ${bookmarksRepository.bookmarks[index].name ?? '-'}',
+                                            )
+                                                .replaceAll(
+                                                  Characters(''),
+                                                  Characters(
+                                                    '\u{200B}',
+                                                  ),
+                                                )
+                                                .toString(),
+                                            style: secondaryTextStyle(
+                                              context,
+                                            ),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                ReorderableDragStartListener(
+                                  index: index,
+                                  child: Icon(
+                                    Icons.drag_handle,
+                                    color: Theme.of(context)
+                                        .extension<CustomColors>()!
+                                        .textSecondary
+                                        .withOpacity(Constants.opacityIcon),
+                                    size: 24,
+                                  ),
+                                ),
+                              ],
                             ),
                           ],
-                        ),
-                        child: AppListItem(
-                          onTap: () {
-                            openBookmark(index);
-                          },
-                          onLongPress: () {
-                            HapticFeedback.vibrate();
-
-                            showActions(
-                              context,
-                              ResourcesBookmarkActions(
-                                index: index,
-                              ),
-                            );
-                          },
-                          child: Column(
-                            children: [
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Expanded(
-                                    child: Column(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.start,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          bookmarksRepository
-                                                      .bookmarks[index].type ==
-                                                  BookmarkType.list
-                                              ? bookmarksRepository
-                                                  .bookmarks[index]
-                                                  .resource
-                                                  .plural
-                                              : bookmarksRepository
-                                                  .bookmarks[index]
-                                                  .resource
-                                                  .singular,
-                                          style: primaryTextStyle(
-                                            context,
-                                          ),
-                                        ),
-                                        Column(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.start,
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
-                                          children: [
-                                            Text(
-                                              Characters(
-                                                'Cluster: ${cluster?.name ?? bookmarksRepository.bookmarks[index].clusterId}',
-                                              )
-                                                  .replaceAll(
-                                                    Characters(''),
-                                                    Characters('\u{200B}'),
-                                                  )
-                                                  .toString(),
-                                              style: secondaryTextStyle(
-                                                context,
-                                              ),
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
-                                            ),
-                                            Text(
-                                              Characters(
-                                                'Namespace: ${bookmarksRepository.bookmarks[index].namespace ?? '-'}',
-                                              )
-                                                  .replaceAll(
-                                                    Characters(''),
-                                                    Characters('\u{200B}'),
-                                                  )
-                                                  .toString(),
-                                              style: secondaryTextStyle(
-                                                context,
-                                              ),
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
-                                            ),
-                                            Text(
-                                              Characters(
-                                                'Name: ${bookmarksRepository.bookmarks[index].name ?? '-'}',
-                                              )
-                                                  .replaceAll(
-                                                    Characters(''),
-                                                    Characters(
-                                                      '\u{200B}',
-                                                    ),
-                                                  )
-                                                  .toString(),
-                                              style: secondaryTextStyle(
-                                                context,
-                                              ),
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
-                                            ),
-                                          ],
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                  ReorderableDragStartListener(
-                                    index: index,
-                                    child: Icon(
-                                      Icons.drag_handle,
-                                      color: Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .textSecondary
-                                          .withOpacity(Constants.opacityIcon),
-                                      size: 24,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
                         ),
                       ),
                     ),

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:code_text_field/code_text_field.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:highlight/languages/json.dart' as highlight_json;
 import 'package:highlight/languages/yaml.dart' as highlight_yaml;
 import 'package:provider/provider.dart';
@@ -719,101 +718,95 @@ class ResourcesListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Slidable(
-      key: Key('$namespace-$name'),
-      endActionPane: ActionPane(
-        motion: const DrawerMotion(),
-        extentRatio: 0.2,
-        children: [
-          SlidableAction(
-            onPressed: (BuildContext context) {
-              showActions(
-                context,
-                ResourcesListItemActions(
-                  name: name,
-                  namespace: namespace,
-                  resource: resource,
-                  item: item,
-                ),
-              );
-            },
-            backgroundColor: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            icon: Icons.more_horiz,
+    return AppListItem(
+      onTap: () {
+        navigate(
+          context,
+          ResourcesDetails(
+            name: name,
+            namespace: namespace,
+            resource: resource,
           ),
-        ],
-      ),
-      child: AppListItem(
-        onTap: () {
-          navigate(
-            context,
-            ResourcesDetails(
-              name: name,
-              namespace: namespace,
-              resource: resource,
-            ),
-          );
-        },
-        onLongPress: () {
-          HapticFeedback.vibrate();
+        );
+      },
+      onLongPress: () {
+        HapticFeedback.vibrate();
 
-          showActions(
-            context,
-            ResourcesListItemActions(
-              name: name,
-              namespace: namespace,
-              resource: resource,
-              item: item,
-            ),
-          );
-        },
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    Characters(name)
-                        .replaceAll(Characters(''), Characters('\u{200B}'))
-                        .toString(),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: primaryTextStyle(
-                      context,
-                    ),
-                  ),
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: List.generate(
-                      details.length,
-                      (index) {
-                        return Text(
-                          Characters(
-                            details[index],
-                          )
-                              .replaceAll(
-                                Characters(''),
-                                Characters('\u{200B}'),
-                              )
-                              .toString(),
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 1,
-                          style: secondaryTextStyle(
-                            context,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                ],
+        showActions(
+          context,
+          ResourcesListItemActions(
+            name: name,
+            namespace: namespace,
+            resource: resource,
+            item: item,
+          ),
+        );
+      },
+      slidableActions: [
+        AppListItemSlidableAction(
+          icon: Icons.more_horiz,
+          label: 'More',
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          foregroundColor: Theme.of(context).colorScheme.onPrimary,
+          onTap: (BuildContext context) {
+            showActions(
+              context,
+              ResourcesListItemActions(
+                name: name,
+                namespace: namespace,
+                resource: resource,
+                item: item,
               ),
-            ),
-            _buildStatus(context, status),
-          ],
+            );
+          },
         ),
+      ],
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  Characters(name)
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: primaryTextStyle(
+                    context,
+                  ),
+                ),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: List.generate(
+                    details.length,
+                    (index) {
+                      return Text(
+                        Characters(
+                          details[index],
+                        )
+                            .replaceAll(
+                              Characters(''),
+                              Characters('\u{200B}'),
+                            )
+                            .toString(),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        style: secondaryTextStyle(
+                          context,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _buildStatus(context, status),
+        ],
       ),
     );
   }

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/models/cluster.dart';
@@ -131,110 +130,105 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
         left: Constants.spacingMiddle,
         right: Constants.spacingMiddle,
       ),
-      child: Slidable(
-        key: Key(widget.cluster.id),
-        endActionPane: ActionPane(
-          motion: const DrawerMotion(),
-          extentRatio: 0.4,
-          children: [
-            SlidableAction(
-              onPressed: (BuildContext context) {
-                showModal(
-                  context,
-                  SettingsEditCluster(cluster: widget.cluster),
-                );
-              },
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              icon: Icons.edit,
-            ),
-            SlidableAction(
-              onPressed: (BuildContext context) async {
-                ClustersRepository clustersRepository =
-                    Provider.of<ClustersRepository>(
-                  context,
-                  listen: false,
-                );
-                BookmarksRepository bookmarksRepository =
-                    Provider.of<BookmarksRepository>(
-                  context,
-                  listen: false,
-                );
+      child: AppListItem(
+        onTap: widget.onTap,
+        onLongPress: widget.onLongPress,
+        slidableActions: [
+          AppListItemSlidableAction(
+            icon: Icons.edit,
+            label: 'Edit',
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            onTap: (BuildContext context) {
+              showModal(
+                context,
+                SettingsEditCluster(cluster: widget.cluster),
+              );
+            },
+          ),
+          AppListItemSlidableAction(
+            icon: Icons.delete,
+            label: 'Delete',
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+            onTap: (BuildContext context) async {
+              ClustersRepository clustersRepository =
+                  Provider.of<ClustersRepository>(
+                context,
+                listen: false,
+              );
+              BookmarksRepository bookmarksRepository =
+                  Provider.of<BookmarksRepository>(
+                context,
+                listen: false,
+              );
 
-                try {
-                  await clustersRepository.deleteCluster(widget.cluster.id);
-                  await bookmarksRepository
-                      .removeBookmarksForCluster(widget.cluster.id);
-                  if (context.mounted) {
-                    showSnackbar(
-                      context,
-                      'Cluster Deleted',
-                      'The cluster ${widget.cluster.name} was deleted',
-                    );
-                  }
-                } catch (err) {
-                  if (context.mounted) {
-                    showSnackbar(
-                      context,
-                      'Failed to Delete Cluster',
-                      err.toString(),
-                    );
-                  }
+              try {
+                await clustersRepository.deleteCluster(widget.cluster.id);
+                await bookmarksRepository
+                    .removeBookmarksForCluster(widget.cluster.id);
+                if (context.mounted) {
+                  showSnackbar(
+                    context,
+                    'Cluster Deleted',
+                    'The cluster ${widget.cluster.name} was deleted',
+                  );
                 }
-              },
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
-              icon: Icons.delete,
+              } catch (err) {
+                if (context.mounted) {
+                  showSnackbar(
+                    context,
+                    'Failed to Delete Cluster',
+                    err.toString(),
+                  );
+                }
+              }
+            },
+          ),
+        ],
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        Characters(widget.cluster.name)
+                            .replaceAll(
+                              Characters(''),
+                              Characters('\u{200B}'),
+                            )
+                            .toString(),
+                        style: primaryTextStyle(
+                          context,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Text(
+                        Characters(widget.cluster.clusterProviderType.title())
+                            .replaceAll(
+                              Characters(''),
+                              Characters('\u{200B}'),
+                            )
+                            .toString(),
+                        style: secondaryTextStyle(
+                          context,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                _buildIcon(),
+              ],
             ),
           ],
-        ),
-        child: AppListItem(
-          onTap: widget.onTap,
-          onLongPress: widget.onLongPress,
-          child: Column(
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          Characters(widget.cluster.name)
-                              .replaceAll(
-                                Characters(''),
-                                Characters('\u{200B}'),
-                              )
-                              .toString(),
-                          style: primaryTextStyle(
-                            context,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        Text(
-                          Characters(widget.cluster.clusterProviderType.title())
-                              .replaceAll(
-                                Characters(''),
-                                Characters('\u{200B}'),
-                              )
-                              .toString(),
-                          style: secondaryTextStyle(
-                            context,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ),
-                  ),
-                  _buildIcon(),
-                ],
-              ),
-            ],
-          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 
 import 'package:kubenav/repositories/app_repository.dart';
@@ -71,76 +70,70 @@ class SettingsNamespaces extends StatelessWidget {
         left: Constants.spacingMiddle,
         right: Constants.spacingMiddle,
       ),
-      child: Slidable(
-        key: Key(namespace),
-        endActionPane: ActionPane(
-          motion: const DrawerMotion(),
-          extentRatio: 0.2,
+      child: AppListItem(
+        onTap: () {
+          showActions(
+            context,
+            SettingsDeleteNamespace(
+              namespace: namespace,
+            ),
+          );
+        },
+        onLongPress: () {
+          HapticFeedback.vibrate();
+
+          showActions(
+            context,
+            SettingsDeleteNamespace(
+              namespace: namespace,
+            ),
+          );
+        },
+        slidableActions: [
+          AppListItemSlidableAction(
+            icon: Icons.delete,
+            label: 'Delete',
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+            onTap: (BuildContext context) {
+              appRepository.deleteNamespace(namespace);
+              showSnackbar(
+                context,
+                'Namespace Deleted',
+                'The Namespace $namespace was deleted',
+              );
+            },
+          ),
+        ],
+        child: Row(
           children: [
-            SlidableAction(
-              onPressed: (BuildContext context) {
-                appRepository.deleteNamespace(namespace);
-                showSnackbar(
-                  context,
-                  'Namespace Deleted',
-                  'The Namespace $namespace was deleted',
-                );
-              },
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
-              icon: Icons.delete,
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    namespace,
+                    style: primaryTextStyle(
+                      context,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            ReorderableDragStartListener(
+              index: index,
+              child: Icon(
+                Icons.drag_handle,
+                color: Theme.of(context)
+                    .extension<CustomColors>()!
+                    .textPrimary
+                    .withOpacity(Constants.opacityIcon),
+              ),
             ),
           ],
-        ),
-        child: AppListItem(
-          onTap: () {
-            showActions(
-              context,
-              SettingsDeleteNamespace(
-                namespace: namespace,
-              ),
-            );
-          },
-          onLongPress: () {
-            HapticFeedback.vibrate();
-
-            showActions(
-              context,
-              SettingsDeleteNamespace(
-                namespace: namespace,
-              ),
-            );
-          },
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      namespace,
-                      style: primaryTextStyle(
-                        context,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-              ReorderableDragStartListener(
-                index: index,
-                child: Icon(
-                  Icons.drag_handle,
-                  color: Theme.of(context)
-                      .extension<CustomColors>()!
-                      .textPrimary
-                      .withOpacity(Constants.opacityIcon),
-                ),
-              ),
-            ],
-          ),
         ),
       ),
     );

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 
@@ -37,122 +36,117 @@ class SettingsProviders extends StatelessWidget {
       listen: false,
     );
 
-    return Slidable(
-      key: Key(provider.name ?? ''),
-      endActionPane: ActionPane(
-        motion: const DrawerMotion(),
-        extentRatio: 0.4,
-        children: [
-          SlidableAction(
-            onPressed: (BuildContext context) {
-              showModal(context, buildProviderModal(provider));
-            },
-            backgroundColor: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            icon: Icons.edit,
-          ),
-          SlidableAction(
-            onPressed: (BuildContext context) async {
-              try {
-                await clustersRepository.deleteProvider(provider.id!);
-                if (context.mounted) {
-                  showSnackbar(
-                    context,
-                    'Provider Deleted',
-                    'The provider ${provider.name} was deleted',
-                  );
-                }
-              } catch (err) {
-                if (context.mounted) {
-                  showSnackbar(
-                    context,
-                    'Failed to Delete Provider',
-                    err.toString(),
-                  );
-                }
+    return AppListItem(
+      onTap: () {
+        showActions(
+          context,
+          SettingsProviderActions(provider: provider),
+        );
+      },
+      onLongPress: () {
+        HapticFeedback.vibrate();
+
+        showActions(
+          context,
+          SettingsProviderActions(provider: provider),
+        );
+      },
+      slidableActions: [
+        AppListItemSlidableAction(
+          icon: Icons.edit,
+          label: 'Edit',
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          foregroundColor: Theme.of(context).colorScheme.onPrimary,
+          onTap: (BuildContext context) {
+            showModal(context, buildProviderModal(provider));
+          },
+        ),
+        AppListItemSlidableAction(
+          icon: Icons.delete,
+          label: 'Delete',
+          backgroundColor: Theme.of(context).colorScheme.error,
+          foregroundColor: Theme.of(context).colorScheme.onError,
+          onTap: (BuildContext context) async {
+            try {
+              await clustersRepository.deleteProvider(provider.id!);
+              if (context.mounted) {
+                showSnackbar(
+                  context,
+                  'Provider Deleted',
+                  'The provider ${provider.name} was deleted',
+                );
               }
-            },
-            backgroundColor: Theme.of(context).colorScheme.error,
-            foregroundColor: Theme.of(context).colorScheme.onError,
-            icon: Icons.delete,
+            } catch (err) {
+              if (context.mounted) {
+                showSnackbar(
+                  context,
+                  'Failed to Delete Provider',
+                  err.toString(),
+                );
+              }
+            }
+          },
+        ),
+      ],
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primary,
+              borderRadius: const BorderRadius.all(
+                Radius.circular(Constants.sizeBorderRadius),
+              ),
+            ),
+            height: 54,
+            width: 54,
+            padding: const EdgeInsets.all(
+              Constants.spacingIcon54x54,
+            ),
+            child: SvgPicture.asset(provider.type!.icon()),
+          ),
+          const SizedBox(width: Constants.spacingSmall),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  provider.name!,
+                  style: primaryTextStyle(
+                    context,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  provider.type!.title(),
+                  style: secondaryTextStyle(
+                    context,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  provider.type!.subtitle(),
+                  style: secondaryTextStyle(
+                    context,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: Constants.spacingSmall),
+          Icon(
+            Icons.arrow_forward_ios,
+            color: Theme.of(context)
+                .extension<CustomColors>()!
+                .textSecondary
+                .withOpacity(Constants.opacityIcon),
+            size: 24,
           ),
         ],
-      ),
-      child: AppListItem(
-        onTap: () {
-          showActions(
-            context,
-            SettingsProviderActions(provider: provider),
-          );
-        },
-        onLongPress: () {
-          HapticFeedback.vibrate();
-
-          showActions(
-            context,
-            SettingsProviderActions(provider: provider),
-          );
-        },
-        child: Row(
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(Constants.sizeBorderRadius),
-                ),
-              ),
-              height: 54,
-              width: 54,
-              padding: const EdgeInsets.all(
-                Constants.spacingIcon54x54,
-              ),
-              child: SvgPicture.asset(provider.type!.icon()),
-            ),
-            const SizedBox(width: Constants.spacingSmall),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    provider.name!,
-                    style: primaryTextStyle(
-                      context,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  Text(
-                    provider.type!.title(),
-                    style: secondaryTextStyle(
-                      context,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  Text(
-                    provider.type!.subtitle(),
-                    style: secondaryTextStyle(
-                      context,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: Constants.spacingSmall),
-            Icon(
-              Icons.arrow_forward_ios,
-              color: Theme.of(context)
-                  .extension<CustomColors>()!
-                  .textSecondary
-                  .withOpacity(Constants.opacityIcon),
-              size: 24,
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/widgets/shared/app_list_item.dart
+++ b/lib/widgets/shared/app_list_item.dart
@@ -1,7 +1,25 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_slidable/flutter_slidable.dart';
+
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/themes.dart';
+
+class AppListItemSlidableAction {
+  final IconData icon;
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final void Function(BuildContext context)? onTap;
+
+  const AppListItemSlidableAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    required this.backgroundColor,
+    required this.foregroundColor,
+  });
+}
 
 /// The [AppListItem] widget can be used to render an item in a list.
 class AppListItem extends StatelessWidget {
@@ -9,15 +27,16 @@ class AppListItem extends StatelessWidget {
     super.key,
     this.onTap,
     this.onLongPress,
+    this.slidableActions,
     required this.child,
   });
 
   final void Function()? onTap;
   final void Function()? onLongPress;
+  final List<AppListItemSlidableAction>? slidableActions;
   final Widget child;
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildItem(BuildContext context) {
     return InkWell(
       onTap: onTap,
       onLongPress: onLongPress,
@@ -40,5 +59,58 @@ class AppListItem extends StatelessWidget {
         child: child,
       ),
     );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (slidableActions != null) {
+      return Stack(
+        clipBehavior: Clip.antiAlias,
+        children: [
+          Positioned.fill(
+            child: Builder(
+              builder: (context) => Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: Constants.sizeBorderRadius,
+                ),
+                child: Container(
+                  color: slidableActions![0].backgroundColor,
+                ),
+              ),
+            ),
+          ),
+          Slidable(
+            key: UniqueKey(),
+            endActionPane: ActionPane(
+              motion: const DrawerMotion(),
+              extentRatio: 0.3 * slidableActions!.length,
+              children: List.generate(
+                slidableActions!.length,
+                (int index) {
+                  return SlidableAction(
+                    onPressed: slidableActions![index].onTap,
+                    backgroundColor: slidableActions![index].backgroundColor,
+                    foregroundColor: slidableActions![index].foregroundColor,
+                    icon: slidableActions![index].icon,
+                    label: slidableActions![index].label,
+                    borderRadius: slidableActions!.length - 1 == index
+                        ? const BorderRadius.only(
+                            topRight:
+                                Radius.circular(Constants.sizeBorderRadius),
+                            bottomRight:
+                                Radius.circular(Constants.sizeBorderRadius),
+                          )
+                        : BorderRadius.zero,
+                  );
+                },
+              ),
+            ),
+            child: _buildItem(context),
+          ),
+        ],
+      );
+    }
+
+    return _buildItem(context);
   }
 }


### PR DESCRIPTION
The `Slidable` widget has rounded corners now and the background of the item which is swiped is now in the same color as the first action.

We also moved the `Slidable` wiedget to the `AppListItem` widget, which now has a new property `slidableActions` which can be used to define the actions, which are triggered via the swipe gesture.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
