### PR TITLE
Fix opacity deprecation warnings

### DIFF
--- a/lib/utils/themes.dart
+++ b/lib/utils/themes.dart
@@ -699,7 +699,7 @@ final lightTheme = ThemeData(
     ),
     TerminalColors(
       cursor: catppuccin.latte.rosewater,
-      selection: catppuccin.latte.rosewater.withOpacity(0.5),
+      selection: catppuccin.latte.rosewater.withValues(alpha: 0.5),
       foreground: catppuccin.latte.text,
       background: catppuccin.latte.mantle,
       black: catppuccin.latte.surface1,
@@ -854,7 +854,7 @@ final darkTheme = ThemeData(
     ),
     TerminalColors(
       cursor: catppuccin.macchiato.rosewater,
-      selection: catppuccin.macchiato.rosewater.withOpacity(0.5),
+      selection: catppuccin.macchiato.rosewater.withValues(alpha: 0.5),
       foreground: catppuccin.macchiato.text,
       background: catppuccin.macchiato.mantle,
       black: catppuccin.macchiato.surface1,

--- a/lib/widgets/plugins/cert-manager/plugin_cert_manager.dart
+++ b/lib/widgets/plugins/cert-manager/plugin_cert_manager.dart
@@ -67,7 +67,7 @@ class PluginCertManager extends StatelessWidget {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textSecondary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 24,
             ),
           ],

--- a/lib/widgets/plugins/flux/plugin_flux.dart
+++ b/lib/widgets/plugins/flux/plugin_flux.dart
@@ -66,7 +66,7 @@ class PluginFlux extends StatelessWidget {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textSecondary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 24,
             ),
           ],

--- a/lib/widgets/plugins/plugins.dart
+++ b/lib/widgets/plugins/plugins.dart
@@ -138,7 +138,7 @@ class Plugins extends StatelessWidget {
                   color: Theme.of(context)
                       .extension<CustomColors>()!
                       .textSecondary
-                      .withOpacity(Constants.opacityIcon),
+                      .withValues(alpha: Constants.opacityIcon),
                   size: 24,
                 ),
               ],

--- a/lib/widgets/resources/bookmarks/resources_bookmarks.dart
+++ b/lib/widgets/resources/bookmarks/resources_bookmarks.dart
@@ -309,7 +309,9 @@ class _ResourcesBookmarksState extends State<ResourcesBookmarks> {
                                     color: Theme.of(context)
                                         .extension<CustomColors>()!
                                         .textSecondary
-                                        .withOpacity(Constants.opacityIcon),
+                                        .withValues(
+                                          alpha: Constants.opacityIcon,
+                                        ),
                                     size: 24,
                                   ),
                                 ),

--- a/lib/widgets/resources/resources.dart
+++ b/lib/widgets/resources/resources.dart
@@ -90,7 +90,7 @@ class Resources extends StatelessWidget {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textSecondary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 24,
             ),
           ],

--- a/lib/widgets/resources/resources/resources_clusterrolebindings.dart
+++ b/lib/widgets/resources/resources/resources_clusterrolebindings.dart
@@ -229,7 +229,7 @@ List<Widget> _buildIcon(BuildContext context, String kind) {
         color: Theme.of(context)
             .extension<CustomColors>()!
             .textSecondary
-            .withOpacity(Constants.opacityIcon),
+            .withValues(alpha: Constants.opacityIcon),
         size: 24,
       ),
     ];

--- a/lib/widgets/resources/resources/resources_configmaps.dart
+++ b/lib/widgets/resources/resources/resources_configmaps.dart
@@ -177,7 +177,7 @@ final resourceConfigMap = Resource(
                       color: Theme.of(context)
                           .extension<CustomColors>()!
                           .textSecondary
-                          .withOpacity(Constants.opacityIcon),
+                          .withValues(alpha: Constants.opacityIcon),
                       size: 24,
                     ),
                   ],

--- a/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
+++ b/lib/widgets/resources/resources/resources_customresourcedefinitions.dart
@@ -250,7 +250,7 @@ final resourceCustomResourceDefinition = Resource(
                       color: Theme.of(context)
                           .extension<CustomColors>()!
                           .textSecondary
-                          .withOpacity(Constants.opacityIcon),
+                          .withValues(alpha: Constants.opacityIcon),
                       size: 24,
                     ),
                   ],

--- a/lib/widgets/resources/resources/resources_nodes.dart
+++ b/lib/widgets/resources/resources/resources_nodes.dart
@@ -317,7 +317,7 @@ final resourceNode = Resource(
                           color: Theme.of(context)
                               .extension<CustomColors>()!
                               .textSecondary
-                              .withOpacity(Constants.opacityIcon),
+                              .withValues(alpha: Constants.opacityIcon),
                           size: 24,
                         ),
                       ],

--- a/lib/widgets/resources/resources/resources_pods.dart
+++ b/lib/widgets/resources/resources/resources_pods.dart
@@ -861,7 +861,7 @@ class DetailsContainer extends StatelessWidget {
                             color: Theme.of(context)
                                 .extension<CustomColors>()!
                                 .textSecondary
-                                .withOpacity(Constants.opacityIcon),
+                                .withValues(alpha: Constants.opacityIcon),
                             size: 24,
                           ),
                         ],
