### PR TITLE
OIDC: Add Option to Disable Default Scopes

### DIFF
--- a/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
+++ b/android/app/src/main/kotlin/io/kubenav/kubenav/KubenavPlugin.kt
@@ -261,14 +261,15 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val clientSecret = call.argument<String>("clientSecret")
       val certificateAuthority = call.argument<String>("certificateAuthority")
       val scopes = call.argument<String>("scopes")
+      val addDefaultScopes = call.argument<Boolean>("addDefaultScopes")
       val redirectURL = call.argument<String>("redirectURL")
       val pkceMethod = call.argument<String>("pkceMethod")
       val state = call.argument<String>("state")
 
-      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || redirectURL == null || pkceMethod == null || state == null) {
+      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || addDefaultScopes == null || redirectURL == null || pkceMethod == null || state == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state, result)
+        oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, state, result)
       }
     } else if (call.method == "oidcGetRefreshToken") {
       val discoveryURL = call.argument<String>("discoveryURL")
@@ -276,16 +277,17 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val clientSecret = call.argument<String>("clientSecret")
       val certificateAuthority = call.argument<String>("certificateAuthority")
       val scopes = call.argument<String>("scopes")
+      val addDefaultScopes = call.argument<Boolean>("addDefaultScopes")
       val redirectURL = call.argument<String>("redirectURL")
       val pkceMethod = call.argument<String>("pkceMethod")
       val code = call.argument<String>("code")
       val verifier = call.argument<String>("verifier")
       val useAccessToken = call.argument<Boolean>("useAccessToken")
 
-      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || redirectURL == null || pkceMethod == null || code == null || verifier == null || useAccessToken == null) {
+      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || addDefaultScopes == null || redirectURL == null || pkceMethod == null || code == null || verifier == null || useAccessToken == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, code, verifier, useAccessToken, result)
+        oidcGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, code, verifier, useAccessToken, result)
       }
     } else if (call.method == "oidcGetAccessToken") {
       val discoveryURL = call.argument<String>("discoveryURL")
@@ -293,38 +295,41 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
       val clientSecret = call.argument<String>("clientSecret")
       val certificateAuthority = call.argument<String>("certificateAuthority")
       val scopes = call.argument<String>("scopes")
+      val addDefaultScopes = call.argument<Boolean>("addDefaultScopes")
       val redirectURL = call.argument<String>("redirectURL")
       val refreshToken = call.argument<String>("refreshToken")
       val useAccessToken = call.argument<Boolean>("useAccessToken")
 
-      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || redirectURL == null || refreshToken == null || useAccessToken == null) {
+      if (discoveryURL == null || clientID == null || clientSecret == null || certificateAuthority == null || scopes == null || addDefaultScopes == null || redirectURL == null || refreshToken == null || useAccessToken == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, refreshToken, useAccessToken, result)
+        oidcGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes , redirectURL, refreshToken, useAccessToken, result)
       }
     } else if (call.method == "oidcDeviceAuth") {
       val discoveryURL = call.argument<String>("discoveryURL")
       val clientID = call.argument<String>("clientID")
       val certificateAuthority = call.argument<String>("certificateAuthority")
       val scopes = call.argument<String>("scopes")
+      val addDefaultScopes = call.argument<Boolean>("addDefaultScopes")
 
-      if (discoveryURL == null || clientID == null || certificateAuthority == null || scopes == null) {
+      if (discoveryURL == null || clientID == null || certificateAuthority == null || scopes == null || addDefaultScopes == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes, result)
+        oidcDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes, result)
       }
     } else if (call.method == "oidcDeviceAuthGetRefreshToken") {
       val discoveryURL = call.argument<String>("discoveryURL")
       val clientID = call.argument<String>("clientID")
       val certificateAuthority = call.argument<String>("certificateAuthority")
       val scopes = call.argument<String>("scopes")
+      val addDefaultScopes = call.argument<Boolean>("addDefaultScopes")
       val deviceCode = call.argument<String>("deviceCode")
       val useAccessToken = call.argument<Boolean>("useAccessToken")
 
-      if (discoveryURL == null || clientID == null || certificateAuthority == null || scopes == null || deviceCode == null || useAccessToken == null) {
+      if (discoveryURL == null || clientID == null || certificateAuthority == null || scopes == null || addDefaultScopes == null || deviceCode == null || useAccessToken == null) {
         result.error("BAD_ARGUMENTS", null, null)
       } else {
-        oidcDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, deviceCode, useAccessToken, result)
+        oidcDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes, deviceCode, useAccessToken, result)
       }
     } else if (call.method == "prometheusGetData") {
       val clusterServer = call.argument<String>("clusterServer")
@@ -494,45 +499,45 @@ class KubenavPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
-  private fun oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, state: String, result: MethodChannel.Result) {
+  private fun oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Boolean, redirectURL: String, pkceMethod: String, state: String, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state)
+      val data: String = Kubenav.oidcGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, state)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_GET_LINK_FAILED", e.localizedMessage, null)
     }
   }
 
-  private fun oidcGetRefreshToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, code: String, verifier: String, useAccessToken: Boolean, result: MethodChannel.Result) {
+  private fun oidcGetRefreshToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Boolean, redirectURL: String, pkceMethod: String, code: String, verifier: String, useAccessToken: Boolean, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, code, verifier, useAccessToken)
+      val data: String = Kubenav.oidcGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, code, verifier, useAccessToken)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_GET_REFRESH_TOKEN_FAILED", e.localizedMessage, null)
     }
   }
 
-  private fun oidcGetAccessToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, refreshToken: String, useAccessToken: Boolean, result: MethodChannel.Result) {
+  private fun oidcGetAccessToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Boolean, redirectURL: String, refreshToken: String, useAccessToken: Boolean, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, refreshToken, useAccessToken)
+      val data: String = Kubenav.oidcGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, refreshToken, useAccessToken)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_GET_ACCESS_TOKEN_FAILED", e.localizedMessage, null)
     }
   }
 
-  private fun oidcDeviceAuth(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, result: MethodChannel.Result) {
+  private fun oidcDeviceAuth(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, addDefaultScopes: Boolean, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes)
+      val data: String = Kubenav.oidcDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_DEVICE_AUTH_FAILED", e.localizedMessage, null)
     }
   }
 
