### PR TITLE
Helm: Add Uninstall Action

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -235,6 +235,26 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       } else {
         helmRollbackRelease(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout, namespace, name, version, options, result)
       }
+    } else if (call.method == "helmUninstallRelease") {
+      val clusterServer = call.argument<String>("clusterServer")
+      val clusterCertificateAuthorityData = call.argument<String>("clusterCertificateAuthorityData")
+      val clusterInsecureSkipTLSVerify = call.argument<Boolean>("clusterInsecureSkipTLSVerify")
+      val userClientCertificateData = call.argument<String>("userClientCertificateData")
+      val userClientKeyData = call.argument<String>("userClientKeyData")
+      val userToken = call.argument<String>("userToken")
+      val userUsername = call.argument<String>("userUsername")
+      val userPassword = call.argument<String>("userPassword")
+      val proxy = call.argument<String>("proxy")
+      val timeout = call.argument<Number>("timeout")?.toLong()
+      val namespace = call.argument<String>("namespace")
+      val name = call.argument<String>("name")
+      val options = call.argument<String>("options")
+
+      if (clusterServer == null || clusterCertificateAuthorityData == null || clusterInsecureSkipTLSVerify == null || userClientCertificateData == null || userClientKeyData == null || userToken == null || userUsername == null || userPassword == null || proxy == null || timeout == null || namespace == null || name == null || options == null) {
+        result.error("BAD_ARGUMENTS", null, null)
+      } else {
+        helmUninstallRelease(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout, namespace, name, options, result)
+      }
     } else if (call.method == "oidcGetLink") {
       val discoveryURL = call.argument<String>("discoveryURL")
       val clientID = call.argument<String>("clientID")
@@ -461,6 +481,15 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       result.success("")
     } catch (e: Exception) {
       result.error("HELM_ROLLBACK_RELEASE_FAILED", e.localizedMessage, null)
+    }
+  }
+
+  private fun helmUninstallRelease(clusterServer: String, clusterCertificateAuthorityData: String, clusterInsecureSkipTLSVerify: Boolean, userClientCertificateData: String, userClientKeyData: String, userToken: String, userUsername: String, userPassword: String, proxy: String, timeout: Long, namespace: String, name: String, options: String, result: MethodChannel.Result) {
+    try {
+      val data: String = Kubenav.helmUninstallRelease(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout, namespace, name, options)
+      result.success(data)
+    } catch (e: Exception) {
+      result.error("HELM_UNINSTALL_RELEASE_FAILED", e.localizedMessage, null)
     }
   }
 

--- a/cmd/kubenav/helm.go
+++ b/cmd/kubenav/helm.go
@@ -21,6 +21,15 @@ type RollbackOptions struct {
 	WaitForJobs   bool  `json:"waitForJobs"`
 }
 