@@ -930,7 +930,7 @@ class DetailsContainer extends StatelessWidget {
                             color: Theme.of(context)
                                 .extension<CustomColors>()!
                                 .textSecondary
-                                .withOpacity(Constants.opacityIcon),
+                                .withValues(alpha: Constants.opacityIcon),
                             size: 24,
                           ),
                         ],

--- a/lib/widgets/resources/resources/resources_rolebindings.dart
+++ b/lib/widgets/resources/resources/resources_rolebindings.dart
@@ -241,7 +241,7 @@ List<Widget> _buildIcon(BuildContext context, String kind) {
         color: Theme.of(context)
             .extension<CustomColors>()!
             .textSecondary
-            .withOpacity(Constants.opacityIcon),
+            .withValues(alpha: Constants.opacityIcon),
         size: 24,
       ),
     ];

--- a/lib/widgets/resources/resources/resources_secrets.dart
+++ b/lib/widgets/resources/resources/resources_secrets.dart
@@ -230,7 +230,7 @@ List<Widget> _buildData(
                   color: Theme.of(context)
                       .extension<CustomColors>()!
                       .textSecondary
-                      .withOpacity(Constants.opacityIcon),
+                      .withValues(alpha: Constants.opacityIcon),
                   size: 24,
                 ),
               ],

--- a/lib/widgets/resources/resources/resources_serviceaccounts.dart
+++ b/lib/widgets/resources/resources/resources_serviceaccounts.dart
@@ -176,7 +176,7 @@ final resourceServiceAccount = Resource(
                       color: Theme.of(context)
                           .extension<CustomColors>()!
                           .textSecondary
-                          .withOpacity(Constants.opacityIcon),
+                          .withValues(alpha: Constants.opacityIcon),
                       size: 24,
                     ),
                   ],

--- a/lib/widgets/settings/clusters/settings_cluster_item.dart
+++ b/lib/widgets/settings/clusters/settings_cluster_item.dart
@@ -100,7 +100,7 @@ class _SettingsClusterItemState extends State<SettingsClusterItem> {
           color: Theme.of(context)
               .extension<CustomColors>()!
               .textPrimary
-              .withOpacity(Constants.opacityIcon),
+              .withValues(alpha: Constants.opacityIcon),
         ),
       );
     }

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -210,7 +210,7 @@ class Settings extends StatelessWidget {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -242,7 +242,7 @@ class Settings extends StatelessWidget {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -308,7 +308,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],
@@ -340,7 +340,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],
@@ -512,7 +512,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],
@@ -546,7 +546,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],
@@ -580,7 +580,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],
@@ -614,7 +614,7 @@ class Settings extends StatelessWidget {
                         color: Theme.of(context)
                             .extension<CustomColors>()!
                             .textPrimary
-                            .withOpacity(Constants.opacityIcon),
+                            .withValues(alpha: Constants.opacityIcon),
                         size: 16,
                       ),
                     ],

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -106,7 +106,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -140,7 +140,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -231,7 +231,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -260,7 +260,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -289,7 +289,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -351,7 +351,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],
@@ -380,7 +380,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
               color: Theme.of(context)
                   .extension<CustomColors>()!
                   .textPrimary
-                  .withOpacity(Constants.opacityIcon),
+                  .withValues(alpha: Constants.opacityIcon),
               size: 16,
             ),
           ],

--- a/lib/widgets/settings/settings_help.dart
+++ b/lib/widgets/settings/settings_help.dart
@@ -85,7 +85,7 @@ class SettingsHelp extends StatelessWidget {
                   color: Theme.of(context)
                       .extension<CustomColors>()!
                       .textPrimary
-                      .withOpacity(Constants.opacityIcon),
+                      .withValues(alpha: Constants.opacityIcon),
                   size: 16,
                 ),
               ],

--- a/lib/widgets/settings/settings_namespaces.dart
+++ b/lib/widgets/settings/settings_namespaces.dart
@@ -129,7 +129,7 @@ class SettingsNamespaces extends StatelessWidget {
                 color: Theme.of(context)
                     .extension<CustomColors>()!
                     .textPrimary
-                    .withOpacity(Constants.opacityIcon),
+                    .withValues(alpha: Constants.opacityIcon),
               ),
             ),
           ],

--- a/lib/widgets/settings/settings_providers.dart
+++ b/lib/widgets/settings/settings_providers.dart
@@ -142,7 +142,7 @@ class SettingsProviders extends StatelessWidget {
             color: Theme.of(context)
                 .extension<CustomColors>()!
                 .textSecondary
-                .withOpacity(Constants.opacityIcon),
+                .withValues(alpha: Constants.opacityIcon),
             size: 24,
           ),
         ],

--- a/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
+++ b/lib/widgets/shared/app_bottom_navigation_bar_widget.dart
@@ -33,7 +33,7 @@ class AppBottomNavigationBarWidget extends StatelessWidget {
       backgroundColor: Theme.of(context).colorScheme.primary,
       selectedItemColor: Theme.of(context).colorScheme.onPrimary,
       unselectedItemColor:
-          Theme.of(context).colorScheme.onPrimary.withOpacity(0.60),
+          Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.60),
       selectedFontSize: 14,
       unselectedFontSize: 14,
       currentIndex: appRepository.currentPageIndex,


### PR DESCRIPTION
Changes in the dart:ui Color class API are deprecating the use of `withOpacity()` and advising migration to `withValues()`

See:
https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity