### PR TITLE
Catch Panics in Go Functions

### DIFF
--- a/cmd/kubenav/aws.go
+++ b/cmd/kubenav/aws.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,6 +56,12 @@ type AWSSSOAccount struct {
 // AWSGetClusters returns all clusters which can be accessed with the given
 // credentials.
 func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	var clusters []*eks.Cluster
 	var names []*string
 	var nextToken *string
@@ -110,6 +117,12 @@ func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string
 // of a cluster with the given clusterID.
 // See: https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/7547c74e660f8d34d9980f2c69aa008eed1f48d0/pkg/token/token.go#L310
 func AWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	cred := credentials.NewStaticCredentials(accessKeyID, secretKey, sessionToken)
 
 	sess, err := session.NewSession(&aws.Config{Region: aws.String(region), Credentials: cred})
@@ -137,6 +150,12 @@ func AWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterI
 // authentication. The client and device authentication is returned, so that we
 // can use the information in the following steps of the SSO flow.
 func AWSGetSSOConfig(ssoRegion, startURL string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	clientName := "kubenav"
 	clientType := "public"
 
@@ -179,6 +198,12 @@ func AWSGetSSOConfig(ssoRegion, startURL string) (string, error) {
 // information from the former step in the sso flow. The retrieved access token
 // is then used to get the credentials for AWS.
 func AWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, accessToken string, accessTokenExpire int64) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	grantType := "urn:ietf:params:oauth:grant-type:device_code"
 
 	sess, err := session.NewSession()
@@ -237,6 +262,12 @@ func AWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret
 // authenticated user, so that a user does not have to provide these information
 // by his own.
 func AWSGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	grantType := "urn:ietf:params:oauth:grant-type:device_code"
 
 	sess, err := session.NewSession()

--- a/cmd/kubenav/azure.go
+++ b/cmd/kubenav/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -23,6 +24,12 @@ type AzureCluster struct {
 // Azure credentials, the returned JSON encoded string contains all the clusters
 // with there name and kubeconfig.
 func AzureGetClusters(subscriptionID, tenantID, clientID, clientSecret string, isAdmin bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	credentials, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
 		return "", err

--- a/cmd/kubenav/helm.go
+++ b/cmd/kubenav/helm.go
@@ -2,6 +2,7 @@ package kubenav
 
 import (
 	"encoding/json"
+	"log"
 	"sort"
 	"time"
 
@@ -33,6 +34,12 @@ type UninstallOptions struct {
 // HelmListReleases returns a list of Helm releases for the given cluster and
 // namespace. If an error occures during the process the error is returned.
 func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err
@@ -64,6 +71,12 @@ func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clu
 // identified by it's namespace, name and version. If an error occures during
 // the process the error is returned.
 func HelmGetRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err
@@ -91,6 +104,12 @@ func HelmGetRelease(clusterServer, clusterCertificateAuthorityData string, clust
 // identified by it's namespace and name. If an error occures during the process
 // the error is returned.
 func HelmListReleaseHistory(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err
@@ -122,6 +141,12 @@ func HelmListReleaseHistory(clusterServer, clusterCertificateAuthorityData strin
 // by it's namespace and name. The Helm release is rolled back to the provided
 // version. If an error occures during the process the error is returned.
 func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64, options string) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return err
@@ -148,6 +173,12 @@ func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, 
 // the error is returned. If the operation was successful the uninstall message
 // is returned.
 func HelmUninstallRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, options string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, _, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err

--- a/cmd/kubenav/helpers.go
+++ b/cmd/kubenav/helpers.go
@@ -2,6 +2,7 @@ package kubenav
 
 import (
 	"encoding/json"
+	"log"
 
 	"github.com/wI2L/jsondiff"
 	"sigs.k8s.io/yaml"
@@ -12,6 +13,12 @@ import (
 // map[string]interface{} which we can then marshal to the prettified yaml
 // string.
 func PrettifyYAML(jsonStr string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	var jsonObj map[string]interface{}
 
 	err := json.Unmarshal([]byte(jsonStr), &jsonObj)
@@ -32,6 +39,12 @@ func PrettifyYAML(jsonStr string) (string, error) {
 // the current resource and the target is the edited manifest. The returned
 // patch can then be send to the Kubernetes API to edit the resource.
 func CreateJSONPatch(source, target string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	patch, err := jsondiff.CompareJSON([]byte(source), []byte(target))
 	if err != nil {
 		return "", err

--- a/cmd/kubenav/kube/kube.go
+++ b/cmd/kubenav/kube/kube.go
@@ -11,17 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func NewClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (restClient *rest.Config, clientset *kubernetes.Clientset, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic: %#v", r)
-		}
-	}()
-
-	return newClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
-}
-
-func newClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (*rest.Config, *kubernetes.Clientset, error) {
+func NewClient(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64) (*rest.Config, *kubernetes.Clientset, error) {
 	// If a token is provided, we must ensure that the username and password are
 	// empty. Otherwise the app would crash in such cases.
 	if userToken != "" {

--- a/cmd/kubenav/kubernetes.go
+++ b/cmd/kubenav/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -25,6 +26,12 @@ import (
 // for the actually request. E.g. to get all Pods from the Kubernetes API the
 // method "GET" and the URL "/api/v1/pods" can be used.
 func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, requestMethod, requestURL, requestBody string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	_, clientset, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err
@@ -74,6 +81,12 @@ func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, cl
 // of the Pod names. To use this function a user must also provide the
 // namespace, container, since and previous parameter.
 func KubernetesGetLogs(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, names, namespace, container string, since int64, filter string, previous bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	_, clientset, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err
@@ -166,5 +179,11 @@ func kubernetesGetLogs(clientset *kubernetes.Clientset, clusterServer, name, nam
 // server is responsible for providing the port forwarding and Pod exec feature
 // for kubenav.
 func KubernetesStartServer() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	server.Start()
 }

--- a/cmd/kubenav/oidc.go
+++ b/cmd/kubenav/oidc.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -82,6 +83,12 @@ func oidcContext(ctx context.Context, certificateAuthority string) (context.Cont
 // OIDCGetLink returns the link for the configured OIDC provider. The Link can
 // then be used by the user to login.
 func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, state string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -153,6 +160,12 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 // The refresh token can be used to get a new access token via the
 // OIDCGetAccessToken function.
 func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, code, verifier string, useAccessToken bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -213,6 +226,12 @@ func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthor
 
 // OIDCGetAccessToken is used to retrieve an access token from a refresh token.
 func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, refreshToken string, useAccessToken bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -268,6 +287,12 @@ func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthori
 }
 
 func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err
@@ -318,6 +343,12 @@ func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string,
 }
 
 func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool, deviceCode string, useAccessToken bool) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	ctx, err := oidcContext(context.Background(), certificateAuthority)
 	if err != nil {
 		return "", err

--- a/cmd/kubenav/prometheus.go
+++ b/cmd/kubenav/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"log"
 	"math"
 	"net"
 	"net/http"
@@ -64,6 +65,12 @@ type datum struct {
 // PrometheusGetData can be used to run a list multiple PromQL queries against a
 // Prometheus instance.
 func PrometheusGetData(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, request string) (string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("panic: %#v", r)
+		}
+	}()
+
 	restConfig, clientset, err := kube.NewClient(clusterServer, clusterCertificateAuthorityData, clusterInsecureSkipTLSVerify, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy, timeout)
 	if err != nil {
 		return "", err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/kubenav/kubenav
 
 go 1.24.0
+
 replace golang.org/x/oauth2 => github.com/kubenav/oauth2 v0.0.0-20240830072915-86aad6e7f9f3
 
 require (

--- a/lib/services/helpers_service.dart
+++ b/lib/services/helpers_service.dart
@@ -16,17 +16,11 @@ class HelpersService {
   /// implemented in Go, because Dart lacks a good package to work with YAML.
   Future<String> prettifyYAML(String json) async {
     try {
-      Logger.log(
-        'HelperService prettifyYAML',
-        'Run prettifyYAML',
-        json,
-      );
+      Logger.log('HelperService prettifyYAML', 'Run prettifyYAML', json);
 
       final String result = await platform.invokeMethod(
         'prettifyYAML',
-        <String, dynamic>{
-          'jsonStr': json,
-        },
+        <String, dynamic>{'jsonStr': json},
       );
 
       Logger.log(
@@ -34,13 +28,14 @@ class HelpersService {
         'prettifyYAML Succeeded',
         result,
       );
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       return result;
     } catch (err) {
-      Logger.log(
-        'HelpersService prettifyYAML',
-        'prettifyYAML Failed',
-        err,
-      );
+      Logger.log('HelpersService prettifyYAML', 'prettifyYAML Failed', err);
       rethrow;
     }
   }
@@ -59,10 +54,7 @@ class HelpersService {
 
       final String result = await platform.invokeMethod(
         'createJSONPatch',
-        <String, dynamic>{
-          'source': source,
-          'target': target,
-        },
+        <String, dynamic>{'source': source, 'target': target},
       );
 
       Logger.log(
@@ -70,6 +62,11 @@ class HelpersService {
         'createJSONPatch Succeeded',
         result,
       );
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       return result;
     } catch (err) {
       Logger.log(

--- a/lib/services/kubernetes_service.dart
+++ b/lib/services/kubernetes_service.dart
@@ -46,31 +46,33 @@ class KubernetesService {
       '${cluster.name}, $method, $url, $body',
     );
 
-    final String result = await platform.invokeMethod(
-      'kubernetesRequest',
-      <String, dynamic>{
-        'clusterServer': cluster.clusterServer,
-        'clusterCertificateAuthorityData':
-            cluster.clusterCertificateAuthorityData,
-        'clusterInsecureSkipTLSVerify': cluster.clusterInsecureSkipTLSVerify,
-        'userClientCertificateData': cluster.userClientCertificateData,
-        'userClientKeyData': cluster.userClientKeyData,
-        'userToken': cluster.userToken,
-        'userUsername': cluster.userUsername,
-        'userPassword': cluster.userPassword,
-        'proxy': proxy,
-        'timeout': timeout,
-        'requestMethod': method,
-        'requestURL': url,
-        'requestBody': body,
-      },
-    );
+    final String result = await platform
+        .invokeMethod('kubernetesRequest', <String, dynamic>{
+          'clusterServer': cluster.clusterServer,
+          'clusterCertificateAuthorityData':
+              cluster.clusterCertificateAuthorityData,
+          'clusterInsecureSkipTLSVerify': cluster.clusterInsecureSkipTLSVerify,
+          'userClientCertificateData': cluster.userClientCertificateData,
+          'userClientKeyData': cluster.userClientKeyData,
+          'userToken': cluster.userToken,
+          'userUsername': cluster.userUsername,
+          'userPassword': cluster.userPassword,
+          'proxy': proxy,
+          'timeout': timeout,
+          'requestMethod': method,
+          'requestURL': url,
+          'requestBody': body,
+        });
 
     Logger.log(
       'KubernetesService kubernetesRequest',
       'Result of the kubernetesRequest function',
       result,
     );
+
+    if (result.isEmpty) {
+      throw Exception('An unknown error occured');
+    }
 
     return result;
   }
@@ -94,11 +96,7 @@ class KubernetesService {
       }
       return false;
     } catch (err) {
-      Logger.log(
-        'KubernetesService checkHealth',
-        'Health check failed',
-        err,
-      );
+      Logger.log('KubernetesService checkHealth', 'Health check failed', err);
       rethrow;
     }
   }
@@ -119,11 +117,7 @@ class KubernetesService {
       );
       return result;
     } catch (err) {
-      Logger.log(
-        'KubernetesService getRequest',
-        'Get request failed',
-        err,
-      );
+      Logger.log('KubernetesService getRequest', 'Get request failed', err);
       rethrow;
     }
   }
@@ -160,21 +154,10 @@ class KubernetesService {
   /// json patch.
   Future<void> patchRequest(String url, String body) async {
     try {
-      await kubernetesRequest(
-        cluster,
-        proxy,
-        timeout,
-        'PATCH',
-        url,
-        body,
-      );
+      await kubernetesRequest(cluster, proxy, timeout, 'PATCH', url, body);
       return;
     } catch (err) {
-      Logger.log(
-        'KubernetesService patchRequest',
-        'Patch request failed',
-        err,
-      );
+      Logger.log('KubernetesService patchRequest', 'Patch request failed', err);
       rethrow;
     }
   }
@@ -185,21 +168,10 @@ class KubernetesService {
   /// Kubernetes manifest which should be created.
   Future<void> postRequest(String url, String body) async {
     try {
-      await kubernetesRequest(
-        cluster,
-        proxy,
-        timeout,
-        'POST',
-        url,
-        body,
-      );
+      await kubernetesRequest(cluster, proxy, timeout, 'POST', url, body);
       return;
     } catch (err) {
-      Logger.log(
-        'KubernetesService postRequest',
-        'Post request failed',
-        err,
-      );
+      Logger.log('KubernetesService postRequest', 'Post request failed', err);
       rethrow;
     }
   }
@@ -210,21 +182,10 @@ class KubernetesService {
   /// Kubernetes manifest which is used for the update.
   Future<void> putRequest(String url, String body) async {
     try {
-      await kubernetesRequest(
-        cluster,
-        proxy,
-        timeout,
-        'PUT',
-        url,
-        body,
-      );
+      await kubernetesRequest(cluster, proxy, timeout, 'PUT', url, body);
       return;
     } catch (err) {
-      Logger.log(
-        'KubernetesService putRequest',
-        'Put request failed',
-        err,
-      );
+      Logger.log('KubernetesService putRequest', 'Put request failed', err);
       rethrow;
     }
   }
@@ -276,14 +237,14 @@ class KubernetesService {
         result,
       );
 
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       Map<String, dynamic> jsonData = json.decode(result);
       return jsonData['logs'] ?? [];
     } catch (err) {
-      Logger.log(
-        'KubernetesService getLogs',
-        'Get logs request failed',
-        err,
-      );
+      Logger.log('KubernetesService getLogs', 'Get logs request failed', err);
       rethrow;
     }
   }
@@ -370,9 +331,7 @@ class KubernetesService {
     try {
       final response = await http.post(
         Uri.parse('http://localhost:14122/portforwarding'),
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: {'Content-Type': 'application/json'},
         body: json.encode({
           'contextName': cluster.name,
           'clusterServer': cluster.clusterServer,
@@ -430,12 +389,8 @@ class KubernetesService {
     try {
       final response = await http.delete(
         Uri.parse('http://localhost:14122/portforwarding'),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: json.encode({
-          'sessionID': sessionID,
-        }),
+        headers: {'Content-Type': 'application/json'},
+        body: json.encode({'sessionID': sessionID}),
       );
 
       if (response.statusCode == 200) {
@@ -517,11 +472,11 @@ class KubernetesService {
         },
       );
 
-      Logger.log(
-        'KubernetesService helmListReleases',
-        'Helm Releases',
-        result,
-      );
+      Logger.log('KubernetesService helmListReleases', 'Helm Releases', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       if (result == 'null') {
         return [];
@@ -571,11 +526,11 @@ class KubernetesService {
         },
       );
 
-      Logger.log(
-        'KubernetesService helmGetRelease',
-        'Helm Release',
-        result,
-      );
+      Logger.log('KubernetesService helmGetRelease', 'Helm Release', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       return compute(_decodeHelmGetRelease, result);
     } catch (err) {
@@ -626,6 +581,10 @@ class KubernetesService {
         result,
       );
 
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       if (result == 'null') {
         return [];
       }
@@ -656,31 +615,25 @@ class KubernetesService {
         '${cluster.name}, $namespace, $name, $version',
       );
 
-      await platform.invokeMethod(
-        'helmRollbackRelease',
-        <String, dynamic>{
-          'clusterServer': cluster.clusterServer,
-          'clusterCertificateAuthorityData':
-              cluster.clusterCertificateAuthorityData,
-          'clusterInsecureSkipTLSVerify': cluster.clusterInsecureSkipTLSVerify,
-          'userClientCertificateData': cluster.userClientCertificateData,
-          'userClientKeyData': cluster.userClientKeyData,
-          'userToken': cluster.userToken,
-          'userUsername': cluster.userUsername,
-          'userPassword': cluster.userPassword,
-          'proxy': proxy,
-          'timeout': timeout,
-          'namespace': namespace,
-          'name': name,
-          'version': version,
-          'options': options,
-        },
-      );
+      await platform.invokeMethod('helmRollbackRelease', <String, dynamic>{
+        'clusterServer': cluster.clusterServer,
+        'clusterCertificateAuthorityData':
+            cluster.clusterCertificateAuthorityData,
+        'clusterInsecureSkipTLSVerify': cluster.clusterInsecureSkipTLSVerify,
+        'userClientCertificateData': cluster.userClientCertificateData,
+        'userClientKeyData': cluster.userClientKeyData,
+        'userToken': cluster.userToken,
+        'userUsername': cluster.userUsername,
+        'userPassword': cluster.userPassword,
+        'proxy': proxy,
+        'timeout': timeout,
+        'namespace': namespace,
+        'name': name,
+        'version': version,
+        'options': options,
+      });
 
-      Logger.log(
-        'KubernetesService helmRollbackRelease',
-        'Rollback Succeeded',
-      );
+      Logger.log('KubernetesService helmRollbackRelease', 'Rollback Succeeded');
 
       return;
     } catch (err) {
@@ -752,13 +705,14 @@ class KubernetesService {
     int timeEnd,
   ) async {
     try {
-      final request = Request(
-        prometheus: prometheus,
-        manifest: manifest,
-        queries: queries,
-        timeStart: timeStart,
-        timeEnd: timeEnd,
-      ).toString();
+      final request =
+          Request(
+            prometheus: prometheus,
+            manifest: manifest,
+            queries: queries,
+            timeStart: timeStart,
+            timeEnd: timeEnd,
+          ).toString();
 
       Logger.log(
         'KubernetesService prometheusGetData',
@@ -789,6 +743,10 @@ class KubernetesService {
         'List Helm charts was ok',
         result,
       );
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       if (result == 'null') {
         return [];

--- a/lib/services/providers/aws_service.dart
+++ b/lib/services/providers/aws_service.dart
@@ -51,18 +51,17 @@ class AWSCluster {
     required this.certificateAuthority,
   });
 
-  factory AWSCluster.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory AWSCluster.fromJson(Map<String, dynamic> data) {
     return AWSCluster(
       name: data.containsKey('Name') ? data['Name'] : null,
       endpoint: data.containsKey('Endpoint') ? data['Endpoint'] : null,
-      certificateAuthority: data.containsKey('CertificateAuthority') &&
-              data['CertificateAuthority'] != null
-          ? AWSClusterCertificateAuthority.fromJson(
-              data['CertificateAuthority'],
-            )
-          : null,
+      certificateAuthority:
+          data.containsKey('CertificateAuthority') &&
+                  data['CertificateAuthority'] != null
+              ? AWSClusterCertificateAuthority.fromJson(
+                data['CertificateAuthority'],
+              )
+              : null,
     );
   }
 
@@ -80,22 +79,16 @@ class AWSCluster {
 class AWSClusterCertificateAuthority {
   String? data;
 
-  AWSClusterCertificateAuthority({
-    required this.data,
-  });
+  AWSClusterCertificateAuthority({required this.data});
 
-  factory AWSClusterCertificateAuthority.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory AWSClusterCertificateAuthority.fromJson(Map<String, dynamic> data) {
     return AWSClusterCertificateAuthority(
       data: data.containsKey('Data') ? data['Data'] : null,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'Data': data,
-    };
+    return {'Data': data};
   }
 }
 
@@ -105,29 +98,23 @@ class AWSSSOConfig {
   AWSSSOConfigClient? client;
   AWSSSOConfigDevice? device;
 
-  AWSSSOConfig({
-    required this.client,
-    required this.device,
-  });
+  AWSSSOConfig({required this.client, required this.device});
 
-  factory AWSSSOConfig.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory AWSSSOConfig.fromJson(Map<String, dynamic> data) {
     return AWSSSOConfig(
-      client: data.containsKey('client') && data['client'] != null
-          ? AWSSSOConfigClient.fromJson(data['client'])
-          : null,
-      device: data.containsKey('device') && data['device'] != null
-          ? AWSSSOConfigDevice.fromJson(data['device'])
-          : null,
+      client:
+          data.containsKey('client') && data['client'] != null
+              ? AWSSSOConfigClient.fromJson(data['client'])
+              : null,
+      device:
+          data.containsKey('device') && data['device'] != null
+              ? AWSSSOConfigDevice.fromJson(data['device'])
+              : null,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'client': client?.toJson(),
-      'device': device?.toJson(),
-    };
+    return {'client': client?.toJson(), 'device': device?.toJson()};
   }
 }
 
@@ -150,14 +137,16 @@ class AWSSSOConfigClient {
   factory AWSSSOConfigClient.fromJson(Map<String, dynamic> data) {
     return AWSSSOConfigClient(
       clientId: data.containsKey('ClientId') ? data['ClientId'] : null,
-      clientIdIssuedAt: data.containsKey('ClientIdIssuedAt')
-          ? data['ClientIdIssuedAt']
-          : null,
+      clientIdIssuedAt:
+          data.containsKey('ClientIdIssuedAt')
+              ? data['ClientIdIssuedAt']
+              : null,
       clientSecret:
           data.containsKey('ClientSecret') ? data['ClientSecret'] : null,
-      clientSecretExpiresAt: data.containsKey('ClientSecretExpiresAt')
-          ? data['ClientSecretExpiresAt']
-          : null,
+      clientSecretExpiresAt:
+          data.containsKey('ClientSecretExpiresAt')
+              ? data['ClientSecretExpiresAt']
+              : null,
     );
   }
 
@@ -199,9 +188,10 @@ class AWSSSOConfigDevice {
       userCode: data.containsKey('UserCode') ? data['UserCode'] : null,
       verificationUri:
           data.containsKey('VerificationUri') ? data['VerificationUri'] : null,
-      verificationUriComplete: data.containsKey('VerificationUriComplete')
-          ? data['VerificationUriComplete']
-          : null,
+      verificationUriComplete:
+          data.containsKey('VerificationUriComplete')
+              ? data['VerificationUriComplete']
+              : null,
     );
   }
 
@@ -245,9 +235,10 @@ class AWSSSOCredentials {
           data.containsKey('sessionToken') ? data['sessionToken'] : null,
       expire: data.containsKey('expire') ? data['expire'] : null,
       accessToken: data.containsKey('accessToken') ? data['accessToken'] : null,
-      accessTokenExpire: data.containsKey('accessTokenExpire')
-          ? data['accessTokenExpire']
-          : null,
+      accessTokenExpire:
+          data.containsKey('accessTokenExpire')
+              ? data['accessTokenExpire']
+              : null,
     );
   }
 
@@ -284,13 +275,15 @@ class AWSSSOAccount {
     return AWSSSOAccount(
       accountId: data.containsKey('accountId') ? data['accountId'] : null,
       accountName: data.containsKey('accountName') ? data['accountName'] : null,
-      roles: data.containsKey('roles')
-          ? List<String>.from(data['roles'].map((v) => v))
-          : null,
+      roles:
+          data.containsKey('roles')
+              ? List<String>.from(data['roles'].map((v) => v))
+              : null,
       accessToken: data.containsKey('accessToken') ? data['accessToken'] : null,
-      accessTokenExpire: data.containsKey('accessTokenExpire')
-          ? data['accessTokenExpire']
-          : null,
+      accessTokenExpire:
+          data.containsKey('accessTokenExpire')
+              ? data['accessTokenExpire']
+              : null,
     );
   }
 
@@ -321,22 +314,20 @@ class AWSService {
     String roleArn,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'awsGetClusters',
-        <String, dynamic>{
-          'accessKeyID': accessKeyID,
-          'secretKey': secretKey,
-          'region': region,
-          'sessionToken': sessionToken,
-          'roleArn': roleArn,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('awsGetClusters', <String, dynamic>{
+            'accessKeyID': accessKeyID,
+            'secretKey': secretKey,
+            'region': region,
+            'sessionToken': sessionToken,
+            'roleArn': roleArn,
+          });
 
-      Logger.log(
-        'AWSService getClusters',
-        'Clusters Returned',
-        result,
-      );
+      Logger.log('AWSService getClusters', 'Clusters Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       List<dynamic> tmpClusters = json.decode(result);
       List<AWSCluster> clusters = [];
@@ -345,11 +336,7 @@ class AWSService {
       }
       return clusters;
     } catch (err) {
-      Logger.log(
-        'AWSService getClusters',
-        'Failed to Get AWS Clusters',
-        err,
-      );
+      Logger.log('AWSService getClusters', 'Failed to Get AWS Clusters', err);
       rethrow;
     }
   }
@@ -365,64 +352,49 @@ class AWSService {
     String clusterID,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'awsGetToken',
-        <String, dynamic>{
-          'accessKeyID': accessKeyID,
-          'secretKey': secretKey,
-          'region': region,
-          'sessionToken': sessionToken,
-          'roleArn': roleArn,
-          'clusterID': clusterID,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('awsGetToken', <String, dynamic>{
+            'accessKeyID': accessKeyID,
+            'secretKey': secretKey,
+            'region': region,
+            'sessionToken': sessionToken,
+            'roleArn': roleArn,
+            'clusterID': clusterID,
+          });
 
-      Logger.log(
-        'AWSService getToken',
-        'New Access Token Returned',
-        result,
-      );
+      Logger.log('AWSService getToken', 'New Access Token Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       return result;
     } catch (err) {
-      Logger.log(
-        'AWSService getToken',
-        'Failed to Get Access Token',
-        err,
-      );
+      Logger.log('AWSService getToken', 'Failed to Get Access Token', err);
       rethrow;
     }
   }
 
   /// [getSSOConfig] can be used to get the sso config which can be used with
   /// the AWS SSO provider.
-  Future<AWSSSOConfig> getSSOConfig(
-    String ssoRegion,
-    String startURL,
-  ) async {
+  Future<AWSSSOConfig> getSSOConfig(String ssoRegion, String startURL) async {
     try {
       final String result = await platform.invokeMethod(
         'awsGetSSOConfig',
-        <String, dynamic>{
-          'ssoRegion': ssoRegion,
-          'startURL': startURL,
-        },
+        <String, dynamic>{'ssoRegion': ssoRegion, 'startURL': startURL},
       );
 
-      Logger.log(
-        'AWSService getSSOConfig',
-        'SSO Config Returned',
-        result,
-      );
+      Logger.log('AWSService getSSOConfig', 'SSO Config Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       Map<String, dynamic> jsonData = json.decode(result);
       AWSSSOConfig tmpSSOConfig = AWSSSOConfig.fromJson(jsonData);
       return tmpSSOConfig;
     } catch (err) {
-      Logger.log(
-        'AWSService getSSOConfig',
-        'Failed to Get SSO Config',
-        err,
-      );
+      Logger.log('AWSService getSSOConfig', 'Failed to Get SSO Config', err);
       rethrow;
     }
   }
@@ -439,36 +411,31 @@ class AWSService {
     int accessTokenExpire,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'awsGetSSOToken',
-        <String, dynamic>{
-          'accountID': accountID,
-          'roleName': roleName,
-          'ssoRegion': ssoRegion,
-          'ssoClientID': ssoClientID,
-          'ssoClientSecret': ssoClientSecret,
-          'ssoDeviceCode': ssoDeviceCode,
-          'accessToken': accessToken,
-          'accessTokenExpire': accessTokenExpire,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('awsGetSSOToken', <String, dynamic>{
+            'accountID': accountID,
+            'roleName': roleName,
+            'ssoRegion': ssoRegion,
+            'ssoClientID': ssoClientID,
+            'ssoClientSecret': ssoClientSecret,
+            'ssoDeviceCode': ssoDeviceCode,
+            'accessToken': accessToken,
+            'accessTokenExpire': accessTokenExpire,
+          });
 
-      Logger.log(
-        'AWSService getSSOToken',
-        'SSO Token Returned',
-        result,
-      );
+      Logger.log('AWSService getSSOToken', 'SSO Token Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       Map<String, dynamic> jsonData = json.decode(result);
-      AWSSSOCredentials tmpSSOCredentials =
-          AWSSSOCredentials.fromJson(jsonData);
+      AWSSSOCredentials tmpSSOCredentials = AWSSSOCredentials.fromJson(
+        jsonData,
+      );
       return tmpSSOCredentials;
     } catch (err) {
-      Logger.log(
-        'AWSService getSSOToken',
-        'Failed to Get SSO Token',
-        err,
-      );
+      Logger.log('AWSService getSSOToken', 'Failed to Get SSO Token', err);
       rethrow;
     }
   }
@@ -482,21 +449,19 @@ class AWSService {
     String ssoDeviceCode,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'awsGetSSOAccounts',
-        <String, dynamic>{
-          'ssoRegion': ssoRegion,
-          'ssoClientID': ssoClientID,
-          'ssoClientSecret': ssoClientSecret,
-          'ssoDeviceCode': ssoDeviceCode,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('awsGetSSOAccounts', <String, dynamic>{
+            'ssoRegion': ssoRegion,
+            'ssoClientID': ssoClientID,
+            'ssoClientSecret': ssoClientSecret,
+            'ssoDeviceCode': ssoDeviceCode,
+          });
 
-      Logger.log(
-        'AWSService getSSOAccounts',
-        'Accounts Returned',
-        result,
-      );
+      Logger.log('AWSService getSSOAccounts', 'Accounts Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       List<dynamic> jsonData = json.decode(result);
       final accounts = <AWSSSOAccount>[];

--- a/lib/services/providers/azure_service.dart
+++ b/lib/services/providers/azure_service.dart
@@ -12,27 +12,20 @@ class AzureCluster {
   String? name;
   Kubeconfig? kubeconfig;
 
-  AzureCluster({
-    required this.name,
-    required this.kubeconfig,
-  });
+  AzureCluster({required this.name, required this.kubeconfig});
 
-  factory AzureCluster.fromJson(
-    Map<String, dynamic> data,
-  ) {
+  factory AzureCluster.fromJson(Map<String, dynamic> data) {
     return AzureCluster(
       name: data.containsKey('name') ? data['name'] : null,
-      kubeconfig: data.containsKey('kubeconfig')
-          ? Kubeconfig.fromJson(data['kubeconfig'])
-          : null,
+      kubeconfig:
+          data.containsKey('kubeconfig')
+              ? Kubeconfig.fromJson(data['kubeconfig'])
+              : null,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'name': name,
-      'kubeconfig': kubeconfig?.toJson(),
-    };
+    return {'name': name, 'kubeconfig': kubeconfig?.toJson()};
   }
 }
 
@@ -52,22 +45,20 @@ class AzureService {
     bool isAdmin,
   ) async {
     try {
-      final String result = await platform.invokeMethod(
-        'azureGetClusters',
-        <String, dynamic>{
-          'subscriptionID': subscriptionID,
-          'tenantID': tenantID,
-          'clientID': clientID,
-          'clientSecret': clientSecret,
-          'isAdmin': isAdmin,
-        },
-      );
+      final String result = await platform
+          .invokeMethod('azureGetClusters', <String, dynamic>{
+            'subscriptionID': subscriptionID,
+            'tenantID': tenantID,
+            'clientID': clientID,
+            'clientSecret': clientSecret,
+            'isAdmin': isAdmin,
+          });
 
-      Logger.log(
-        'AzureService getClusters',
-        'Clusters Returned',
-        result,
-      );
+      Logger.log('AzureService getClusters', 'Clusters Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       List<dynamic> tmpClusters = json.decode(result);
       List<AzureCluster> clusters = [];

--- a/lib/services/providers/oidc_service.dart
+++ b/lib/services/providers/oidc_service.dart
@@ -150,6 +150,10 @@ class OIDCService {
 
       Logger.log('OIDCService getLink', 'Link was generated', result);
 
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);
     } catch (err) {
@@ -195,6 +199,10 @@ class OIDCService {
         result,
       );
 
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);
     } catch (err) {
@@ -236,6 +244,10 @@ class OIDCService {
 
       Logger.log('OIDCService getAccessToken', 'Access Token Returned', result);
 
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
+
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);
     } catch (err) {
@@ -271,6 +283,10 @@ class OIDCService {
           });
 
       Logger.log('OIDCService deviceAuth', 'Device Auth Data Returned', result);
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCDeviceAuth.fromJson(jsonData);
@@ -314,6 +330,10 @@ class OIDCService {
         'Refresh Token Returned',
         result,
       );
+
+      if (result.isEmpty) {
+        throw Exception('An unknown error occured');
+      }
 
       Map<String, dynamic> jsonData = json.decode(result);
       return OIDCResponse.fromJson(jsonData);


### PR DESCRIPTION
This is a follow up PR for #780, which didn"t resolved #776. Because it
is still not clear where the app crashes exactly when a broken
Kubeconfig is used, we now catch the panics in all called Go functions
and check if the result is empty in the Dart code to return an "Unknown
Error" error message.

If this still doesn't solve the issue, the error might be within the
Dart code. I have no idea where an error can happen there which crashes
the app.

We can also try to provide a entrypoint for the app which can be used to
delete the whole cluster and provider configuration.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
