### PR TITLE
Fix Warning for Unused Default Case

### DIFF
--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -464,8 +464,6 @@ extension ClusterProviderTypeExtension on ClusterProviderType {
         return 'Rancher';
       case ClusterProviderType.manual:
         return 'Manual';
-      default:
-        return 'Manual';
     }
   }
 
@@ -490,8 +488,6 @@ extension ClusterProviderTypeExtension on ClusterProviderType {
         return 'Import your Rancher Clusters';
       case ClusterProviderType.manual:
         return 'Manual Cluster Configuration';
-      default:
-        return 'Manual Cluster Configuration';
     }
   }
 
@@ -515,8 +511,6 @@ extension ClusterProviderTypeExtension on ClusterProviderType {
       case ClusterProviderType.rancher:
         return 'assets/providers/rancher.svg';
       case ClusterProviderType.manual:
-        return 'assets/providers/manual.svg';
-      default:
         return 'assets/providers/manual.svg';
     }
   }

--- a/lib/repositories/terminal_repository.dart
+++ b/lib/repositories/terminal_repository.dart
@@ -24,8 +24,6 @@ extension TerminalTypeExtension on TerminalType {
         return 'Logs Stream';
       case TerminalType.exec:
         return 'Terminal';
-      default:
-        return 'Invalid';
     }
   }
 }

--- a/lib/widgets/settings/clusters/settings_reuse_provider_config_actions.dart
+++ b/lib/widgets/settings/clusters/settings_reuse_provider_config_actions.dart
@@ -113,8 +113,6 @@ class SettingsReuseProviderActions extends StatelessWidget {
         return const SettingsRancherProvider(
           provider: null,
         );
-      default:
-        return const SettingsAddClusterManual();
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -966,5 +966,5 @@ packages:
     source: hosted
     version: "0.0.6"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
The `default` case was never used in some of the `switch` statements,
because we already checked all possible values before, which resulted in
a warning. For these cases ther `default` was removed.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
