### PR TITLE
Fix Creation of Jobs from CronJobs

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -97,3 +97,29 @@ Future<void> hapticFeedback() async {
     await HapticFeedback.vibrate();
   }
 }
+
+/// [removeNull] removes all null values from the given [params] map or list.
+dynamic removeNull(dynamic params) {
+  if (params is Map) {
+    var map = {};
+    params.forEach((key, val) {
+      var value = removeNull(val);
+      if (value != null) {
+        map[key] = value;
+      }
+    });
+    if (map.isNotEmpty) return map;
+  } else if (params is List) {
+    var list = [];
+    for (var val in params) {
+      var value = removeNull(val);
+      if (value != null) {
+        list.add(value);
+      }
+    }
+    if (list.isNotEmpty) return list;
+  } else if (params != null) {
+    return params;
+  }
+  return null;
+}

--- a/lib/widgets/resources/actions/create_job.dart
+++ b/lib/widgets/resources/actions/create_job.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -12,10 +13,15 @@ import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/services/kubernetes_service.dart';
 import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/logger.dart';
 import 'package:kubenav/utils/showmodal.dart';
 import 'package:kubenav/widgets/resources/resources/resources_jobs.dart';
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+String _createBody(IoK8sApiBatchV1Job job) {
+  return json.encode(removeNull(resourceJob.toJson(job)));
+}
 
 /// The [CreateJob] widget can be used to create a Job for a CronJob. The
 /// provided [cronJob] is the CronJob for which we want to create a Job and is
