### PR TITLE
Add State Parameter to OIDC Login URL

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -263,11 +263,12 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val scopes = call.argument<String>("scopes")
       val redirectURL = call.argument<String>("redirectURL")
       val pkceMethod = call.argument<String>("pkceMethod")
+      val state = call.argument<String>("state")
 
-      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || redirectURL == null || pkceMethod == null) {
+      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || redirectURL == null || pkceMethod == null || state == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, result)
+        oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state, result)
       }
     } else if (call.method == "oidcGetRefreshToken") {
       val discoveryURL = call.argument<String>("discoveryURL")
@@ -493,9 +494,9 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
-  private fun oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, result: MethodChannel.Result) {
+  private fun oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, state: String, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod)
+      val data: String = Kubenav.oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_GET_LINK_FAILED", e.localizedMessage, null)

--- a/cmd/kubenav/oidc.go
+++ b/cmd/kubenav/oidc.go
@@ -81,7 +81,7 @@ func oidcContext(ctx context.Context, certificateAuthority string) (context.Cont
 
 // OIDCGetLink returns the link for the configured OIDC provider. The Link can
 // then be used by the user to login.
-func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod string) (string, error) {
+func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state string) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -115,7 +115,8 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 		challenge := createS256Challenge(verifier)
 
 		oidcResponse = OIDCResponse{
-			URL: oauth2Config.AuthCodeURL("",
+			URL: oauth2Config.AuthCodeURL(
+				state,
 				oauth2.AccessTypeOffline,
 				oauth2.ApprovalForce,
 				oauth2.SetAuthURLParam("code_challenge", challenge),
@@ -125,7 +126,11 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 		}
 	} else {
 		oidcResponse = OIDCResponse{
-			URL: oauth2Config.AuthCodeURL("", oauth2.AccessTypeOffline, oauth2.ApprovalForce),
+			URL: oauth2Config.AuthCodeURL(
+				state,
+				oauth2.AccessTypeOffline,
+				oauth2.ApprovalForce,
+			),
 		}
 	}
 

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -252,9 +252,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let certificateAuthority = args["certificateAuthority"] as? String,
         let scopes = args["scopes"] as? String,
         let redirectURL = args["redirectURL"] as? String,
-        let pkceMethod = args["pkceMethod"] as? String
+        let pkceMethod = args["pkceMethod"] as? String,
+        let state = args["state"] as? String
       {
-        oidcGetLink(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, redirectURL: redirectURL, pkceMethod: pkceMethod, result: result)
+        oidcGetLink(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, redirectURL: redirectURL, pkceMethod: pkceMethod, state: state, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -511,10 +512,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, result: FlutterResult) {
+  private func oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, state: String, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, &error)
+    let data = KubenavOIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_GET_LINK_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {

--- a/landing/auth/oidc.html
+++ b/landing/auth/oidc.html
@@ -43,7 +43,19 @@
   <div class="open-app">
     <br/><br/><br/><br/><br/>
     <button onClick="copyCodeToClipboard()">Copy Code</button>
+    <br/><br/>
+    <div class="code-state-container">
+      <strong>Code:</strong> <span id="code"></span>
+      <br/>
+      <strong>State:</strong> <span id="state"></span>
+    </div>
   </div>
+
+  <script type="text/javascript">
+    const params = new URLSearchParams(window.location.search);
+    document.getElementById("code").innerText = params.get("code");
+    document.getElementById("state").innerText = params.get("state");
+  </script>
 
   <script type="text/javascript">
     function copyCodeToClipboard() {

--- a/landing/css/index.css
+++ b/landing/css/index.css
@@ -290,3 +290,8 @@ img {
   text-decoration: none;
   display: inline-block;
 }
+
+.code-state-container {
+  padding: 12px;
+  word-break: break-all;
+}

--- a/lib/services/providers/oidc_service.dart
+++ b/lib/services/providers/oidc_service.dart
@@ -136,6 +136,7 @@ class OIDCService {
     String scopes,
     String redirectURL,
     String pkceMethod,
+    String state,
   ) async {
     try {
       final String result = await platform.invokeMethod(
@@ -148,6 +149,7 @@ class OIDCService {
           'scopes': scopes,
           'redirectURL': redirectURL,
           'pkceMethod': pkceMethod,
+          'state': state,
         },
       );
 

--- a/lib/widgets/settings/providers/settings_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_oidc_provider_config.dart
@@ -39,6 +39,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   final _refreshTokenController = TextEditingController();
   final _redirectURLController = TextEditingController();
   final _codeController = TextEditingController();
+  final _stateController = TextEditingController();
   String _verifier = '';
   bool _useAccessToken = false;
   bool _isLoading = false;
@@ -67,6 +68,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         _scopesController.text,
         _redirectURLController.text,
         _pkceMethod,
+        _stateController.text,
       );
 
       if (oidcResponse.url != null) {
@@ -393,8 +395,8 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   Widget _buildPkceMethod() {
     if (_pkceMethod == '') {
       return Padding(
-        padding: const EdgeInsets.only(
-          top: Constants.spacingMiddle,
+        padding: const EdgeInsets.symmetric(
+          vertical: Constants.spacingSmall,
         ),
         child: TextFormField(
           controller: _clientSecretController,
@@ -632,6 +634,24 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         padding: const EdgeInsets.symmetric(
           vertical: Constants.spacingSmall,
         ),
+        child: TextFormField(
+          controller: _stateController,
+          keyboardType: TextInputType.text,
+          enabled: false,
+          autocorrect: false,
+          enableSuggestions: false,
+          maxLines: 1,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'State',
+          ),
+          validator: _validator,
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: Constants.spacingSmall,
+        ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -715,6 +735,8 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
     } else {
       _redirectURLController.text = Constants.oidcRedirectURI;
     }
+
+    _stateController.text = generateRandomString(6);
   }
 
   @override
@@ -728,6 +750,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
     _refreshTokenController.dispose();
     _redirectURLController.dispose();
     _codeController.dispose();
+    _stateController.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
Add the state parameter to the OIDC login url. We show a random generated string in the OIDC login url, which is shown in the provider config and on the redirect page. Normally this should be veryfied automatically, but since we do not redirect to the app a user should manually compare the state parameters from the provider configuration and redirect page.

Close #709 
<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
