### PR TITLE
Add Support for Role ARN in AWS SSO Provider

### DIFF
--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -128,6 +128,7 @@ class ClusterProviderAWSSSO {
   String? startURL;
   String? accountID;
   String? roleName;
+  String? roleArn;
   String? ssoRegion;
   String? region;
   AWSSSOConfig? ssoConfig;
@@ -137,6 +138,7 @@ class ClusterProviderAWSSSO {
     required this.startURL,
     required this.accountID,
     required this.roleName,
+    required this.roleArn,
     required this.ssoRegion,
     required this.region,
     required this.ssoConfig,
@@ -148,6 +150,7 @@ class ClusterProviderAWSSSO {
       startURL: data.containsKey('startURL') ? data['startURL'] : null,
       accountID: data.containsKey('accountID') ? data['accountID'] : null,
       roleName: data.containsKey('roleName') ? data['roleName'] : null,
+      roleArn: data.containsKey('roleArn') ? data['roleArn'] : null,
       ssoRegion: data.containsKey('ssoRegion') ? data['ssoRegion'] : null,
       region: data.containsKey('region') ? data['region'] : null,
       ssoConfig: data.containsKey('ssoConfig') && data['ssoConfig'] != null
@@ -165,6 +168,7 @@ class ClusterProviderAWSSSO {
       'startURL': startURL,
       'accountID': accountID,
       'roleName': roleName,
+      'roleArn': roleArn,
       'ssoRegion': ssoRegion,
       'region': region,
       'ssoConfig': ssoConfig?.toJson(),

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -57,7 +57,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
           widget.provider.awssso?.ssoCredentials?.secretAccessKey ?? '',
           widget.provider.awssso?.region ?? '',
           widget.provider.awssso?.ssoCredentials?.sessionToken ?? '',
-          '',
+          widget.provider.awssso?.roleArn ?? '',
         );
 
         Logger.log(

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_config.dart
@@ -24,6 +24,7 @@ class _SettingsAWSSSOMultipleProvidersState
     extends State<SettingsAWSSSOMultipleProviders> {
   final _providerConfigFormKey = GlobalKey<FormState>();
   final _startURLController = TextEditingController();
+  final _roleArnController = TextEditingController();
   String _ssoRegion = 'us-east-1';
   AWSSSOConfig? _awsSSOConfig;
   bool _isLoading = false;
@@ -122,6 +123,7 @@ class _SettingsAWSSSOMultipleProvidersState
             context,
             SettingsAWSSSOMultipleProvidersSelect(
               startURL: _startURLController.text,
+              roleArn: _roleArnController.text,
               ssoRegion: _ssoRegion,
               ssoConfig: _awsSSOConfig!,
               accounts: accounts,
@@ -146,6 +148,7 @@ class _SettingsAWSSSOMultipleProvidersState
   @override
   void dispose() {
     _startURLController.dispose();
+    _roleArnController.dispose();
     super.dispose();
   }
 
@@ -186,6 +189,18 @@ class _SettingsAWSSSOMultipleProvidersState
                     labelText: 'Start URL',
                   ),
                   validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _roleArnController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Role ARN (optional)',
+                  ),
                 ),
                 const SizedBox(height: Constants.spacingMiddle),
                 Row(

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
@@ -39,12 +39,14 @@ class SettingsAWSSSOMultipleProvidersSelect extends StatefulWidget {
   const SettingsAWSSSOMultipleProvidersSelect({
     super.key,
     required this.startURL,
+    required this.roleArn,
     required this.ssoRegion,
     required this.ssoConfig,
     required this.accounts,
   });
 
   final String startURL;
+  final String roleArn;
   final String ssoRegion;
   final AWSSSOConfig ssoConfig;
   final List<AWSSSOAccount> accounts;
@@ -94,6 +96,7 @@ class _SettingsAWSSSOMultipleProvidersSelectState
             startURL: widget.startURL,
             accountID: account.accountId,
             roleName: account.role,
+            roleArn: widget.roleArn,
             ssoRegion: widget.ssoRegion,
             // NOTE: Currently we are using the provided SSO region also for the
             // cluster region. This may not be perfect but regarding

--- a/lib/widgets/settings/providers/settings_awssso_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_awssso_provider_config.dart
@@ -32,6 +32,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
   final _startURLController = TextEditingController();
   final _accountIDController = TextEditingController();
   final _roleNameController = TextEditingController();
+  final _roleArnController = TextEditingController();
   String _ssoRegion = 'us-east-1';
   String _region = 'us-east-1';
   AWSSSOConfig? _awsSSOConfig;
@@ -174,6 +175,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
               startURL: _startURLController.text,
               accountID: _accountIDController.text,
               roleName: _roleNameController.text,
+              roleArn: _roleArnController.text,
               ssoRegion: _ssoRegion,
               region: _region,
               ssoConfig: _awsSSOConfig!,
@@ -236,6 +238,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
       _startURLController.text = widget.provider!.awssso!.startURL ?? '';
       _accountIDController.text = widget.provider!.awssso!.accountID ?? '';
       _roleNameController.text = widget.provider!.awssso!.roleName ?? '';
+      _roleArnController.text = widget.provider!.awssso!.roleArn ?? '';
       _ssoRegion = widget.provider!.awssso!.ssoRegion ?? '';
       _region = widget.provider!.awssso!.region ?? '';
     }
@@ -247,6 +250,7 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
     _startURLController.dispose();
     _accountIDController.dispose();
     _roleNameController.dispose();
+    _roleArnController.dispose();
     super.dispose();
   }
 
@@ -326,6 +330,18 @@ class _SettingsAWSSSOProviderState extends State<SettingsAWSSSOProvider> {
                     labelText: 'Role Name',
                   ),
                   validator: _validator,
+                ),
+                const SizedBox(height: Constants.spacingMiddle),
+                TextFormField(
+                  controller: _roleArnController,
+                  keyboardType: TextInputType.text,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  maxLines: 1,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Role ARN (optional)',
+                  ),
                 ),
                 const SizedBox(height: Constants.spacingMiddle),
                 Row(


### PR DESCRIPTION
With the AWS provider is was already possible, that a user could provide a Role ARN, this commit adds the same feature for the AWS SSO provider.

The provided Role ARN will then be used to get the cluster configuration.

Closes #515

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