@@ -37,94 +43,124 @@ class CreateJob extends StatefulWidget {
 }
 
 class _CreateJobState extends State<CreateJob> {
+  final _createJobFormKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
   bool _isLoading = false;
+
+  /// [_validator] is used to validate the required field [_nameController].
+  String? _validator(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'This field is required';
+    }
+
+    return null;
+  }
 
   /// [_createJob] creates a Job for the provided CronJob. The Job is created
   /// with the same spec as the CronJob. The user gets a snackbar message if the
   /// creation was successful or failed.
   Future<void> _createJob() async {
-    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
-      context,
-      listen: false,
-    );
-    AppRepository appRepository = Provider.of<AppRepository>(
-      context,
-      listen: false,
-    );
-
-    try {
-      setState(() {
-        _isLoading = true;
-      });
-
-      final jobName = '${widget.name}-manual';
-      final job = IoK8sApiBatchV1Job(
-        kind: 'Job',
-        apiVersion: 'batch/v1',
-        metadata: IoK8sApimachineryPkgApisMetaV1ObjectMeta(
-          name: jobName,
-          namespace: widget.namespace,
-          labels: {
-            'job-name': jobName,
-          },
-          annotations: {
-            'cronjob.kubernetes.io/instantiate': 'manual',
-          },
-          ownerReferences: [
-            IoK8sApimachineryPkgApisMetaV1OwnerReference(
-              apiVersion: 'batch/v1',
-              blockOwnerDeletion: true,
-              controller: true,
-              kind: 'CronJob',
-              name: widget.name,
-              uid: widget.cronJob.metadata?.uid ?? '',
-            ),
-          ],
-        ),
-        spec: widget.cronJob.spec?.jobTemplate.spec,
+    if (_createJobFormKey.currentState != null &&
+        _createJobFormKey.currentState!.validate()) {
+      ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+        context,
+        listen: false,
       );
-      final String body = jsonEncode(job.toJson());
-
-      final cluster = await clustersRepository.getClusterWithCredentials(
-        clustersRepository.activeClusterId,
+      AppRepository appRepository = Provider.of<AppRepository>(
+        context,
+        listen: false,
       );
-      final url =
-          '${resourceJob.path}/namespaces/${widget.namespace}/${resourceJob.resource}';
 
-      await KubernetesService(
-        cluster: cluster!,
-        proxy: appRepository.settings.proxy,
-        timeout: appRepository.settings.timeout,
-      ).postRequest(url, body);
+      try {
+        setState(() {
+          _isLoading = true;
+        });
 
-      setState(() {
-        _isLoading = false;
-      });
-      if (mounted) {
-        showSnackbar(
-          context,
-          'Job Created',
-          'The Job $jobName for the CronJob ${widget.namespace}/${widget.name} was created',
+        final Map<String, String> annotations = {
+          'cronjob.kubernetes.io/instantiate': 'manual',
+        };
+        if (widget.cronJob.spec?.jobTemplate.metadata?.annotations != null) {
+          annotations.addAll(
+            widget.cronJob.spec!.jobTemplate.metadata!.annotations,
+          );
+        }
+
+        final job = IoK8sApiBatchV1Job(
+          kind: 'Job',
+          apiVersion: 'batch/v1',
+          metadata: IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name: _nameController.text,
+            namespace: widget.namespace,
+            labels: widget.cronJob.spec?.jobTemplate.metadata?.labels ?? {},
+            annotations: annotations,
+            ownerReferences: [
+              IoK8sApimachineryPkgApisMetaV1OwnerReference(
+                apiVersion: 'batch/v1',
+                blockOwnerDeletion: true,
+                controller: true,
+                kind: 'CronJob',
+                name: widget.name,
+                uid: widget.cronJob.metadata?.uid ?? '',
+              ),
+            ],
+          ),
+          spec: widget.cronJob.spec?.jobTemplate.spec,
         );
-        Navigator.pop(context);
-      }
-    } catch (err) {
-      Logger.log(
-        'CreateJob _createJob',
-        'Failed to Create Job',
-        err,
-      );
-      setState(() {
-        _isLoading = false;
-      });
-      if (mounted) {
-        showSnackbar(
-          context,
+        final String body = await compute(_createBody, job);
+
+        final cluster = await clustersRepository.getClusterWithCredentials(
+          clustersRepository.activeClusterId,
+        );
+        final url =
+            '${resourceJob.path}/namespaces/${widget.namespace}/${resourceJob.resource}';
+
+        await KubernetesService(
+          cluster: cluster!,
+          proxy: appRepository.settings.proxy,
+          timeout: appRepository.settings.timeout,
+        ).postRequest(url, body);
+
+        setState(() {
+          _isLoading = false;
+        });
+        if (mounted) {
+          showSnackbar(
+            context,
+            'Job Created',
+            'The Job ${_nameController.text} for the CronJob ${widget.namespace}/${widget.name} was created',
+          );
+          Navigator.pop(context);
+        }
+      } catch (err) {
+        Logger.log(
+          'CreateJob _createJob',
           'Failed to Create Job',
-          err.toString(),
+          err,
         );
+        setState(() {
+          _isLoading = false;
+        });
+        if (mounted) {
+          showSnackbar(
+            context,
+            'Failed to Create Job',
+            err.toString(),
+          );
+        }
       }
     }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController.text = '${widget.name}-manual';
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
   }
 
   @override
@@ -141,16 +177,39 @@ class _CreateJobState extends State<CreateJob> {
         _createJob();
       },
       actionIsLoading: _isLoading,
-      child: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.only(
-            top: Constants.spacingMiddle,
-            bottom: Constants.spacingMiddle,
-            left: Constants.spacingMiddle,
-            right: Constants.spacingMiddle,
-          ),
-          child: Text(
-            'Do you really want to create a Job for the CronJob ${widget.namespace}/${widget.name}?',
+      child: Form(
+        key: _createJobFormKey,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
+            ),
+            child: Column(
+              children: [
+                Text(
+                  'Do you really want to create a Job for the CronJob ${widget.namespace}/${widget.name}?',
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Job Name',
+                  ),
+                  validator: _validator,
+                  onFieldSubmitted: (String value) {
+                    _createJob();
+                  },
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
It could happen that the creation of Jobs from a CronJob failed via the corresponding action, because some fields which can not be present in the Job spec, where null or an empty list. This is now fixed by removing these values before making the Kubernetes API call.

Besides that we are now using the same logic as kubectl to create the Job, see https://github.com/kubernetes/kubectl/blob/d3ad75324522280fa8bccd7ad949b34336f5fc84/pkg/cmd/create/create_job.go#L254

For that we also added a new text field, which can be used to specify the name of the job which should be created. To make it easier for users, the field is prefilled with the CronJob name and the `-manual` suffix.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