-  private fun oidcDeviceAuthGetRefreshToken(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, deviceCode: String, useAccessToken: Boolean, result: MethodChannel.Result) {
+  private fun oidcDeviceAuthGetRefreshToken(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, addDefaultScopes: Boolean, deviceCode: String, useAccessToken: Boolean, result: MethodChannel.Result) {
     try {
-      val data: String = Kubenav.oidcDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, deviceCode, useAccessToken)
+      val data: String = Kubenav.oidcDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes, deviceCode, useAccessToken)
       result.success(data)
     } catch (e: Exception) {
       result.error("OIDC_DEVICE_AUTH_GET_REFRESH_TOKEN_FAILED", e.localizedMessage, null)

--- a/cmd/kubenav/oidc.go
+++ b/cmd/kubenav/oidc.go
@@ -81,7 +81,7 @@ func oidcContext(ctx context.Context, certificateAuthority string) (context.Cont
 
 // OIDCGetLink returns the link for the configured OIDC provider. The Link can
 // then be used by the user to login.
-func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state string) (string, error) {
+func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, state string) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -93,12 +93,14 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 	}
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
-	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	if discoveryURL != "https://accounts.google.com" {
-		// Google doesn't support the `offline_access` scope, so that we only
-		// add it for non-Google providers.
-		// See: https://github.com/kubenav/kubenav/issues/718
-		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if addDefaultScopes {
+		parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
+		if discoveryURL != "https://accounts.google.com" {
+			// Google doesn't support the `offline_access` scope, so that we
+			// only add it for non-Google providers.
+			// See: https://github.com/kubenav/kubenav/issues/718
+			parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+		}
 	}
 
 	oauth2Config := oauth2.Config{
@@ -150,7 +152,7 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 // OIDCGetRefreshToken returns a refresh token for the configured OIDC provider.
 // The refresh token can be used to get a new access token via the
 // OIDCGetAccessToken function.
-func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, code, verifier string, useAccessToken bool) (string, error) {
+func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, code, verifier string, useAccessToken bool) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -162,9 +164,11 @@ func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthor
 	}
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
-	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	if discoveryURL != "https://accounts.google.com" {
-		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if addDefaultScopes {
+		parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
+		if discoveryURL != "https://accounts.google.com" {
+			parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+		}
 	}
 
 	oauth2Config := oauth2.Config{
@@ -208,7 +212,7 @@ func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthor
 }
 
 // OIDCGetAccessToken is used to retrieve an access token from a refresh token.
-func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, refreshToken string, useAccessToken bool) (string, error) {
+func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, refreshToken string, useAccessToken bool) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -220,9 +224,11 @@ func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthori
 	}
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
-	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	if discoveryURL != "https://accounts.google.com" {
-		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if addDefaultScopes {
+		parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
+		if discoveryURL != "https://accounts.google.com" {
+			parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+		}
 	}
 
 	oauth2Config := oauth2.Config{
@@ -261,7 +267,7 @@ func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthori
 	return string(oidcResponseBytes), nil
 }
 
-func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string) (string, error) {
+func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -281,9 +287,11 @@ func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string)
 	}
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
-	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	if discoveryURL != "https://accounts.google.com" {
-		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if addDefaultScopes {
+		parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
+		if discoveryURL != "https://accounts.google.com" {
+			parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+		}
 	}
 
 	oauth2Config := oauth2.Config{
@@ -309,7 +317,7 @@ func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string)
 	return string(deviceAuthData), nil
 }
 
-func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, deviceCode string, useAccessToken bool) (string, error) {
+func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool, deviceCode string, useAccessToken bool) (string, error) {
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -329,9 +337,11 @@ func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority,
 	}
 
 	parsedScopes := strings.Split(strings.ReplaceAll(scopes, " ", ""), ",")
