### PR TITLE
Fix `SnackBar` for Long Error Messages

### DIFF
--- a/lib/utils/showmodal.dart
+++ b/lib/utils/showmodal.dart
@@ -61,12 +61,15 @@ void showSnackbar(BuildContext context, String title, String message) {
             style: TextStyle(
               color: Theme.of(context).extension<CustomColors>()!.onMessage,
             ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
           Text(
             message,
             style: TextStyle(
               color: Theme.of(context).extension<CustomColors>()!.onMessage,
             ),
+            maxLines: 5,
           ),
         ],
       ),


### PR DESCRIPTION
The `Snackbar` widget which is used to show error messages, can fill the whole screen when the error message is very long. This makes the app unusable and a user might have to restart the app.

To fix this problem we are now limiting the error messages to 5 lines.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