+type UninstallOptions struct {
+	Cascade      string `json:"cascade"`
+	DryRun       bool   `json:"dryRun"`
+	KeepHistory  bool   `json:"keepHistory"`
+	DisableHooks bool   `json:"disableHooks"`
+	Timeout      int64  `json:"timeout"`
+	Wait         bool   `json:"wait"`
+}
+
 // HelmListReleases returns a list of Helm releases for the given cluster and
 // namespace. If an error occures during the process the error is returned.
 func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace string) (string, error) {
@@ -132,4 +141,30 @@ func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, 
 	rollbackTimeout := time.Duration(rollbackOptions.Timeout) * time.Second
 
 	return client.RollbackRelease(name, version, rollbackOptions.CleanupOnFail, rollbackOptions.DryRun, rollbackOptions.Force, rollbackOptions.MaxHistory, rollbackOptions.DisableHooks, rollbackOptions.Recreate, rollbackTimeout, rollbackOptions.Wait, rollbackOptions.WaitForJobs)
+}
+
+// HelmUninstallRelease uninstalls a Helm release. The Helm release is
+// identified by it's namespace and name. If an error occures during the process
+// the error is returned. If the operation was successful the uninstall message
+// is returned.
+func HelmUninstallRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, options string) (string, error) {
+	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := helm.NewClient(restConfig, namespace)
+	if err != nil {
+		return "", err
+	}
+
+	var uninstallOptions UninstallOptions
+	err = json.Unmarshal([]byte(options), &uninstallOptions)
+	if err != nil {
+		return "", err
+	}
+
+	rollbackTimeout := time.Duration(uninstallOptions.Timeout) * time.Second
+
+	return client.UninstallRelease(name, uninstallOptions.Cascade, uninstallOptions.DryRun, uninstallOptions.KeepHistory, uninstallOptions.DisableHooks, rollbackTimeout, uninstallOptions.Wait)
 }

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -224,6 +224,26 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
+    } else if call.method == "helmUninstallRelease" {
+      if let args = call.arguments as? Dictionary<String, Any>,
+        let clusterServer = args["clusterServer"] as? String,
+        let clusterCertificateAuthorityData = args["clusterCertificateAuthorityData"] as? String,
+        let clusterInsecureSkipTLSVerify = args["clusterInsecureSkipTLSVerify"] as? Bool,
+        let userClientCertificateData = args["userClientCertificateData"] as? String,
+        let userClientKeyData = args["userClientKeyData"] as? String,
+        let userToken = args["userToken"] as? String,
+        let userUsername = args["userUsername"] as? String,
+        let userPassword = args["userPassword"] as? String,
+        let proxy = args["proxy"] as? String,
+        let timeout = args["timeout"] as? Int64,
+        let namespace = args["namespace"] as? String,
+        let name = args["name"] as? String,
+        let options = args["options"] as? String
+      {
+        helmUninstallRelease(clusterServer: clusterServer, clusterCertificateAuthorityData: clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify: clusterInsecureSkipTLSVerify, userClientCertificateData: userClientCertificateData, userClientKeyData: userClientKeyData, userToken: userToken, userUsername: userUsername, userPassword: userPassword, proxy: proxy, timeout: timeout, namespace: namespace, name: name, options: options, result: result)
+      } else {
+        result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
+      }
     } else if call.method == "oidcGetLink" {
       if let args = call.arguments as? Dictionary<String, Any>,
         let discoveryURL = args["discoveryURL"] as? String,
@@ -477,6 +497,17 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
       result(FlutterError(code: "HELM_ROLLBACK_RELEASE_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
       result("")
+    }
+  }
+
+  private func helmUninstallRelease(clusterServer: String, clusterCertificateAuthorityData: String, clusterInsecureSkipTLSVerify: Bool, userClientCertificateData: String, userClientKeyData: String, userToken: String, userUsername: String, userPassword: String, proxy: String, timeout: Int64, namespace: String, name: String, options: String, result: FlutterResult) {
+    var error: NSError?
+
+    let data = KubenavHelmUninstallRelease(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout, namespace, name, options, &error)
+    if error != nil {
+      result(FlutterError(code: "HELM_UNINSTALL_RELEASE_FAILED", message: error?.localizedDescription ?? "", details: nil))
+    } else {
+      result(data)
     }
   }
 

--- a/lib/services/kubernetes_service.dart
+++ b/lib/services/kubernetes_service.dart
@@ -668,6 +668,55 @@ class KubernetesService {
     }
   }
 