-	parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
-	if discoveryURL != "https://accounts.google.com" {
-		parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+	if addDefaultScopes {
+		parsedScopes = append(parsedScopes, oidc.ScopeOpenID)
+		if discoveryURL != "https://accounts.google.com" {
+			parsedScopes = append(parsedScopes, oidc.ScopeOfflineAccess)
+		}
 	}
 
 	opts := []oauth2.AuthCodeOption{}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -66,7 +66,7 @@ SPEC CHECKSUMS:
   ASN1Swift: bbd56c299b2084ba71bd7d7769c6202451598948
   file_picker: fb04e739ae6239a76ce1f571863a196a922c87d4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   in_app_purchase_storekit: e126ef1b89e4a9fdf07e28f005f82632b4609437
   local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391

--- a/ios/Runner/KubenavPlugin.swift
+++ b/ios/Runner/KubenavPlugin.swift
@@ -251,11 +251,12 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let clientSecret = args["clientSecret"] as? String,
         let certificateAuthority = args["certificateAuthority"] as? String,
         let scopes = args["scopes"] as? String,
+        let addDefaultScopes = args["addDefaultScopes"] as? Bool,
         let redirectURL = args["redirectURL"] as? String,
         let pkceMethod = args["pkceMethod"] as? String,
         let state = args["state"] as? String
       {
-        oidcGetLink(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, redirectURL: redirectURL, pkceMethod: pkceMethod, state: state, result: result)
+        oidcGetLink(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, addDefaultScopes: addDefaultScopes, redirectURL: redirectURL, pkceMethod: pkceMethod, state: state, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -266,13 +267,14 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let clientSecret = args["clientSecret"] as? String,
         let certificateAuthority = args["certificateAuthority"] as? String,
         let scopes = args["scopes"] as? String,
+        let addDefaultScopes = args["addDefaultScopes"] as? Bool,
         let redirectURL = args["redirectURL"] as? String,
         let pkceMethod = args["pkceMethod"] as? String,
         let code = args["code"] as? String,
         let verifier = args["verifier"] as? String,
         let useAccessToken = args["useAccessToken"] as? Bool
       {
-        oidcGetRefreshToken(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, redirectURL: redirectURL, pkceMethod: pkceMethod, code: code, verifier: verifier, useAccessToken: useAccessToken, result: result)
+        oidcGetRefreshToken(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, addDefaultScopes: addDefaultScopes, redirectURL: redirectURL, pkceMethod: pkceMethod, code: code, verifier: verifier, useAccessToken: useAccessToken, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -283,11 +285,12 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let clientSecret = args["clientSecret"] as? String,
         let certificateAuthority = args["certificateAuthority"] as? String,
         let scopes = args["scopes"] as? String,
+        let addDefaultScopes = args["addDefaultScopes"] as? Bool,
         let redirectURL = args["redirectURL"] as? String,
         let refreshToken = args["refreshToken"] as? String,
         let useAccessToken = args["useAccessToken"] as? Bool
       {
-        oidcGetAccessToken(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, redirectURL: redirectURL, refreshToken: refreshToken, useAccessToken: useAccessToken, result: result)
+        oidcGetAccessToken(discoveryURL: discoveryURL, clientID: clientID, clientSecret: clientSecret, certificateAuthority: certificateAuthority, scopes: scopes, addDefaultScopes: addDefaultScopes, redirectURL: redirectURL, refreshToken: refreshToken, useAccessToken: useAccessToken, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -296,9 +299,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let discoveryURL = args["discoveryURL"] as? String,
         let clientID = args["clientID"] as? String,
         let certificateAuthority = args["certificateAuthority"] as? String,
-        let scopes = args["scopes"] as? String
+        let scopes = args["scopes"] as? String,
+        let addDefaultScopes = args["addDefaultScopes"] as? Bool
       {
-        oidcDeviceAuth(discoveryURL: discoveryURL, clientID: clientID, certificateAuthority: certificateAuthority, scopes: scopes, result: result)
+        oidcDeviceAuth(discoveryURL: discoveryURL, clientID: clientID, certificateAuthority: certificateAuthority, scopes: scopes, addDefaultScopes: addDefaultScopes, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -308,10 +312,11 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
         let clientID = args["clientID"] as? String,
         let certificateAuthority = args["certificateAuthority"] as? String,
         let scopes = args["scopes"] as? String,
+        let addDefaultScopes = args["addDefaultScopes"] as? Bool,
         let deviceCode = args["deviceCode"] as? String,
         let useAccessToken = args["useAccessToken"] as? Bool
       {
-        oidcDeviceAuthGetRefreshToken(discoveryURL: discoveryURL, clientID: clientID, certificateAuthority: certificateAuthority, scopes: scopes, deviceCode: deviceCode, useAccessToken: useAccessToken, result: result)
+        oidcDeviceAuthGetRefreshToken(discoveryURL: discoveryURL, clientID: clientID, certificateAuthority: certificateAuthority, scopes: scopes, addDefaultScopes: addDefaultScopes, deviceCode: deviceCode, useAccessToken: useAccessToken, result: result)
       } else {
         result(FlutterError(code: "BAD_ARGUMENTS", message: nil, details: nil))
       }
@@ -512,10 +517,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, state: String, result: FlutterResult) {
+  private func oidcGetLink(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Bool, redirectURL: String, pkceMethod: String, state: String, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, state, &error)
+    let data = KubenavOIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, state, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_GET_LINK_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
@@ -523,10 +528,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcGetRefreshToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, pkceMethod: String, code: String, verifier: String, useAccessToken: Bool, result: FlutterResult) {
+  private func oidcGetRefreshToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Bool, redirectURL: String, pkceMethod: String, code: String, verifier: String, useAccessToken: Bool, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, pkceMethod, code, verifier, useAccessToken, &error)
+    let data = KubenavOIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, pkceMethod, code, verifier, useAccessToken, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_GET_REFRESH_TOKEN_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
@@ -534,10 +539,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcGetAccessToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, redirectURL: String, refreshToken: String, useAccessToken: Bool, result: FlutterResult) {
+  private func oidcGetAccessToken(discoveryURL: String, clientID: String, clientSecret: String, certificateAuthority: String, scopes: String, addDefaultScopes: Bool, redirectURL: String, refreshToken: String, useAccessToken: Bool, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, redirectURL, refreshToken, useAccessToken, &error)
+    let data = KubenavOIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes, addDefaultScopes, redirectURL, refreshToken, useAccessToken, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_GET_ACCESS_TOKEN_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
@@ -545,10 +550,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcDeviceAuth(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, result: FlutterResult) {
+  private func oidcDeviceAuth(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, addDefaultScopes: Bool, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes, &error)
+    let data = KubenavOIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_DEVICE_AUTH_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {
@@ -556,10 +561,10 @@ public class KubenavPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func oidcDeviceAuthGetRefreshToken(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, deviceCode: String, useAccessToken: Bool, result: FlutterResult) {
+  private func oidcDeviceAuthGetRefreshToken(discoveryURL: String, clientID: String, certificateAuthority: String, scopes: String, addDefaultScopes: Bool, deviceCode: String, useAccessToken: Bool, result: FlutterResult) {
     var error: NSError?
 
-    let data = KubenavOIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, deviceCode, useAccessToken, &error)
+    let data = KubenavOIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes, addDefaultScopes, deviceCode, useAccessToken, &error)
     if error != nil {
       result(FlutterError(code: "OIDC_DEVICE_AUTH_GET_REFRESH_TOKEN_FAILED", message: error?.localizedDescription ?? "", details: nil))
     } else {

--- a/lib/models/cluster_provider.dart
+++ b/lib/models/cluster_provider.dart
@@ -36,31 +36,38 @@ class ClusterProvider {
     return ClusterProvider(
       id: data.containsKey('id') ? data['id'] : null,
       name: data.containsKey('name') ? data['name'] : null,
-      type: data.containsKey('type')
-          ? getClusterProviderType(data['type'])
-          : null,
-      aws: data.containsKey('aws') && data['aws'] != null
-          ? ClusterProviderAWS.fromJson(data['aws'])
-          : null,
-      awssso: data.containsKey('awssso') && data['awssso'] != null
-          ? ClusterProviderAWSSSO.fromJson(data['awssso'])
-          : null,
-      azure: data.containsKey('azure') && data['azure'] != null
-          ? ClusterProviderAzure.fromJson(data['azure'])
-          : null,
+      type:
+          data.containsKey('type')
+              ? getClusterProviderType(data['type'])
+              : null,
+      aws:
+          data.containsKey('aws') && data['aws'] != null
+              ? ClusterProviderAWS.fromJson(data['aws'])
+              : null,
+      awssso:
+          data.containsKey('awssso') && data['awssso'] != null
+              ? ClusterProviderAWSSSO.fromJson(data['awssso'])
+              : null,
+      azure:
+          data.containsKey('azure') && data['azure'] != null
+              ? ClusterProviderAzure.fromJson(data['azure'])
+              : null,
       digitalocean:
           data.containsKey('digitalocean') && data['digitalocean'] != null
               ? ClusterProviderDigitalOcean.fromJson(data['digitalocean'])
               : null,
-      google: data.containsKey('google') && data['google'] != null
-          ? ClusterProviderGoogle.fromJson(data['google'])
-          : null,
-      oidc: data.containsKey('oidc') && data['oidc'] != null
-          ? ClusterProviderOIDC.fromJson(data['oidc'])
-          : null,
-      rancher: data.containsKey('rancher') && data['rancher'] != null
-          ? ClusterProviderRancher.fromJson(data['rancher'])
-          : null,
+      google:
+          data.containsKey('google') && data['google'] != null
+              ? ClusterProviderGoogle.fromJson(data['google'])
+              : null,
+      oidc:
+          data.containsKey('oidc') && data['oidc'] != null
+              ? ClusterProviderOIDC.fromJson(data['oidc'])
+              : null,
+      rancher:
+          data.containsKey('rancher') && data['rancher'] != null
+              ? ClusterProviderRancher.fromJson(data['rancher'])
+              : null,
     );
   }
 
@@ -153,9 +160,10 @@ class ClusterProviderAWSSSO {
       roleArn: data.containsKey('roleArn') ? data['roleArn'] : null,
       ssoRegion: data.containsKey('ssoRegion') ? data['ssoRegion'] : null,
       region: data.containsKey('region') ? data['region'] : null,
-      ssoConfig: data.containsKey('ssoConfig') && data['ssoConfig'] != null
-          ? AWSSSOConfig.fromJson(data['ssoConfig'])
-          : null,
+      ssoConfig:
+          data.containsKey('ssoConfig') && data['ssoConfig'] != null
+              ? AWSSSOConfig.fromJson(data['ssoConfig'])
+              : null,
       ssoCredentials:
           data.containsKey('ssoCredentials') && data['ssoCredentials'] != null
               ? AWSSSOCredentials.fromJson(data['ssoCredentials'])
@@ -226,9 +234,7 @@ class ClusterProviderAzure {
 class ClusterProviderDigitalOcean {
   String? token;
 
-  ClusterProviderDigitalOcean({
-    required this.token,
-  });
+  ClusterProviderDigitalOcean({required this.token});
 
   factory ClusterProviderDigitalOcean.fromJson(Map<String, dynamic> data) {
     return ClusterProviderDigitalOcean(
@@ -237,9 +243,7 @@ class ClusterProviderDigitalOcean {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'token': token,
-    };
+    return {'token': token};
   }
 }
 
@@ -273,14 +277,16 @@ class ClusterProviderGoogle {
           data.containsKey('clientSecret') ? data['clientSecret'] : null,
       code: data.containsKey('code') ? data['code'] : null,
       accessToken: data.containsKey('accessToken') ? data['accessToken'] : null,
-      accessTokenExpires: data.containsKey('accessTokenExpires')
-          ? data['accessTokenExpires']
-          : null,
+      accessTokenExpires:
+          data.containsKey('accessTokenExpires')
+              ? data['accessTokenExpires']
+              : null,
       refreshToken:
           data.containsKey('refreshToken') ? data['refreshToken'] : null,
-      redirectURL: data.containsKey('redirectURL')
-          ? data['redirectURL']
-          : Constants.googleRedirectURI,
+      redirectURL:
+          data.containsKey('redirectURL')
+              ? data['redirectURL']
+              : Constants.googleRedirectURI,
     );
   }
 
@@ -306,6 +312,7 @@ class ClusterProviderOIDC {
   String? clientSecret;
   String? certificateAuthority;
   String? scopes;
+  bool? addDefaultScopes;
   String? pkceMethod;
   String? verifier;
   String? code;
@@ -321,6 +328,7 @@ class ClusterProviderOIDC {
     required this.clientSecret,
     required this.certificateAuthority,
     required this.scopes,
+    required this.addDefaultScopes,
     required this.pkceMethod,
     required this.verifier,
     required this.code,
@@ -332,27 +340,34 @@ class ClusterProviderOIDC {
 
   factory ClusterProviderOIDC.fromJson(Map<String, dynamic> data) {
     return ClusterProviderOIDC(
-      flow: data.containsKey('flow')
-          ? getOIDCFlowFromString(data['flow'])
-          : OIDCFlow.standard,
+      flow:
+          data.containsKey('flow')
+              ? getOIDCFlowFromString(data['flow'])
+              : OIDCFlow.standard,
       discoveryURL:
           data.containsKey('discoveryURL') ? data['discoveryURL'] : null,
       clientID: data.containsKey('clientID') ? data['clientID'] : null,
       clientSecret:
           data.containsKey('clientSecret') ? data['clientSecret'] : null,
-      certificateAuthority: data.containsKey('certificateAuthority')
-          ? data['certificateAuthority']
-          : null,
+      certificateAuthority:
+          data.containsKey('certificateAuthority')
+              ? data['certificateAuthority']
+              : null,
       scopes: data.containsKey('scopes') ? data['scopes'] : null,
+      addDefaultScopes:
+          data.containsKey('addDefaultScopes')
+              ? data['addDefaultScopes']
+              : true,
       pkceMethod: data.containsKey('pkceMethod') ? data['pkceMethod'] : null,
       verifier: data.containsKey('verifier') ? data['verifier'] : null,
       code: data.containsKey('code') ? data['code'] : null,
       idToken: data.containsKey('idToken') ? data['idToken'] : null,
       refreshToken:
           data.containsKey('refreshToken') ? data['refreshToken'] : null,
-      redirectURL: data.containsKey('redirectURL')
-          ? data['redirectURL']
-          : Constants.oidcRedirectURI,
+      redirectURL:
+          data.containsKey('redirectURL')
+              ? data['redirectURL']
+              : Constants.oidcRedirectURI,
       useAccessToken:
           data.containsKey('useAccessToken') ? data['useAccessToken'] : false,
     );
@@ -366,6 +381,7 @@ class ClusterProviderOIDC {
       'clientSecret': clientSecret,
       'certificateAuthority': certificateAuthority,
       'scopes': scopes,
+      'addDefaultScopes': addDefaultScopes,
       'pkceMethod': pkceMethod,
       'verifier': verifier,
       'code': code,
@@ -398,9 +414,10 @@ class ClusterProviderRancher {
     return ClusterProviderRancher(
       serverAddress:
           data.containsKey('serverAddress') ? data['serverAddress'] : null,
-      allowInsecureConnections: data.containsKey('allowInsecureConnections')
-          ? data['allowInsecureConnections']
-          : false,
+      allowInsecureConnections:
+          data.containsKey('allowInsecureConnections')
+              ? data['allowInsecureConnections']
+              : false,
       username: data.containsKey('username') ? data['username'] : null,
       password: data.containsKey('password') ? data['password'] : null,
       token: data.containsKey('token') ? data['token'] : null,

--- a/lib/repositories/clusters_repository.dart
+++ b/lib/repositories/clusters_repository.dart
@@ -32,10 +32,7 @@ class ClustersRepository with ChangeNotifier {
   /// Storage package.
   Future<void> _save() async {
     try {
-      Logger.log(
-        'ClustersRepository _save',
-        'Save',
-      );
+      Logger.log('ClustersRepository _save', 'Save');
       await Storage().write(
         'kubenavClustersRepository',
         json.encode(
@@ -47,11 +44,7 @@ class ClustersRepository with ChangeNotifier {
         ),
       );
     } catch (err) {
-      Logger.log(
-        'ClustersRepository _save',
-        'Failed to Save Clusters',
-        err,
-      );
+      Logger.log('ClustersRepository _save', 'Failed to Save Clusters', err);
     }
   }
 
@@ -63,19 +56,16 @@ class ClustersRepository with ChangeNotifier {
     try {
       final storedData = await Storage().read('kubenavClustersRepository');
       if (storedData != null) {
-        final parsedStoredData =
-            ClustersRepositoryStorage.fromJson(json.decode(storedData));
+        final parsedStoredData = ClustersRepositoryStorage.fromJson(
+          json.decode(storedData),
+        );
         _clusters = parsedStoredData.clusters;
         _providers = parsedStoredData.providers;
         _activeClusterId = parsedStoredData.activeClusterId;
       }
       notifyListeners();
     } catch (err) {
-      Logger.log(
-        'ClustersRepository init',
-        'Failed to Load Clusters',
-        err,
-      );
+      Logger.log('ClustersRepository init', 'Failed to Load Clusters', err);
     }
   }
 
@@ -196,11 +186,8 @@ class ClustersRepository with ChangeNotifier {
         throw 'No Clusters Found';
       }
 
-      final cluster = _clusters
-          .where(
-            (cluster) => cluster.id == clusterId,
-          )
-          .toList()[0];
+      final cluster =
+          _clusters.where((cluster) => cluster.id == clusterId).toList()[0];
 
       if (cluster.clusterProviderType == ClusterProviderType.aws) {
         /// When the cluster provider is AWS we get the expiration time saved in
@@ -230,9 +217,10 @@ class ClustersRepository with ChangeNotifier {
               cluster.clusterProviderInternal,
             );
             cluster.userToken = token;
-            cluster.userTokenExpireTimestamp = DateTime.now()
-                .add(const Duration(minutes: 10))
-                .microsecondsSinceEpoch;
+            cluster.userTokenExpireTimestamp =
+                DateTime.now()
+                    .add(const Duration(minutes: 10))
+                    .microsecondsSinceEpoch;
             await editClusterWithoutNotify(cluster);
             return cluster;
           } else {
@@ -287,9 +275,10 @@ class ClustersRepository with ChangeNotifier {
             );
 
             cluster.userToken = token;
-            cluster.userTokenExpireTimestamp = DateTime.now()
-                .add(const Duration(minutes: 10))
-                .microsecondsSinceEpoch;
+            cluster.userTokenExpireTimestamp =
+                DateTime.now()
+                    .add(const Duration(minutes: 10))
+                    .microsecondsSinceEpoch;
             await editClusterWithoutNotify(cluster);
             return cluster;
           } else {
@@ -318,7 +307,8 @@ class ClustersRepository with ChangeNotifier {
             provider?.google?.refreshToken ?? '',
           );
 
-          final expires = DateTime.now().millisecondsSinceEpoch +
+          final expires =
+              DateTime.now().millisecondsSinceEpoch +
               googleTokens.expiresIn! * 1000;
           provider?.google?.accessToken = googleTokens.accessToken!;
           provider?.google?.accessTokenExpires = expires;
@@ -362,6 +352,7 @@ class ClustersRepository with ChangeNotifier {
             provider?.oidc?.clientSecret ?? '',
             provider?.oidc?.certificateAuthority ?? '',
             provider?.oidc?.scopes ?? '',
+            provider?.oidc?.addDefaultScopes ?? true,
             Constants.oidcRedirectURI,
             provider?.oidc?.refreshToken ?? '',
             provider?.oidc?.useAccessToken ?? false,
@@ -522,14 +513,18 @@ class ClustersRepositoryStorage {
 
   factory ClustersRepositoryStorage.fromJson(Map<String, dynamic> data) {
     return ClustersRepositoryStorage(
-      clusters: data.containsKey('clusters') && data['clusters'] != null
-          ? List<Cluster>.from(data['clusters'].map((v) => Cluster.fromJson(v)))
-          : [],
-      providers: data.containsKey('providers') && data['providers'] != null
-          ? List<ClusterProvider>.from(
-              data['providers'].map((v) => ClusterProvider.fromJson(v)),
-            )
-          : [],
+      clusters:
+          data.containsKey('clusters') && data['clusters'] != null
+              ? List<Cluster>.from(
+                data['clusters'].map((v) => Cluster.fromJson(v)),
+              )
+              : [],
+      providers:
+          data.containsKey('providers') && data['providers'] != null
+              ? List<ClusterProvider>.from(
+                data['providers'].map((v) => ClusterProvider.fromJson(v)),
+              )
+              : [],
       activeClusterId:
           data.containsKey('activeClusterId') && data['activeClusterId'] != null
               ? data['activeClusterId']

--- a/lib/services/providers/oidc_service.dart
+++ b/lib/services/providers/oidc_service.dart
@@ -7,10 +7,7 @@ import 'package:kubenav/utils/logger.dart';
 
 /// [OIDCFlow] is a `enum` for the OIDC flow which should be used within a OIDC
 /// provider.
-enum OIDCFlow {
-  standard,
-  device,
-}
+enum OIDCFlow { standard, device }
 
 extension OIDCFlowExtension on OIDCFlow {
   /// [toShortString] returns a short string of the OIDC flow, so that we
@@ -57,9 +54,7 @@ class OIDCResponse {
     required this.verifier,
   });
 
-  factory OIDCResponse.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory OIDCResponse.fromJson(Map<String, dynamic> data) {
     return OIDCResponse(
       url: data.containsKey('url') ? data['url'] : null,
       idToken: data.containsKey('idToken') ? data['idToken'] : null,
@@ -95,18 +90,18 @@ class OIDCDeviceAuth {
     required this.verificationURIComplete,
   });
 
-  factory OIDCDeviceAuth.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory OIDCDeviceAuth.fromJson(Map<String, dynamic> data) {
     return OIDCDeviceAuth(
       deviceCode: data.containsKey('device_code') ? data['device_code'] : null,
       userCode: data.containsKey('user_code') ? data['user_code'] : null,
-      verificationURI: data.containsKey('verification_uri')
-          ? data['verification_uri']
-          : null,
-      verificationURIComplete: data.containsKey('verification_uri_complete')
-          ? data['verification_uri_complete']
-          : null,
+      verificationURI:
+          data.containsKey('verification_uri')
+              ? data['verification_uri']
+              : null,
+      verificationURIComplete:
+          data.containsKey('verification_uri_complete')
+              ? data['verification_uri_complete']
+              : null,
     );
   }
 
@@ -134,39 +129,31 @@ class OIDCService {
     String clientSecret,
     String certificateAuthority,
     String scopes,
+    bool addDefaultScopes,
     String redirectURL,
     String pkceMethod,
     String state,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'oidcGetLink',
-        <String, dynamic>{
-          'discoveryURL': discoveryURL,
-          'clientID': clientID,
-          'clientSecret': clientSecret,
-          'certificateAuthority': certificateAuthority,
-          'scopes': scopes,
-          'redirectURL': redirectURL,
-          'pkceMethod': pkceMethod,
-          'state': state,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('oidcGetLink', <String, dynamic>{
+            'discoveryURL': discoveryURL,
+            'clientID': clientID,
+            'clientSecret': clientSecret,
+            'certificateAuthority': certificateAuthority,
+            'scopes': scopes,
+            'addDefaultScopes': addDefaultScopes,
+            'redirectURL': redirectURL,
+            'pkceMethod': pkceMethod,
+            'state': state,
+          });
 
-      Logger.log(
-        'OIDCService getLink',
-        'Link was generated',
-        result,
-      );
+      Logger.log('OIDCService getLink', 'Link was generated', result);
 
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);
     } catch (err) {
-      Logger.log(
-        'OIDCService getLink',
-        'Failed to Get OIDC Login Url',
-        err,
-      );
+      Logger.log('OIDCService getLink', 'Failed to Get OIDC Login Url', err);
       rethrow;
     }
   }
@@ -179,6 +166,7 @@ class OIDCService {
     String clientSecret,
     String certificateAuthority,
     String scopes,
+    bool addDefaultScopes,
     String redirectURL,
     String pkceMethod,
     String code,
@@ -186,21 +174,20 @@ class OIDCService {
     bool useAccessToken,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'oidcGetRefreshToken',
-        <String, dynamic>{
-          'discoveryURL': discoveryURL,
-          'clientID': clientID,
-          'clientSecret': clientSecret,
-          'certificateAuthority': certificateAuthority,
-          'scopes': scopes,
-          'redirectURL': redirectURL,
-          'pkceMethod': pkceMethod,
-          'code': code,
-          'verifier': verifier,
-          'useAccessToken': useAccessToken,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('oidcGetRefreshToken', <String, dynamic>{
+            'discoveryURL': discoveryURL,
+            'clientID': clientID,
+            'clientSecret': clientSecret,
+            'certificateAuthority': certificateAuthority,
+            'scopes': scopes,
+            'addDefaultScopes': addDefaultScopes,
+            'redirectURL': redirectURL,
+            'pkceMethod': pkceMethod,
+            'code': code,
+            'verifier': verifier,
+            'useAccessToken': useAccessToken,
+          });
 
       Logger.log(
         'OIDCService getRefreshToken',
@@ -228,30 +215,26 @@ class OIDCService {
     String clientSecret,
     String certificateAuthority,
     String scopes,
+    bool addDefaultScopes,
     String redirectURL,
     String refreshToken,
     bool useAccessToken,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'oidcGetAccessToken',
-        <String, dynamic>{
-          'discoveryURL': discoveryURL,
-          'clientID': clientID,
-          'clientSecret': clientSecret,
-          'certificateAuthority': certificateAuthority,
-          'scopes': scopes,
-          'redirectURL': redirectURL,
-          'refreshToken': refreshToken,
-          'useAccessToken': useAccessToken,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('oidcGetAccessToken', <String, dynamic>{
+            'discoveryURL': discoveryURL,
+            'clientID': clientID,
+            'clientSecret': clientSecret,
+            'certificateAuthority': certificateAuthority,
+            'scopes': scopes,
+            'addDefaultScopes': addDefaultScopes,
+            'redirectURL': redirectURL,
+            'refreshToken': refreshToken,
+            'useAccessToken': useAccessToken,
+          });
 
-      Logger.log(
-        'OIDCService getAccessToken',
-        'Access Token Returned',
-        result,
-      );
+      Logger.log('OIDCService getAccessToken', 'Access Token Returned', result);
 
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);
@@ -275,23 +258,19 @@ class OIDCService {
     String clientID,
     String certificateAuthority,
     String scopes,
+    bool addDefaultScopes,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'oidcDeviceAuth',
-        <String, dynamic>{
-          'discoveryURL': discoveryURL,
-          'clientID': clientID,
-          'certificateAuthority': certificateAuthority,
-          'scopes': scopes,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('oidcDeviceAuth', <String, dynamic>{
+            'discoveryURL': discoveryURL,
+            'clientID': clientID,
+            'certificateAuthority': certificateAuthority,
+            'scopes': scopes,
+            'addDefaultScopes': addDefaultScopes,
+          });
 
-      Logger.log(
-        'OIDCService deviceAuth',
-        'Device Auth Data Returned',
-        result,
-      );
+      Logger.log('OIDCService deviceAuth', 'Device Auth Data Returned', result);
 
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCDeviceAuth.fromJson(jsonData);
@@ -314,21 +293,21 @@ class OIDCService {
     String clientID,
     String certificateAuthority,
     String scopes,
+    bool addDefaultScopes,
     String deviceCode,
     bool useAccessToken,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'oidcDeviceAuthGetRefreshToken',
-        <String, dynamic>{
-          'discoveryURL': discoveryURL,
-          'clientID': clientID,
-          'certificateAuthority': certificateAuthority,
-          'scopes': scopes,
-          'deviceCode': deviceCode,
-          'useAccessToken': useAccessToken,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('oidcDeviceAuthGetRefreshToken', <String, dynamic>{
+            'discoveryURL': discoveryURL,
+            'clientID': clientID,
+            'certificateAuthority': certificateAuthority,
+            'scopes': scopes,
+            'addDefaultScopes': addDefaultScopes,
+            'deviceCode': deviceCode,
+            'useAccessToken': useAccessToken,
+          });
 
       Logger.log(
         'OIDCService deviceAuthGetRefreshToken',

--- a/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/reauthenticate/settings_reauthenticate_oidc_provider_config.dart
@@ -33,6 +33,7 @@ class _SettingsReauthenticateOIDCState
         _provider?.oidc?.clientSecret ?? '',
         _provider?.oidc?.certificateAuthority ?? '',
         _provider?.oidc?.scopes ?? '',
+        _provider?.oidc?.addDefaultScopes ?? true,
         _provider?.oidc?.redirectURL ?? '',
         _provider?.oidc?.pkceMethod ?? '',
         _stateController.text,
@@ -54,11 +55,7 @@ class _SettingsReauthenticateOIDCState
         err,
       );
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Open Sign In Url',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Open Sign In Url', err.toString());
       }
     }
   }
@@ -76,6 +73,7 @@ class _SettingsReauthenticateOIDCState
         _provider?.oidc?.clientSecret ?? '',
         _provider?.oidc?.certificateAuthority ?? '',
         _provider?.oidc?.scopes ?? '',
+        _provider?.oidc?.addDefaultScopes ?? true,
         _provider?.oidc?.redirectURL ?? '',
         _provider?.oidc?.pkceMethod ?? '',
         _codeController.text,
@@ -102,11 +100,7 @@ class _SettingsReauthenticateOIDCState
         err,
       );
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Get Credentials',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Get Credentials', err.toString());
       }
     }
   }
@@ -173,9 +167,7 @@ class _SettingsReauthenticateOIDCState
               foregroundColor: Theme.of(context).colorScheme.onPrimary,
               minimumSize: const Size.fromHeight(40),
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(
-                  Constants.sizeBorderRadius,
-                ),
+                borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
               ),
             ),
             onPressed: _signIn,
@@ -217,9 +209,7 @@ class _SettingsReauthenticateOIDCState
               foregroundColor: Theme.of(context).colorScheme.onPrimary,
               minimumSize: const Size.fromHeight(40),
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(
-                  Constants.sizeBorderRadius,
-                ),
+                borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
               ),
             ),
             onPressed: _codeController.text == '' ? null : _getCredentials,

--- a/lib/widgets/settings/providers/settings_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_oidc_provider_config.dart
@@ -15,10 +15,7 @@ import 'package:kubenav/widgets/settings/clusters/settings_add_cluster_oidc.dart
 import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 
 class SettingsOIDCProvider extends StatefulWidget {
-  const SettingsOIDCProvider({
-    super.key,
-    required this.provider,
-  });
+  const SettingsOIDCProvider({super.key, required this.provider});
 
   final ClusterProvider? provider;
 
@@ -28,6 +25,7 @@ class SettingsOIDCProvider extends StatefulWidget {
 
 class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   final _providerConfigFormKey = GlobalKey<FormState>();
+  final _addDefaultScopesTooltipKey = GlobalKey<TooltipState>();
   final _nameController = TextEditingController();
   OIDCFlow _flow = OIDCFlow.standard;
   final _discoveryURLController = TextEditingController();
@@ -35,6 +33,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   String _pkceMethod = '';
   final _clientSecretController = TextEditingController();
   final _scopesController = TextEditingController();
+  bool _addDefaultScopes = true;
   final _certificateAuthorityController = TextEditingController();
   final _refreshTokenController = TextEditingController();
   final _redirectURLController = TextEditingController();
@@ -66,6 +65,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         _clientSecretController.text,
         _certificateAuthorityController.text,
         _scopesController.text,
+        _addDefaultScopes,
         _redirectURLController.text,
         _pkceMethod,
         _stateController.text,
@@ -87,11 +87,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         err,
       );
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Open Sign In Url',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Open Sign In Url', err.toString());
       }
     }
   }
@@ -106,6 +102,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         _clientIDController.text,
         _certificateAuthorityController.text,
         _scopesController.text,
+        _addDefaultScopes,
       );
 
       setState(() {
@@ -142,11 +139,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         err,
       );
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Verify Device',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Verify Device', err.toString());
       }
     }
   }
@@ -174,6 +167,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             _clientIDController.text,
             _certificateAuthorityController.text,
             _scopesController.text,
+            _addDefaultScopes,
             _deviceAuthData?.deviceCode ?? '',
             _useAccessToken,
           );
@@ -190,6 +184,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
                 clientSecret: _clientSecretController.text,
                 certificateAuthority: _certificateAuthorityController.text,
                 scopes: _scopesController.text,
+                addDefaultScopes: _addDefaultScopes,
                 pkceMethod: _pkceMethod,
                 verifier: _verifier,
                 code: _codeController.text,
@@ -206,12 +201,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             });
             if (mounted) {
               Navigator.pop(context);
-              showModal(
-                context,
-                SettingsAddClusterOIDC(
-                  provider: provider,
-                ),
-              );
+              showModal(context, SettingsAddClusterOIDC(provider: provider));
             }
           } else {
             final provider = widget.provider!;
@@ -223,6 +213,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             provider.oidc!.certificateAuthority =
                 _certificateAuthorityController.text;
             provider.oidc!.scopes = _scopesController.text;
+            provider.oidc!.addDefaultScopes = _addDefaultScopes;
             provider.oidc!.pkceMethod = _pkceMethod;
             provider.oidc!.verifier = _verifier;
             provider.oidc!.code = _codeController.text;
@@ -273,6 +264,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
               _clientSecretController.text,
               _certificateAuthorityController.text,
               _scopesController.text,
+              _addDefaultScopes,
               _redirectURLController.text,
               _pkceMethod,
               _codeController.text,
@@ -295,6 +287,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
               _clientSecretController.text,
               _certificateAuthorityController.text,
               _scopesController.text,
+              _addDefaultScopes,
               _redirectURLController.text,
               _refreshTokenController.text,
               _useAccessToken,
@@ -322,6 +315,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
                 clientSecret: _clientSecretController.text,
                 certificateAuthority: _certificateAuthorityController.text,
                 scopes: _scopesController.text,
+                addDefaultScopes: _addDefaultScopes,
                 pkceMethod: _pkceMethod,
                 verifier: _verifier,
                 code: _codeController.text,
@@ -338,12 +332,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             });
             if (mounted) {
               Navigator.pop(context);
-              showModal(
-                context,
-                SettingsAddClusterOIDC(
-                  provider: provider,
-                ),
-              );
+              showModal(context, SettingsAddClusterOIDC(provider: provider));
             }
           } else {
             final provider = widget.provider!;
@@ -355,6 +344,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             provider.oidc!.certificateAuthority =
                 _certificateAuthorityController.text;
             provider.oidc!.scopes = _scopesController.text;
+            provider.oidc!.addDefaultScopes = _addDefaultScopes;
             provider.oidc!.pkceMethod = _pkceMethod;
             provider.oidc!.verifier = _verifier;
             provider.oidc!.code = _codeController.text;
@@ -395,9 +385,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
   Widget _buildPkceMethod() {
     if (_pkceMethod == '') {
       return Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _clientSecretController,
           keyboardType: TextInputType.text,
@@ -442,9 +430,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             foregroundColor: Theme.of(context).colorScheme.onPrimary,
             minimumSize: const Size.fromHeight(40),
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(
-                Constants.sizeBorderRadius,
-              ),
+              borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
             ),
           ),
           onPressed: _verifyDeviceFlow,
@@ -465,11 +451,12 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             const Text('Use Access Token instead of ID Token'),
             Switch(
               activeColor: Theme.of(context).colorScheme.primary,
-              onChanged: (val) => {
-                setState(() {
-                  _useAccessToken = !_useAccessToken;
-                }),
-              },
+              onChanged:
+                  (val) => {
+                    setState(() {
+                      _useAccessToken = !_useAccessToken;
+                    }),
+                  },
               value: _useAccessToken,
             ),
           ],
@@ -499,15 +486,50 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
           ),
         ),
         const SizedBox(height: Constants.spacingMiddle),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Row(
+              children: [
+                const Text('Add Default Scopes'),
+                IconButton(
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder:
+                          (context) => AlertDialog(
+                            title: Text('Add Default Scopes'),
+                            content: Text(
+                              'Add the "openid" and "offline_access" scopes.',
+                            ),
+                          ),
+                    );
+                  },
+                  icon: Icon(Icons.info),
+                ),
+              ],
+            ),
+            Switch(
+              activeColor: Theme.of(context).colorScheme.primary,
+              onChanged:
+                  (val) => {
+                    setState(() {
+                      _addDefaultScopes = !_addDefaultScopes;
+                    }),
+                  },
+              value: _addDefaultScopes,
+            ),
+          ],
+        ),
+        const SizedBox(height: Constants.spacingMiddle),
         ElevatedButton(
           style: ElevatedButton.styleFrom(
             backgroundColor: Theme.of(context).colorScheme.primary,
             foregroundColor: Theme.of(context).colorScheme.onPrimary,
             minimumSize: const Size.fromHeight(40),
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(
-                Constants.sizeBorderRadius,
-              ),
+              borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
             ),
           ),
           onPressed: _initDeviceFlow,
@@ -526,9 +548,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
 
     return [
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -545,31 +565,28 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
                   _pkceMethod = newValue ?? '';
                 });
               },
-              items: [
-                '',
-                'S256',
-              ].map((value) {
-                return DropdownMenuItem(
-                  value: value,
-                  child: Text(
-                    value,
-                    style: TextStyle(
-                      color: Theme.of(context)
-                          .extension<CustomColors>()!
-                          .textPrimary,
-                    ),
-                  ),
-                );
-              }).toList(),
+              items:
+                  ['', 'S256'].map((value) {
+                    return DropdownMenuItem(
+                      value: value,
+                      child: Text(
+                        value,
+                        style: TextStyle(
+                          color:
+                              Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.textPrimary,
+                        ),
+                      ),
+                    );
+                  }).toList(),
             ),
           ],
         ),
       ),
       _buildPkceMethod(),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _scopesController,
           keyboardType: TextInputType.text,
