### PR TITLE
Add Pod Eviction Action

### DIFF
--- a/lib/widgets/resources/actions/evict_pod.dart
+++ b/lib/widgets/resources/actions/evict_pod.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [EvictPod] widget can be used to evict a pod from the cluster, via the
+/// eviction API.
+///
+/// See https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/
+class EvictPod extends StatefulWidget {
+  const EvictPod({
+    super.key,
+    required this.name,
+    required this.namespace,
+    required this.resource,
+  });
+
+  final String name;
+  final String namespace;
+  final Resource resource;
+
+  @override
+  State<EvictPod> createState() => _EvictPodState();
+}
+
+class _EvictPodState extends State<EvictPod> {
+  bool _isLoading = false;
+
+  Future<void> _evict() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+      final url =
+          '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}/${widget.name}/eviction';
+      final body =
+          '{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":"${widget.name}","namespace":"${widget.namespace}"}}';
+
+      await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).postRequest(url, body);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          '${widget.resource.singular} Evicted',
+          'The ${widget.resource.singular} ${widget.namespace}/${widget.name} was evicted',
+        );
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      Logger.log(
+        'EvictPod _evict',
+        'Failed to Evict ${widget.resource.singular}',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Failed to Evict ${widget.resource.singular}',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Evict',
+      subtitle: '${widget.namespace}/${widget.name}',
+      icon: Icons.delete_forever,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Evict ${widget.resource.singular}',
+      actionPressed: () {
+        _evict();
+      },
+      actionIsLoading: _isLoading,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to evict the ${widget.resource.singular} ${widget.name}?',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/resources_details.dart
+++ b/lib/widgets/resources/resources_details.dart
@@ -18,6 +18,7 @@ import 'package:kubenav/widgets/resources/actions/csr_approve.dart';
 import 'package:kubenav/widgets/resources/actions/csr_deny.dart';
 import 'package:kubenav/widgets/resources/actions/delete_resource.dart';
 import 'package:kubenav/widgets/resources/actions/edit_resource.dart';
+import 'package:kubenav/widgets/resources/actions/evict_pod.dart';
 import 'package:kubenav/widgets/resources/actions/get_logs.dart';
 import 'package:kubenav/widgets/resources/actions/get_logs_pods.dart';
 import 'package:kubenav/widgets/resources/actions/get_terminal.dart';
@@ -112,6 +113,26 @@ List<AppResourceActionsModel> resourceDetailsActions(
       },
     ),
   ];
+
+  if (resource.resource == resourcePod.resource &&
+      resource.path == resourcePod.path) {
+    actions.add(
+      AppResourceActionsModel(
+        title: 'Evict',
+        icon: Icons.delete_forever,
+        onTap: () {
+          showModal(
+            context,
+            EvictPod(
+              name: name,
+              namespace: namespace ?? 'default',
+              resource: resource,
+            ),
+          );
+        },
+      ),
+    );
+  }
 
   if (refresh != null) {
     actions.add(

--- a/lib/widgets/shared/app_resource_actions.dart
+++ b/lib/widgets/shared/app_resource_actions.dart
@@ -55,7 +55,9 @@ class AppResourceActions extends StatelessWidget {
             ? 90
             : actions.length <= 6
                 ? 180
-                : 270,
+                : actions.length <= 9
+                    ? 270
+                    : 360,
         width: MediaQuery.of(context).size.width,
         margin: const EdgeInsets.only(
           bottom: Constants.spacingExtraLarge,


### PR DESCRIPTION
It is now possible to evict Pods via the Kubernetes eviction API within the app. For this the Pod details view contains a new `Evict` action, which can be used to evict a Pod.

This was added as alternative to the delete action, because the eviction API also respects a possible defined PDB, which might be useful in some sitiuations.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
