### PR TITLE
Use `scale` Instead of `patch` for Scaling Resources

### DIFF
--- a/cmd/kubenav/kubernetes.go
+++ b/cmd/kubenav/kubernetes.go
@@ -44,6 +44,8 @@ func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, cl
 		responseResult = clientset.RESTClient().Patch(types.JSONPatchType).RequestURI(requestURL).Body([]byte(requestBody)).Do(ctx)
 	} else if requestMethod == http.MethodPost {
 		responseResult = clientset.RESTClient().Post().RequestURI(requestURL).Body([]byte(requestBody)).Do(ctx)
+	} else if requestMethod == http.MethodPut {
+		responseResult = clientset.RESTClient().Put().RequestURI(requestURL).Body([]byte(requestBody)).Do(ctx)
 	}
 
 	if responseResult.Error() != nil {

--- a/lib/services/kubernetes_service.dart
+++ b/lib/services/kubernetes_service.dart
@@ -204,6 +204,31 @@ class KubernetesService {
     }
   }
 
+  /// [putRequest] can be used to run a put request against a Kubernetes
+  /// cluster. Besides the [url] of the resource, which should be updated, we
+  /// also have to pass a [body] to the function. The [body] must be contain the
+  /// Kubernetes manifest which is used for the update.
+  Future<void> putRequest(String url, String body) async {
+    try {
+      await kubernetesRequest(
+        cluster,
+        proxy,
+        timeout,
+        'PUT',
+        url,
+        body,
+      );
+      return;
+    } catch (err) {
+      Logger.log(
+        'KubernetesService putRequest',
+        'Put request failed',
+        err,
+      );
+      rethrow;
+    }
+  }
+
   /// [getLogs] returns the logs for a list of pods (containers). The pod names
   /// are must be provided via the [names] argument, which should be a commans
   /// separated list of pod names.

--- a/lib/widgets/resources/actions/scale_resource.dart
+++ b/lib/widgets/resources/actions/scale_resource.dart
@@ -82,15 +82,15 @@ class _ScaleResourceState extends State<ScaleResource> {
           clustersRepository.activeClusterId,
         );
         final url =
-            '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}/${widget.name}';
+            '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}/${widget.name}/scale';
 
         await KubernetesService(
           cluster: cluster!,
           proxy: appRepository.settings.proxy,
           timeout: appRepository.settings.timeout,
-        ).patchRequest(
+        ).putRequest(
           url,
-          '[{"op": "replace", "path": "/spec/replicas", "value": ${int.parse(_replicasController.text)}}]',
+          '{"kind":"Scale","apiVersion":"autoscaling/v1","metadata":{"name":"${widget.name}","namespace":"${widget.namespace}"},"spec":{"replicas":${int.parse(_replicasController.text)}}}',
         );
 
         setState(() {


### PR DESCRIPTION
This commit changes the behaviour of the scale action, which can be used to scale a Deployment, StatefulSet or ReplicaSet. Until now we made a `patch` request to the Kubernetes API to adjust the number of replicas. Now we are using the `/scale` endpoint to achieve the same.

This was done, so that only scaling can be allowed in the RBAC rules for a user, see #701.

Closes #701

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