@@ -583,9 +600,47 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Row(
+              children: [
+                const Text('Add Default Scopes'),
+                IconButton(
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder:
+                          (context) => AlertDialog(
+                            title: Text('Add Default Scopes'),
+                            content: Text(
+                              'Add the "openid" and "offline_access" scopes.',
+                            ),
+                          ),
+                    );
+                  },
+                  icon: Icon(Icons.info),
+                ),
+              ],
+            ),
+
+            Switch(
+              activeColor: Theme.of(context).colorScheme.primary,
+              onChanged:
+                  (val) => {
+                    setState(() {
+                      _addDefaultScopes = !_addDefaultScopes;
+                    }),
+                  },
+              value: _addDefaultScopes,
+            ),
+          ],
         ),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _certificateAuthorityController,
           keyboardType: TextInputType.text,
@@ -599,9 +654,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _refreshTokenController,
           keyboardType: TextInputType.text,
@@ -615,9 +668,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _redirectURLController,
           keyboardType: TextInputType.text,
@@ -631,9 +682,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _stateController,
           keyboardType: TextInputType.text,
@@ -649,9 +698,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -659,29 +706,26 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
             const Text('Use Access Token instead of ID Token'),
             Switch(
               activeColor: Theme.of(context).colorScheme.primary,
-              onChanged: (val) => {
-                setState(() {
-                  _useAccessToken = !_useAccessToken;
-                }),
-              },
+              onChanged:
+                  (val) => {
+                    setState(() {
+                      _useAccessToken = !_useAccessToken;
+                    }),
+                  },
               value: _useAccessToken,
             ),
           ],
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: ElevatedButton(
           style: ElevatedButton.styleFrom(
             backgroundColor: Theme.of(context).colorScheme.primary,
             foregroundColor: Theme.of(context).colorScheme.onPrimary,
             minimumSize: const Size.fromHeight(40),
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(
-                Constants.sizeBorderRadius,
-              ),
+              borderRadius: BorderRadius.circular(Constants.sizeBorderRadius),
             ),
           ),
           onPressed: _signIn,
