### PR TITLE
Fix OIDC Provider for Google

### DIFF
--- a/cmd/kubenav/oidc.go
+++ b/cmd/kubenav/oidc.go
@@ -94,7 +94,9 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
 	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if discoveryURL != "https://accounts.google.com" {
+		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	}
 
 	oauth2Config := oauth2.Config{
 		ClientID:     clientID,
@@ -158,7 +160,9 @@ func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthor
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
 	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if discoveryURL != "https://accounts.google.com" {
+		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	}
 
 	oauth2Config := oauth2.Config{
 		ClientID:     clientID,
@@ -214,7 +218,9 @@ func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthori
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
 	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if discoveryURL != "https://accounts.google.com" {
+		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	}
 
 	oauth2Config := oauth2.Config{
 		ClientID:     clientID,
@@ -273,7 +279,9 @@ func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string)
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
 	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if discoveryURL != "https://accounts.google.com" {
+		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	}
 
 	oauth2Config := oauth2.Config{
 		ClientID: clientID,
@@ -319,7 +327,9 @@ func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority,
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
 	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if discoveryURL != "https://accounts.google.com" {
+		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	}
 
 	oauth2Config := oauth2.Config{
 		ClientID: clientID,


### PR DESCRIPTION
When a user wants to use Google as OIDC provider it wasn't working, because we automatically add the `offline_access`, which isn't supported by Google.

This is now fixed, by checking if the provided "Discovery URL" is `https://accounts.google.com`. When this is the case we do not add the `offline_access` scope.

Fixes #718

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
