### PR TITLE
Fix Typo in Settings

### DIFF
--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -380,7 +380,7 @@ class Settings extends StatelessWidget {
                       Expanded(
                         flex: 1,
                         child: Text(
-                          'Show Cluster on Start',
+                          'Show Clusters on Start',
                           style: noramlTextStyle(
                             context,
                           ),


### PR DESCRIPTION
Change label for `showClustersOnStart` setting from `Show Cluster on
Start` to `Show Clusters on Start`.

Fixes #733

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
