### PR TITLE
Catch Panics when Creating a New Kubernetes Client

### DIFF
--- a/cmd/kubenav/kube/kube.go
+++ b/cmd/kubenav/kube/kube.go
@@ -11,7 +11,17 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func NewClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (*rest.Config, *kubernetes.Clientset, error) {
+func NewClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (restClient *rest.Config, clientset *kubernetes.Clientset, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %#v", r)
+		}
+	}()
+
+	return newClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
+}
+
+func newClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (*rest.Config, *kubernetes.Clientset, error) {
 	// If a token is provided, we must ensure that the username and password are
 	// empty. Otherwise the app would crash in such cases.
 	if userToken != "" {


### PR DESCRIPTION
In the past we had reports that the app crashes, when a invalid Kubeconfig is
used within the app. In the past this was caused by using a token, username and
password in the configuration. Since this error is already catched, we now catch
all panics in the `NewClient` function and return the panic message as error.

If we still see crashes of the app afterwards, we might have to do this for all
Go functions.

Fixes #776

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
