### PR TITLE
Fix App Crash on Multi Auth Error

### DIFF
--- a/cmd/kubenav/kube/kube.go
+++ b/cmd/kubenav/kube/kube.go
@@ -12,6 +12,13 @@ import (
 )
 
 func NewClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (*rest.Config, *kubernetes.Clientset, error) {
+	// If a token is provided, we must ensure that the username and password are
+	// empty. Otherwise the app would crash in such cases.
+	if userToken != "" {
+		userUsername = ""
+		userPassword = ""
+	}
+
 	config, err := clientcmd.NewClientConfigFromBytes([]byte(`apiVersion: v1
 clusters:
   - cluster:


### PR DESCRIPTION
If the cluster configuration contained a token, username and password the app crashed because of the multiple authentication methods. This is now fixed by ensuring that the username and password is empty when a token is provided.

Fixes #697 

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
