### PR TITLE
Add Actions to Suspend / Resume CronJobs

### DIFF
--- a/lib/widgets/resources/actions/create_job.dart
+++ b/lib/widgets/resources/actions/create_job.dart
@@ -168,7 +168,7 @@ class _CreateJobState extends State<CreateJob> {
     return AppBottomSheetWidget(
       title: 'Create Job',
       subtitle: '${widget.namespace}/${widget.name}',
-      icon: Icons.play_arrow,
+      icon: Icons.start,
       closePressed: () {
         Navigator.pop(context);
       },

--- a/lib/widgets/resources/actions/cronjob_resume.dart
+++ b/lib/widgets/resources/actions/cronjob_resume.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_batch_v1_cron_job.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [CronJobResume] is used to resume a Flux resource. When the user
+/// presses the action button, the resource is resumed by setting the
+/// `spec.suspend` field to `false` for the provided [item].
+class CronJobResume extends StatefulWidget {
+  const CronJobResume({
+    super.key,
+    required this.name,
+    required this.namespace,
+    required this.resource,
+    required this.cronJob,
+  });
+
+  final String name;
+  final String namespace;
+  final Resource resource;
+  final IoK8sApiBatchV1CronJob cronJob;
+
+  @override
+  State<CronJobResume> createState() => _CronJobResumeState();
+}
+
+class _CronJobResumeState extends State<CronJobResume> {
+  bool _isLoading = false;
+
+  /// [_resume] is used to resume the provided [item]. The resumption is done
+  /// by setting the `spec.suspend` field to `true`.
+  /// The user gets a snackbar message if the resumption was successful or
+  /// failed.
+  Future<void> _resume() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final String body = widget.cronJob.spec?.suspend != null
+          ? '[{ "op": "replace", "path": "/spec/suspend", "value": false }]'
+          : '[{ "op": "add", "path": "/spec/suspend", "value": false }]';
+
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+
+      final url =
+          '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}/${widget.name}';
+
+      await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).patchRequest(url, body);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          '${widget.resource.singular} Resumed',
+          'The ${widget.resource.singular} ${widget.namespace}/${widget.name} was resumed',
+        );
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      Logger.log(
+        'CronJobResume _resume',
+        'Resumption Failed',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Resumption Failed',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Resume',
+      subtitle: '${widget.namespace}/${widget.name}',
+      icon: Icons.play_arrow,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Resume',
+      actionPressed: () {
+        _resume();
+      },
+      actionIsLoading: _isLoading,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to resume the ${widget.resource.singular} ${widget.namespace}/${widget.name}?',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/actions/cronjob_suspend.dart
+++ b/lib/widgets/resources/actions/cronjob_suspend.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/kubernetes/io_k8s_api_batch_v1_cron_job.dart';
+import 'package:kubenav/repositories/app_repository.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/kubernetes_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+import 'package:kubenav/widgets/resources/resources/resources.dart';
+import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
+
+/// The [CronJobSuspend] is used to suspend a Flux resource. When the user
+/// presses the action button, the resource is suspended by setting the
+/// `spec.suspend` field to `true` for the provided [item].
+class CronJobSuspend extends StatefulWidget {
+  const CronJobSuspend({
+    super.key,
+    required this.name,
+    required this.namespace,
+    required this.resource,
+    required this.cronJob,
+  });
+
+  final String name;
+  final String namespace;
+  final Resource resource;
+  final IoK8sApiBatchV1CronJob cronJob;
+
+  @override
+  State<CronJobSuspend> createState() => _CronJobSuspendState();
+}
+
+class _CronJobSuspendState extends State<CronJobSuspend> {
+  bool _isLoading = false;
+
+  /// [_suspend] is used to suspend the provided [item]. The suspension is done
+  /// by setting the `spec.suspend` field to `true`.
+  /// The user gets a snackbar message if the suspension was successful or
+  /// failed.
+  Future<void> _suspend() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+    AppRepository appRepository = Provider.of<AppRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final String body = widget.cronJob.spec?.suspend != null
+          ? '[{ "op": "replace", "path": "/spec/suspend", "value": true }]'
+          : '[{ "op": "add", "path": "/spec/suspend", "value": true }]';
+
+      final cluster = await clustersRepository.getClusterWithCredentials(
+        clustersRepository.activeClusterId,
+      );
+
+      final url =
+          '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}/${widget.name}';
+
+      await KubernetesService(
+        cluster: cluster!,
+        proxy: appRepository.settings.proxy,
+        timeout: appRepository.settings.timeout,
+      ).patchRequest(url, body);
+
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          '${widget.resource.singular} Suspended',
+          'The ${widget.resource.singular} ${widget.namespace}/${widget.name} was suspended',
+        );
+        Navigator.pop(context);
+      }
+    } catch (err) {
+      Logger.log(
+        'CronJobSuspend _suspend',
+        'Suspension Failed',
+        err,
+      );
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Suspension Failed',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBottomSheetWidget(
+      title: 'Suspend',
+      subtitle: '${widget.namespace}/${widget.name}',
+      icon: Icons.pause,
+      closePressed: () {
+        Navigator.pop(context);
+      },
+      actionText: 'Suspend',
+      actionPressed: () {
+        _suspend();
+      },
+      actionIsLoading: _isLoading,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: Constants.spacingMiddle,
+            bottom: Constants.spacingMiddle,
+            left: Constants.spacingMiddle,
+            right: Constants.spacingMiddle,
+          ),
+          child: Text(
+            'Do you really want to suspend the ${widget.resource.singular} ${widget.namespace}/${widget.name}?',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/resources/resources_details.dart
+++ b/lib/widgets/resources/resources_details.dart
@@ -14,6 +14,8 @@ import 'package:kubenav/widgets/plugins/flux/resources/plugin_flux_resources.dar
 import 'package:kubenav/widgets/resources/actions/create_debug_container.dart';
 import 'package:kubenav/widgets/resources/actions/create_job.dart';
 import 'package:kubenav/widgets/resources/actions/create_ssh_pod.dart';
+import 'package:kubenav/widgets/resources/actions/cronjob_resume.dart';
+import 'package:kubenav/widgets/resources/actions/cronjob_suspend.dart';
 import 'package:kubenav/widgets/resources/actions/csr_approve.dart';
 import 'package:kubenav/widgets/resources/actions/csr_deny.dart';
 import 'package:kubenav/widgets/resources/actions/delete_resource.dart';
@@ -239,21 +241,53 @@ List<AppResourceActionsModel> resourceDetailsActions(
 
   if (resource.resource == resourceCronJob.resource &&
       resource.path == resourceCronJob.path) {
-    actions.add(
-      AppResourceActionsModel(
-        title: 'Create Job',
-        icon: Icons.play_arrow,
-        onTap: () {
-          showModal(
-            context,
-            CreateJob(
-              name: name,
-              namespace: namespace ?? 'default',
-              cronJob: item,
-            ),
-          );
-        },
-      ),
+    actions.addAll(
+      [
+        AppResourceActionsModel(
+          title: 'Create Job',
+          icon: Icons.start,
+          onTap: () {
+            showModal(
+              context,
+              CreateJob(
+                name: name,
+                namespace: namespace ?? 'default',
+                cronJob: item,
+              ),
+            );
+          },
+        ),
+        AppResourceActionsModel(
+          title: 'Suspend',
+          icon: Icons.pause,
+          onTap: () {
+            showModal(
+              context,
+              CronJobSuspend(
+                name: name,
+                namespace: namespace ?? 'default',
+                resource: resource,
+                cronJob: item,
+              ),
+            );
+          },
+        ),
+        AppResourceActionsModel(
+          title: 'Resume',
+          icon: Icons.play_arrow,
+          onTap: () {
+            showModal(
+              context,
+              CronJobResume(
+                name: name,
+                namespace: namespace ?? 'default',
+                resource: resource,
+                cronJob: item,
+              ),
+            );
+          },
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
It is now possible to suspend and resume CronJobs via the newly added actions. This should make it easier for users to suspend / resume CronJobs, because they do not have to edit the Yaml files anymore.

For the actions we create a JSON patch were we set the `cronJob.spec.suspend` field to `true` or `false`, depending on the selected action. This is very similar to the suspend / resume action in the Flux plugin.

We also change the icon used for the "Create Job" action, so that we can reuse the icons from the Flux suspend / resume actions.

Closes #686 

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
