### PR TITLE
Change State Token Length to 12 Characters

### DIFF
--- a/lib/widgets/settings/providers/settings_oidc_provider_config.dart
+++ b/lib/widgets/settings/providers/settings_oidc_provider_config.dart
@@ -779,7 +779,7 @@ class _SettingsOIDCProviderState extends State<SettingsOIDCProvider> {
       _redirectURLController.text = Constants.oidcRedirectURI;
     }
 
-    _stateController.text = generateRandomString(6);
+    _stateController.text = generateRandomString(12);
   }
 
   @override


### PR DESCRIPTION
Change the length of the state token to 12 characters, because the current
lenght of 6 characters doesn"t work with all OIDC providers (e.g. Authelia
requires a minumum length of 8 characters).

Fixes #777

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
