### PR TITLE
Change Icons for Cordon and Uncordon Actions

### DIFF
--- a/lib/widgets/resources/actions/node_cordon.dart
+++ b/lib/widgets/resources/actions/node_cordon.dart
@@ -97,7 +97,7 @@ class _NodeCordonState extends State<NodeCordon> {
     return AppBottomSheetWidget(
       title: 'Cordon',
       subtitle: widget.name,
-      icon: Icons.stop,
+      icon: Icons.update_disabled,
       closePressed: () {
         Navigator.pop(context);
       },

--- a/lib/widgets/resources/actions/node_uncordon.dart
+++ b/lib/widgets/resources/actions/node_uncordon.dart
@@ -97,7 +97,7 @@ class _NodeUncordonState extends State<NodeUncordon> {
     return AppBottomSheetWidget(
       title: 'Uncordon',
       subtitle: widget.name,
-      icon: Icons.play_arrow,
+      icon: Icons.update,
       closePressed: () {
         Navigator.pop(context);
       },

--- a/lib/widgets/resources/resources_details.dart
+++ b/lib/widgets/resources/resources_details.dart
@@ -406,7 +406,7 @@ List<AppResourceActionsModel> resourceDetailsActions(
     actions.add(
       AppResourceActionsModel(
         title: 'Cordon',
-        icon: Icons.stop,
+        icon: Icons.update_disabled,
         onTap: () {
           showModal(
             context,
@@ -422,7 +422,7 @@ List<AppResourceActionsModel> resourceDetailsActions(
     actions.add(
       AppResourceActionsModel(
         title: 'Uncordon',
-        icon: Icons.play_arrow,
+        icon: Icons.update,
         onTap: () {
           showModal(
             context,


### PR DESCRIPTION
This commit changes the icons for the cordon and uncordon actions, which are available for a Kubernetes node.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
