### PR TITLE
Simplify Re-Authentication for OIDC Provider

### DIFF
--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -349,6 +349,13 @@ class ClustersRepository with ChangeNotifier {
         DateTime? expiryDate = Jwt.getExpiryDate(provider?.oidc?.idToken ?? '');
 
         if (expiryDate != null && expiryDate.isBefore(DateTime.now())) {
+          if (provider?.oidc?.refreshToken == null ||
+              provider?.oidc?.refreshToken == '') {
+            throw Exception(
+              'oidc_access_token_is_expired_and_no_refresh_token',
+            );
+          }
+
           final oidcResponse = await OIDCService().getAccessToken(
             provider?.oidc?.discoveryURL ?? '',
             provider?.oidc?.clientID ?? '',

--- a/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_oidc_provider_config.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:kubenav/models/cluster_provider.dart';
+import 'package:kubenav/repositories/clusters_repository.dart';
+import 'package:kubenav/services/providers/oidc_service.dart';
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/logger.dart';
+import 'package:kubenav/utils/showmodal.dart';
+
+class SettingsReauthenticateOIDC extends StatefulWidget {
+  const SettingsReauthenticateOIDC({super.key});
+
+  @override
+  State<SettingsReauthenticateOIDC> createState() =>
+      _SettingsReauthenticateOIDCState();
+}
+
+class _SettingsReauthenticateOIDCState
+    extends State<SettingsReauthenticateOIDC> {
+  late ClusterProvider? _provider;
+  final _codeController = TextEditingController();
+  final _stateController = TextEditingController();
+  String _verifier = '';
+
+  Future<void> _signIn() async {
+    try {
+      final oidcResponse = await OIDCService().getLink(
+        _provider?.oidc?.discoveryURL ?? '',
+        _provider?.oidc?.clientID ?? '',
+        _provider?.oidc?.clientSecret ?? '',
+        _provider?.oidc?.certificateAuthority ?? '',
+        _provider?.oidc?.scopes ?? '',
+        _provider?.oidc?.redirectURL ?? '',
+        _provider?.oidc?.pkceMethod ?? '',
+        _stateController.text,
+      );
+
+      if (oidcResponse.url != null) {
+        if (oidcResponse.verifier != null) {
+          setState(() {
+            _verifier = oidcResponse.verifier!;
+          });
+        }
+
+        await openUrl(oidcResponse.url!);
+      }
+    } catch (err) {
+      Logger.log(
+        'SettingsReauthenticateOIDC _signIn',
+        'Failed to Open Sign In Url',
+        err,
+      );
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Failed to Open Sign In Url',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  Future<void> _getCredentials() async {
+    ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+      context,
+      listen: false,
+    );
+
+    try {
+      final oidcResponse = await OIDCService().getRefreshToken(
+        _provider?.oidc?.discoveryURL ?? '',
+        _provider?.oidc?.clientID ?? '',
+        _provider?.oidc?.clientSecret ?? '',
+        _provider?.oidc?.certificateAuthority ?? '',
+        _provider?.oidc?.scopes ?? '',
+        _provider?.oidc?.redirectURL ?? '',
+        _provider?.oidc?.pkceMethod ?? '',
+        _codeController.text,
+        _verifier,
+        _provider?.oidc?.useAccessToken ?? false,
+      );
+
+      _provider!.oidc!.idToken = oidcResponse.idToken;
+      _provider!.oidc!.refreshToken = oidcResponse.refreshToken;
+      _provider!.oidc!.code = _codeController.text;
+      await clustersRepository.editProvider(_provider!);
+
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Provider Configuration Saved',
+          'Refresh the view to use the new credentials',
+        );
+      }
+    } catch (err) {
+      Logger.log(
+        'SettingsReauthenticateOIDC _signIn',
+        'Failed to Get Credentials',
+        err,
+      );
+      if (mounted) {
+        showSnackbar(
+          context,
+          'Failed to Get Credentials',
+          err.toString(),
+        );
+      }
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
+        context,
+        listen: false,
+      );
+
+      final cluster = clustersRepository.getCluster(
+        clustersRepository.activeClusterId,
+      );
+      if (cluster != null) {
+        _provider = clustersRepository.getProvider(cluster.clusterProviderId);
+      } else {
+        _provider = null;
+      }
+
+      _stateController.text = generateRandomString(6);
+    });
+  }
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    _stateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: Constants.spacingSmall,
+            horizontal: Constants.spacingSmall,
+          ),
+          child: TextFormField(
+            controller: _stateController,
+            keyboardType: TextInputType.text,
+            enabled: false,
+            autocorrect: false,
+            enableSuggestions: false,
+            maxLines: 1,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: 'State',
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: Constants.spacingSmall,
+            horizontal: Constants.spacingSmall,
+          ),
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              foregroundColor: Theme.of(context).colorScheme.onPrimary,
+              minimumSize: const Size.fromHeight(40),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(
+                  Constants.sizeBorderRadius,
+                ),
+              ),
+            ),
+            onPressed: _signIn,
+            child: Text(
+              'Sign In',
+              style: primaryTextStyle(
+                context,
+                color: Theme.of(context).colorScheme.onPrimary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: Constants.spacingSmall,
+            horizontal: Constants.spacingSmall,
+          ),
+          child: TextFormField(
+            controller: _codeController,
+            keyboardType: TextInputType.text,
+            autocorrect: false,
+            enableSuggestions: false,
+            maxLines: 1,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: 'Code',
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: Constants.spacingSmall,
+            horizontal: Constants.spacingSmall,
+          ),
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              foregroundColor: Theme.of(context).colorScheme.onPrimary,
+              minimumSize: const Size.fromHeight(40),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(
+                  Constants.sizeBorderRadius,
+                ),
+              ),
+            ),
+            onPressed: _codeController.text == '' ? null : _getCredentials,
+            child: Text(
+              'Get Credentials',
+              style: primaryTextStyle(
+                context,
+                color: Theme.of(context).colorScheme.onPrimary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/shared/app_error_widget.dart
+++ b/lib/widgets/shared/app_error_widget.dart
@@ -7,6 +7,7 @@ import 'package:kubenav/utils/custom_icons.dart';
 import 'package:kubenav/utils/helpers.dart';
 import 'package:kubenav/utils/themes.dart';
 import 'package:kubenav/widgets/settings/providers/reauthenticate/settings_reauthenticate_awssso_provider_config.dart';
+import 'package:kubenav/widgets/settings/providers/reauthenticate/settings_reauthenticate_oidc_provider_config.dart';
 
 /// [AppErrorWidget] is a widget which renders a full width card, to show an
 /// error which occured during an operation in the app. A user must pass in a
@@ -49,6 +50,10 @@ class AppErrorWidget extends StatelessWidget {
   Widget _buildReauthWidget(String details) {
     if (details.contains('aws_sso_access_token_is_expired')) {
       return const SettingsReauthenticateAWSSSO();
+    }
+
+    if (details.contains('oidc_access_token_is_expired_and_no_refresh_token')) {
+      return const SettingsReauthenticateOIDC();
     }
 
     return Container();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 5.2.0+107
+version: 5.2.0+108
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
This commit simplifys the re-authentication within the OIDC provider. This is required, because it looks like not all providers are supporting refresh tokens, so that once the access token is expired a user must re-authenticate.

When we detect this situation (access token expired + no refresh token) we throw a custom error message. Based on this message we then show a custom error widget, where the user can sign in again and after providing the new `code` parameter we can get a new access token.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