@@ -696,9 +740,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
         ),
       ),
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: Constants.spacingSmall,
-        ),
+        padding: const EdgeInsets.symmetric(vertical: Constants.spacingSmall),
         child: TextFormField(
           controller: _codeController,
           keyboardType: TextInputType.text,
@@ -725,6 +767,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
       _pkceMethod = widget.provider?.oidc?.pkceMethod ?? '';
       _clientSecretController.text = widget.provider?.oidc?.clientSecret ?? '';
       _scopesController.text = widget.provider?.oidc?.scopes ?? '';
+      _addDefaultScopes = widget.provider?.oidc?.addDefaultScopes ?? true;
       _certificateAuthorityController.text =
           widget.provider?.oidc?.certificateAuthority ?? '';
       _refreshTokenController.text = widget.provider?.oidc?.refreshToken ?? '';
@@ -809,19 +852,21 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
                           _flow = newValue ?? OIDCFlow.standard;
                         });
                       },
-                      items: OIDCFlow.values.map((value) {
-                        return DropdownMenuItem(
-                          value: value,
-                          child: Text(
-                            value.pretty(),
-                            style: TextStyle(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .textPrimary,
-                            ),
-                          ),
-                        );
-                      }).toList(),
+                      items:
+                          OIDCFlow.values.map((value) {
+                            return DropdownMenuItem(
+                              value: value,
+                              child: Text(
+                                value.pretty(),
+                                style: TextStyle(
+                                  color:
+                                      Theme.of(
+                                        context,
+                                      ).extension<CustomColors>()!.textPrimary,
+                                ),
+                              ),
+                            );
+                          }).toList(),
                     ),
                   ],
                 ),


### PR DESCRIPTION
The OIDC provider now contains an options to disable the default scopes
`openid` and `offline_access`. This was added because the
`offline_access` scope is not supported by some OIDC providers. E.g.
Google doesn't support it and we worked arround this in the past by
checking if the provider url was related to Google. This solutions does
not work for urls where the service is self hosted with a custom url
like mentioned in #750. Therefore it is now possible to skip the default
scopes at all.

We can not simply remove the default scopes at all, because it could
break existing configuration, so that the explicit option was added and
the default value is that the default scopes are added.

Fixes #750

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