+  Future<String> helmUninstallRelease(
+    String namespace,
+    String name,
+    String options,
+  ) async {
+    try {
+      Logger.log(
+        'KubernetesService helmUninstallRelease',
+        'Run helmUninstallRelease function',
+        '${cluster.name}, $namespace, $name',
+      );
+
+      final message = await platform.invokeMethod(
+        'helmUninstallRelease',
+        <String, dynamic>{
+          'clusterServer': cluster.clusterServer,
+          'clusterCertificateAuthorityData':
+              cluster.clusterCertificateAuthorityData,
+          'clusterInsecureSkipTLSVerify': cluster.clusterInsecureSkipTLSVerify,
+          'userClientCertificateData': cluster.userClientCertificateData,
+          'userClientKeyData': cluster.userClientKeyData,
+          'userToken': cluster.userToken,
+          'userUsername': cluster.userUsername,
+          'userPassword': cluster.userPassword,
+          'proxy': proxy,
+          'timeout': timeout,
+          'namespace': namespace,
+          'name': name,
+          'options': options,
+        },
+      );
+
+      Logger.log(
+        'KubernetesService helmUninstallRelease',
+        'Uninstall Succeeded',
+        message,
+      );
+
+      return message;
+    } catch (err) {
+      Logger.log(
+        'KubernetesService helmUninstallRelease',
+        'Uninstall Failed',
+        err,
+      );
+      rethrow;
+    }
+  }
+
   /// [prometheusGetData] returns the data for a PromQL query, which can be used
   /// to render a chart for the query.
   Future<List<Metric>> prometheusGetData(

--- a/lib/widgets/plugins/helm/plugin_helm_details.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details.dart
@@ -17,6 +17,7 @@ import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_manifest.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_rollback.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_template.dart';
+import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_uninstall.dart';
 import 'package:kubenav/widgets/plugins/helm/plugin_helm_details_values.dart';
 import 'package:kubenav/widgets/resources/helpers/details_item.dart';
 import 'package:kubenav/widgets/shared/app_bottom_navigation_bar_widget.dart';
@@ -84,6 +85,19 @@ List<AppResourceActionsModel> helmDetailsActions(
             namespace: release.namespace ?? '',
             name: release.name ?? '',
             version: release.version ?? 0,
+          ),
+        );
+      },
+    ),
+    AppResourceActionsModel(
+      title: 'Uninstall',
+      icon: Icons.delete,
+      onTap: () {
+        showModal(
+          context,
+          PluginHelmDetailsUninstall(
+            namespace: release.namespace ?? '',
+            name: release.name ?? '',
           ),
         );
       },

--- a/lib/widgets/plugins/helm/plugin_helm_details_uninstall.dart
+++ b/lib/widgets/plugins/helm/plugin_helm_details_uninstall.dart
@@ -1,0 +1,330 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/utils/themes.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+class UninstallOptions {
+  String cascade;
+  bool dryRun;
+  bool keepHistory;
+  bool disableHooks;
+  int timeout;
+  bool wait;
+
+  UninstallOptions({
+    required this.cascade,
+    required this.dryRun,
+    required this.keepHistory,
+    required this.disableHooks,
+    required this.timeout,
+    required this.wait,
+  });
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['cascade'] = cascade;
+    data['dryRun'] = dryRun;
+    data['keepHistory'] = keepHistory;
+    data['disableHooks'] = disableHooks;
+    data['timeout'] = timeout;
+    data['wait'] = wait;
+    return data;
+  }
+
+  @override
+  String toString() {
+    return json.encode(toJson());
+  }
+}
+
+class PluginHelmDetailsUninstall extends StatefulWidget {
+  const PluginHelmDetailsUninstall({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String namespace;
+  final String name;
+
+  @override
+  State<PluginHelmDetailsUninstall> createState() =>
+      _PluginHelmDetailsUninstallState();
+}
+
+class _PluginHelmDetailsUninstallState
+    extends State<PluginHelmDetailsUninstall> {
+  final _uninstallFormKey = GlobalKey<FormState>();
+  String _cascade = 'background';
+  bool _dryRun = false;
+  bool _keepHistory = false;
+  bool _disableHooks = false;
+  final _timeoutController = TextEditingController();
+  bool _wait = false;
+  bool _isLoading = false;
+
+  Future<void> _uninstall() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    final cluster = await clustersRepository.getClusterWithCredentials(
+      clustersRepository.activeClusterId,
+    );
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final uninstallOptions = UninstallOptions(
+        cascade: _cascade,
+        dryRun: _dryRun,
+        keepHistory: _keepHistory,
+        disableHooks: _disableHooks,
+        timeout: int.parse(_timeoutController.text),
+        wait: _wait,
+      );
+
+      final message = await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).helmUninstallRelease(
+        widget.namespace,
+        widget.name,
+        uninstallOptions.toString(),
+      );
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        Navigator.pop(context);
+        showSnackbar(
+          context,
+          'Helm Release Uninstalled',
+          message != ''
+              ? message
+              : 'Helm Release ${widget.namespace}/${widget.name} was uninstalled',
+        );
+      }
+    } catch (err) {
+      Logger.log(
+        'PluginHelmDetailsUninstall _uninstall',
+        'Uninstall Failed',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        Navigator.pop(context);
+        showSnackbar(
+          context,
+          'Uninstall Failed',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _timeoutController.text = '300';
+  }
+
+  @override
+  void dispose() {
+    _timeoutController.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Uninstall',
+      subtitle: '${widget.namespace}/${widget.name}',
+      icon: Icons.delete,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Uninstall',
+      actionPressed: () {
+        _uninstall();
+      },
+      actionIsLoading: _isLoading,
+      child: Form(
+        key: _uninstallFormKey,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: Constants.spacingMiddle,
+              bottom: Constants.spacingMiddle,
+              left: Constants.spacingMiddle,
+              right: Constants.spacingMiddle,
+            ),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Cascade'),
+                    DropdownButton(
+                      value: _cascade,
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      onChanged: (String? value) {
+                        setState(() {
+                          _cascade = value ?? '';
+                        });
+                      },
+                      items: [
+                        DropdownMenuItem(
+                          value: 'background',
+                          child: Text(
+                            'background',
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        ),
+                        DropdownMenuItem(
+                          value: 'orphan',
+                          child: Text(
+                            'orphan',
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        ),
+                        DropdownMenuItem(
+                          value: 'foreground',
+                          child: Text(
+                            'foreground',
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .extension<CustomColors>()!
+                                  .textPrimary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Dry Run'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _dryRun = !_dryRun;
+                        });
+                      },
+                      value: _dryRun,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Keep History'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _keepHistory = !_keepHistory;
+                        });
+                      },
+                      value: _keepHistory,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Disable Hooks'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _disableHooks = !_disableHooks;
+                        });
+                      },
+                      value: _disableHooks,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _timeoutController,
+                  keyboardType: TextInputType.number,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Timeout',
+                  ),
+                  onFieldSubmitted: (String value) {
+                    _uninstall();
+                  },
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Wait'),
+                    Switch(
+                      activeColor: Theme.of(context).colorScheme.primary,
+                      onChanged: (value) {
+                        setState(() {
+                          _wait = !_wait;
+                        });
+                      },
+                      value: _wait,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit adds a new action to the Helm plugin, which can be used to uninstall existing Helm releases. A user can provide the same parameters to the actions as it can be done with the `helm uninstall` command.

Closes #409 

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
