### PR TITLE
Fix Typo in `normalTextStyle` Function Name

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -9,8 +9,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:kubenav/utils/constants.dart';
 import 'package:kubenav/utils/themes.dart';
 
-/// [noramlTextStyle] applies our default styles for normal text.
-TextStyle noramlTextStyle(
+/// [normalTextStyle] applies our default styles for normal text.
+TextStyle normalTextStyle(
   BuildContext context, {
   double? size,
   Color? color,
@@ -61,10 +61,7 @@ Future<void> openUrl(String url) async {
     launchMode = LaunchMode.externalApplication;
   }
 
-  await launchUrl(
-    Uri.parse(url),
-    mode: launchMode,
-  );
+  await launchUrl(Uri.parse(url), mode: launchMode);
 }
 
 String getMonospaceFontFamily() {

--- a/lib/widgets/home/home_clusters.dart
+++ b/lib/widgets/home/home_clusters.dart
@@ -47,43 +47,39 @@ class _HomeClustersState extends State<HomeClusters> {
     );
 
     return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text('Select Cluster'),
-      ),
+      appBar: AppBar(centerTitle: true, title: const Text('Select Cluster')),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(Constants.spacingMiddle),
           child: ListView.separated(
-            separatorBuilder: (context, index) => const SizedBox(
-              height: Constants.spacingMiddle,
-            ),
+            separatorBuilder:
+                (context, index) =>
+                    const SizedBox(height: Constants.spacingMiddle),
             itemCount: clustersRepository.clusters.length,
-            itemBuilder: (context, index) => AppListItem(
-              onTap: () {
-                _setActiveCluster(clustersRepository.clusters[index].id);
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.radio_button_unchecked,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      clustersRepository.clusters[index].name,
-                      style: noramlTextStyle(
-                        context,
+            itemBuilder:
+                (context, index) => AppListItem(
+                  onTap: () {
+                    _setActiveCluster(clustersRepository.clusters[index].id);
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.radio_button_unchecked,
+                        size: 24,
+                        color: Theme.of(context).colorScheme.primary,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          clustersRepository.clusters[index].name,
+                          style: normalTextStyle(context),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
+                ),
           ),
         ),
       ),

--- a/lib/widgets/home/overview/overview_metric.dart
+++ b/lib/widgets/home/overview/overview_metric.dart
@@ -39,11 +39,7 @@ const texts = {
 /// [MetricType] is our enum value, which is used to specify which metrics we
 /// want to show in the bottom sheet. The possible values are [cpu], [memory]
 /// and [pods].
-enum MetricType {
-  cpu,
-  memory,
-  pods,
-}
+enum MetricType { cpu, memory, pods }
 
 /// The [Metric] model is used to represent all metrics for a [MetricType]. We
 /// collect the [allocatable], [usage], [requests] and [limits] for each
@@ -68,9 +64,7 @@ class Metric {
 class Metrics {
   Map<MetricType, Metric> metrics;
 
-  Metrics({
-    required this.metrics,
-  });
+  Metrics({required this.metrics});
 
   Metric getMetric(MetricType metric) {
     return metrics[metric]!;
@@ -78,13 +72,9 @@ class Metrics {
 }
 
 Metrics _getMetrics(List<String> results) {
-  final nodesList = IoK8sApiCoreV1NodeList.fromJson(
-    json.decode(results[0]),
-  );
+  final nodesList = IoK8sApiCoreV1NodeList.fromJson(json.decode(results[0]));
 
-  final podsList = IoK8sApiCoreV1PodList.fromJson(
-    json.decode(results[1]),
-  );
+  final podsList = IoK8sApiCoreV1PodList.fromJson(json.decode(results[1]));
 
   final nodeMetricsList = ApisMetricsV1beta1NodeMetricsList.fromJson(
     json.decode(results[2]),
@@ -106,13 +96,15 @@ Metrics _getMetrics(List<String> results) {
   if (nodesList != null && podsList != null && nodeMetricsList.items != null) {
     for (var node in nodesList.items) {
       if (node.status != null && node.status!.allocatable.containsKey('cpu')) {
-        cpuAllocatable = cpuAllocatable +
+        cpuAllocatable =
+            cpuAllocatable +
             cpuMetricsStringToDouble(node.status!.allocatable['cpu']!);
       }
 
       if (node.status != null &&
           node.status!.allocatable.containsKey('memory')) {
-        memoryAllocatable = memoryAllocatable +
+        memoryAllocatable =
+            memoryAllocatable +
             memoryMetricsStringToDouble(node.status!.allocatable['memory']!);
       }
 
@@ -140,15 +132,15 @@ Metrics _getMetrics(List<String> results) {
         for (var container in pod.spec!.containers) {
           if (container.resources != null &&
               container.resources!.requests.containsKey('cpu')) {
-            cpuRequests = cpuRequests +
-                cpuMetricsStringToDouble(
-                  container.resources!.requests['cpu']!,
-                );
+            cpuRequests =
+                cpuRequests +
+                cpuMetricsStringToDouble(container.resources!.requests['cpu']!);
           }
 
           if (container.resources != null &&
               container.resources!.requests.containsKey('memory')) {
-            memoryRequests = memoryRequests +
+            memoryRequests =
+                memoryRequests +
                 memoryMetricsStringToDouble(
                   container.resources!.requests['memory']!,
                 );
@@ -156,13 +148,15 @@ Metrics _getMetrics(List<String> results) {
 
           if (container.resources != null &&
               container.resources!.limits.containsKey('cpu')) {
-            cpuLimits = cpuLimits +
+            cpuLimits =
+                cpuLimits +
                 cpuMetricsStringToDouble(container.resources!.limits['cpu']!);
           }
 
           if (container.resources != null &&
               container.resources!.limits.containsKey('memory')) {
-            memoryLimits = memoryLimits +
+            memoryLimits =
+                memoryLimits +
                 memoryMetricsStringToDouble(
                   container.resources!.limits['memory']!,
                 );
@@ -305,9 +299,7 @@ class _OverviewMetricState extends State<OverviewMetric> {
             toY: data.metrics[widget.metricType]!.allocatable.toDouble(),
             color: Theme.of(context).colorScheme.primary,
             width: 25,
-            borderRadius: const BorderRadius.all(
-              Radius.zero,
-            ),
+            borderRadius: const BorderRadius.all(Radius.zero),
           ),
         ],
       ),
@@ -318,45 +310,37 @@ class _OverviewMetricState extends State<OverviewMetric> {
             toY: data.metrics[widget.metricType]!.usage.toDouble(),
             color: Theme.of(context).colorScheme.primary,
             width: 25,
-            borderRadius: const BorderRadius.all(
-              Radius.zero,
-            ),
+            borderRadius: const BorderRadius.all(Radius.zero),
           ),
         ],
       ),
     ];
 
     if (widget.metricType != MetricType.pods) {
-      barGroups.addAll(
-        [
-          BarChartGroupData(
-            x: 2,
-            barRods: [
-              BarChartRodData(
-                toY: data.metrics[widget.metricType]!.requests.toDouble(),
-                color: Theme.of(context).colorScheme.primary,
-                width: 25,
-                borderRadius: const BorderRadius.all(
-                  Radius.zero,
-                ),
-              ),
-            ],
-          ),
-          BarChartGroupData(
-            x: 3,
-            barRods: [
-              BarChartRodData(
-                toY: data.metrics[widget.metricType]!.limits.toDouble(),
-                color: Theme.of(context).colorScheme.primary,
-                width: 25,
-                borderRadius: const BorderRadius.all(
-                  Radius.zero,
-                ),
-              ),
-            ],
-          ),
-        ],
-      );
+      barGroups.addAll([
+        BarChartGroupData(
+          x: 2,
+          barRods: [
+            BarChartRodData(
+              toY: data.metrics[widget.metricType]!.requests.toDouble(),
+              color: Theme.of(context).colorScheme.primary,
+              width: 25,
+              borderRadius: const BorderRadius.all(Radius.zero),
+            ),
+          ],
+        ),
+        BarChartGroupData(
+          x: 3,
+          barRods: [
+            BarChartRodData(
+              toY: data.metrics[widget.metricType]!.limits.toDouble(),
+              color: Theme.of(context).colorScheme.primary,
+              width: 25,
+              borderRadius: const BorderRadius.all(Radius.zero),
+            ),
+          ],
+        ),
+      ]);
     }
 
     return barGroups;
@@ -373,18 +357,11 @@ class _OverviewMetricState extends State<OverviewMetric> {
         children: [
           Text(
             'Allocatable',
-            style: noramlTextStyle(
-              context,
-              size: Constants.sizeTextSecondary,
-            ),
+            style: normalTextStyle(context, size: Constants.sizeTextSecondary),
           ),
           Text(
-            formatValue(
-              data.metrics[widget.metricType]!.allocatable,
-            ),
-            style: secondaryTextStyle(
-              context,
-            ),
+            formatValue(data.metrics[widget.metricType]!.allocatable),
+            style: secondaryTextStyle(context),
           ),
         ],
       ),
@@ -393,68 +370,51 @@ class _OverviewMetricState extends State<OverviewMetric> {
         children: [
           Text(
             'Usage',
-            style: noramlTextStyle(
-              context,
-              size: Constants.sizeTextSecondary,
-            ),
+            style: normalTextStyle(context, size: Constants.sizeTextSecondary),
           ),
           Text(
-            formatValue(
-              data.metrics[widget.metricType]!.usage,
-            ),
-            style: secondaryTextStyle(
-              context,
-            ),
+            formatValue(data.metrics[widget.metricType]!.usage),
+            style: secondaryTextStyle(context),
           ),
         ],
       ),
     ];
 
     if (widget.metricType != MetricType.pods) {
-      legend.addAll(
-        [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Requests',
-                style: noramlTextStyle(
-                  context,
-                  size: Constants.sizeTextSecondary,
-                ),
+      legend.addAll([
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Requests',
+              style: normalTextStyle(
+                context,
+                size: Constants.sizeTextSecondary,
               ),
-              Text(
-                formatValue(
-                  data.metrics[widget.metricType]!.requests,
-                ),
-                style: secondaryTextStyle(
-                  context,
-                ),
+            ),
+            Text(
+              formatValue(data.metrics[widget.metricType]!.requests),
+              style: secondaryTextStyle(context),
+            ),
+          ],
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Limits',
+              style: normalTextStyle(
+                context,
+                size: Constants.sizeTextSecondary,
               ),
-            ],
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Limits',
-                style: noramlTextStyle(
-                  context,
-                  size: Constants.sizeTextSecondary,
-                ),
-              ),
-              Text(
-                formatValue(
-                  data.metrics[widget.metricType]!.limits,
-                ),
-                style: secondaryTextStyle(
-                  context,
-                ),
-              ),
-            ],
-          ),
-        ],
-      );
+            ),
+            Text(
+              formatValue(data.metrics[widget.metricType]!.limits),
+              style: secondaryTextStyle(context),
+            ),
+          ],
+        ),
+      ]);
     }
 
     return legend;
@@ -462,10 +422,7 @@ class _OverviewMetricState extends State<OverviewMetric> {
 
   @override
   Widget build(BuildContext context) {
-    Provider.of<ClustersRepository>(
-      context,
-      listen: true,
-    );
+    Provider.of<ClustersRepository>(context, listen: true);
 
     return AppBottomSheetWidget(
       title: texts[widget.metricType]!['title']!,
@@ -489,10 +446,7 @@ class _OverviewMetricState extends State<OverviewMetric> {
           ),
           child: FutureBuilder(
             future: _futureFetchMetrics,
-            builder: (
-              BuildContext context,
-              AsyncSnapshot<Metrics> snapshot,
-            ) {
+            builder: (BuildContext context, AsyncSnapshot<Metrics> snapshot) {
               switch (snapshot.connectionState) {
                 case ConnectionState.none:
                 case ConnectionState.waiting:
@@ -515,9 +469,10 @@ class _OverviewMetricState extends State<OverviewMetric> {
                     decoration: BoxDecoration(
                       boxShadow: [
                         BoxShadow(
-                          color: Theme.of(context)
-                              .extension<CustomColors>()!
-                              .shadow,
+                          color:
+                              Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.shadow,
                           blurRadius: Constants.sizeBorderBlurRadius,
                           spreadRadius: Constants.sizeBorderSpreadRadius,
                           offset: const Offset(0.0, 0.0),
@@ -541,12 +496,16 @@ class _OverviewMetricState extends State<OverviewMetric> {
                                   fitInsideHorizontally: true,
                                   fitInsideVertically: true,
                                   getTooltipColor: (BarChartGroupData group) {
-                                    return Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .message;
+                                    return Theme.of(
+                                      context,
+                                    ).extension<CustomColors>()!.message;
                                   },
-                                  getTooltipItem:
-                                      (group, groupIndex, rod, rodIndex) {
+                                  getTooltipItem: (
+                                    group,
+                                    groupIndex,
+                                    rod,
+                                    rodIndex,
+                                  ) {
                                     String label;
                                     switch (group.x.toInt()) {
                                       case 0:
@@ -568,9 +527,10 @@ class _OverviewMetricState extends State<OverviewMetric> {
                                     return BarTooltipItem(
                                       '$label\n',
                                       TextStyle(
-                                        color: Theme.of(context)
-                                            .extension<CustomColors>()!
-                                            .onMessage,
+                                        color:
+                                            Theme.of(context)
+                                                .extension<CustomColors>()!
+                                                .onMessage,
                                         fontWeight: FontWeight.normal,
                                         fontSize: 14,
                                       ),
@@ -578,9 +538,10 @@ class _OverviewMetricState extends State<OverviewMetric> {
                                         TextSpan(
                                           text: formatValue(rod.toY),
                                           style: TextStyle(
-                                            color: Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .onMessage,
+                                            color:
+                                                Theme.of(context)
+                                                    .extension<CustomColors>()!
+                                                    .onMessage,
                                             fontSize: 14,
                                             fontWeight: FontWeight.normal,
                                           ),
@@ -593,19 +554,13 @@ class _OverviewMetricState extends State<OverviewMetric> {
                               titlesData: FlTitlesData(
                                 show: true,
                                 rightTitles: const AxisTitles(
-                                  sideTitles: SideTitles(
-                                    showTitles: false,
-                                  ),
+                                  sideTitles: SideTitles(showTitles: false),
                                 ),
                                 topTitles: const AxisTitles(
-                                  sideTitles: SideTitles(
-                                    showTitles: false,
-                                  ),
+                                  sideTitles: SideTitles(showTitles: false),
                                 ),
                                 leftTitles: const AxisTitles(
-                                  sideTitles: SideTitles(
-                                    showTitles: false,
-                                  ),
+                                  sideTitles: SideTitles(showTitles: false),
                                 ),
                                 bottomTitles: AxisTitles(
                                   sideTitles: SideTitles(
@@ -627,9 +582,7 @@ class _OverviewMetricState extends State<OverviewMetric> {
                                         padding: const EdgeInsets.only(top: 16),
                                         child: Text(
                                           title,
-                                          style: secondaryTextStyle(
-                                            context,
-                                          ),
+                                          style: secondaryTextStyle(context),
                                           textDirection: TextDirection.rtl,
                                           textAlign: TextAlign.center,
                                         ),
@@ -643,18 +596,20 @@ class _OverviewMetricState extends State<OverviewMetric> {
                                 show: true,
                                 getDrawingHorizontalLine: (value) {
                                   return FlLine(
-                                    color: Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .textSecondary,
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textSecondary,
                                     strokeWidth: 0.4,
                                     dashArray: [8, 4],
                                   );
                                 },
                                 getDrawingVerticalLine: (value) {
                                   return FlLine(
-                                    color: Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .textSecondary,
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textSecondary,
                                     strokeWidth: 0.4,
                                     dashArray: [8, 4],
                                   );

--- a/lib/widgets/resources/actions/get_logs_pods.dart
+++ b/lib/widgets/resources/actions/get_logs_pods.dart
@@ -86,11 +86,7 @@ class _GetLogsPodsState extends State<GetLogsPods> {
         }
       });
     } catch (err) {
-      Logger.log(
-        'GetLogsPods _getPods',
-        'Could not get pods',
-        err,
-      );
+      Logger.log('GetLogsPods _getPods', 'Could not get pods', err);
       setState(() {
         _isLoading = false;
         _error = err.toString();
@@ -143,7 +139,8 @@ class _GetLogsPodsState extends State<GetLogsPods> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedPods
+            value:
+                _selectedPods
                     .where(
                       (p) => p.metadata?.name == _pods[index].metadata?.name,
                     )
@@ -158,11 +155,13 @@ class _GetLogsPodsState extends State<GetLogsPods> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedPods = _selectedPods
-                      .where(
-                        (p) => p.metadata?.name != _pods[index].metadata?.name,
-                      )
-                      .toList();
+                  _selectedPods =
+                      _selectedPods
+                          .where(
+                            (p) =>
+                                p.metadata?.name != _pods[index].metadata?.name,
+                          )
+                          .toList();
                 });
               }
             },
@@ -170,9 +169,7 @@ class _GetLogsPodsState extends State<GetLogsPods> {
               Characters(
                 _pods[index].metadata?.name ?? '',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/resources/actions/live_metrics.dart
+++ b/lib/widgets/resources/actions/live_metrics.dart
@@ -31,24 +31,10 @@ class ContainerMetric {
     required int initTime,
     required double initCPU,
     required double initMemory,
-  })  : cpu = [
-          FlSpot(
-            initTime.toDouble(),
-            initCPU,
-          ),
-        ],
-        memory = [
-          FlSpot(
-            initTime.toDouble(),
-            initMemory,
-          ),
-        ];
+  }) : cpu = [FlSpot(initTime.toDouble(), initCPU)],
+       memory = [FlSpot(initTime.toDouble(), initMemory)];
 
-  void add(
-    int newTime,
-    double newCPU,
-    double newMemory,
-  ) {
+  void add(int newTime, double newCPU, double newMemory) {
     if (cpu.length > 25 || memory.length > 25) {
       cpu.removeAt(0);
       memory.removeAt(0);
@@ -92,29 +78,34 @@ PodResourceForLiveMetrics? getResourcesForLiveMetrics(
         if (selectedContainer == '' ||
             selectedContainer == pod.spec!.containers[i].name) {
           if (pod.spec!.containers[i].resources!.requests.containsKey('cpu')) {
-            cpuRequests = cpuRequests +
+            cpuRequests =
+                cpuRequests +
                 cpuMetricsStringToDouble(
                   pod.spec!.containers[i].resources!.requests['cpu']!,
                 );
           }
 
-          if (pod.spec!.containers[i].resources!.requests
-              .containsKey('memory')) {
-            memoryRequests = memoryRequests +
+          if (pod.spec!.containers[i].resources!.requests.containsKey(
+            'memory',
+          )) {
+            memoryRequests =
+                memoryRequests +
                 memoryMetricsStringToDouble(
                   pod.spec!.containers[i].resources!.requests['memory']!,
                 );
           }
 
           if (pod.spec!.containers[i].resources!.limits.containsKey('cpu')) {
-            cpuLimits = cpuLimits +
+            cpuLimits =
+                cpuLimits +
                 cpuMetricsStringToDouble(
                   pod.spec!.containers[i].resources!.limits['cpu']!,
                 );
           }
 
           if (pod.spec!.containers[i].resources!.limits.containsKey('memory')) {
-            memoryLimits = memoryLimits +
+            memoryLimits =
+                memoryLimits +
                 memoryMetricsStringToDouble(
                   pod.spec!.containers[i].resources!.limits['memory']!,
                 );
@@ -215,21 +206,15 @@ class _LiveMetricsState extends State<LiveMetrics> {
                 setState(() {
                   _containerMetrics[container.name]!.add(
                     DateTime.now().millisecondsSinceEpoch,
-                    cpuMetricsStringToDouble(
-                      container.usage!.cpu!,
-                    ),
-                    memoryMetricsStringToDouble(
-                      container.usage!.memory!,
-                    ),
+                    cpuMetricsStringToDouble(container.usage!.cpu!),
+                    memoryMetricsStringToDouble(container.usage!.memory!),
                   );
                 });
               } else {
                 setState(() {
                   _containerMetrics[container.name!] = ContainerMetric(
                     initTime: DateTime.now().millisecondsSinceEpoch,
-                    initCPU: cpuMetricsStringToDouble(
-                      container.usage!.cpu!,
-                    ),
+                    initCPU: cpuMetricsStringToDouble(container.usage!.cpu!),
                     initMemory: memoryMetricsStringToDouble(
                       container.usage!.memory!,
                     ),
@@ -349,10 +334,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                     ),
                     color: Theme.of(context).colorScheme.primary,
                   ),
-                  tabs: const [
-                    Tab(text: 'CPU'),
-                    Tab(text: 'Memory'),
-                  ],
+                  tabs: const [Tab(text: 'CPU'), Tab(text: 'Memory')],
                 ),
               ),
             ),
@@ -372,9 +354,10 @@ class _LiveMetricsState extends State<LiveMetrics> {
                       decoration: BoxDecoration(
                         boxShadow: [
                           BoxShadow(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .shadow,
+                            color:
+                                Theme.of(
+                                  context,
+                                ).extension<CustomColors>()!.shadow,
                             blurRadius: Constants.sizeBorderBlurRadius,
                             spreadRadius: Constants.sizeBorderSpreadRadius,
                             offset: const Offset(0.0, 0.0),
@@ -402,19 +385,21 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                     maxContentWidth:
                                         MediaQuery.of(context).size.width,
                                     getTooltipColor: (LineBarSpot touchedSpot) {
-                                      return Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .message;
+                                      return Theme.of(
+                                        context,
+                                      ).extension<CustomColors>()!.message;
                                     },
                                     getTooltipItems: (touchedSpots) {
-                                      return touchedSpots
-                                          .map((LineBarSpot touchedSpot) {
+                                      return touchedSpots.map((
+                                        LineBarSpot touchedSpot,
+                                      ) {
                                         return LineTooltipItem(
                                           '${_containerMetrics.keys.elementAt(touchedSpot.barIndex)}: ${touchedSpot.y > 1000000000 ? formatCpuMetric(touchedSpot.y) : formatCpuMetric(touchedSpot.y, 0)}',
                                           TextStyle(
-                                            color: Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .onMessage,
+                                            color:
+                                                Theme.of(context)
+                                                    .extension<CustomColors>()!
+                                                    .onMessage,
                                             fontWeight: FontWeight.normal,
                                             fontSize: 14,
                                           ),
@@ -424,40 +409,42 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   ),
                                 ),
                                 clipData: const FlClipData.all(),
-                                lineBarsData: _containerMetrics.entries
-                                    .map(
-                                      (e) => LineChartBarData(
-                                        spots: e.value.cpu,
-                                        dotData: const FlDotData(
-                                          show: false,
-                                        ),
-                                        color: e.key == 'Requests'
-                                            ? Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .warning
-                                            : e.key == 'Limits'
-                                                ? Theme.of(context)
-                                                    .extension<CustomColors>()!
-                                                    .error
-                                                : Theme.of(context)
-                                                    .colorScheme
-                                                    .primary,
-                                        barWidth: 4,
-                                        isCurved: false,
-                                      ),
-                                    )
-                                    .toList(),
+                                lineBarsData:
+                                    _containerMetrics.entries
+                                        .map(
+                                          (e) => LineChartBarData(
+                                            spots: e.value.cpu,
+                                            dotData: const FlDotData(
+                                              show: false,
+                                            ),
+                                            color:
+                                                e.key == 'Requests'
+                                                    ? Theme.of(context)
+                                                        .extension<
+                                                          CustomColors
+                                                        >()!
+                                                        .warning
+                                                    : e.key == 'Limits'
+                                                    ? Theme.of(context)
+                                                        .extension<
+                                                          CustomColors
+                                                        >()!
+                                                        .error
+                                                    : Theme.of(
+                                                      context,
+                                                    ).colorScheme.primary,
+                                            barWidth: 4,
+                                            isCurved: false,
+                                          ),
+                                        )
+                                        .toList(),
                                 titlesData: FlTitlesData(
                                   show: true,
                                   rightTitles: const AxisTitles(
-                                    sideTitles: SideTitles(
-                                      showTitles: false,
-                                    ),
+                                    sideTitles: SideTitles(showTitles: false),
                                   ),
                                   topTitles: const AxisTitles(
-                                    sideTitles: SideTitles(
-                                      showTitles: false,
-                                    ),
+                                    sideTitles: SideTitles(showTitles: false),
                                   ),
                                   leftTitles: AxisTitles(
                                     sideTitles: SideTitles(
@@ -471,9 +458,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           value > 1000000000
                                               ? formatCpuMetric(value)
                                               : formatCpuMetric(value, 0),
-                                          style: secondaryTextStyle(
-                                            context,
-                                          ),
+                                          style: secondaryTextStyle(context),
                                         );
                                       },
                                     ),
@@ -486,8 +471,8 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                       getTitlesWidget: (value, titleMeta) {
                                         final timestamp =
                                             DateTime.fromMillisecondsSinceEpoch(
-                                          value.round(),
-                                        );
+                                              value.round(),
+                                            );
 
                                         return Container(
                                           padding: const EdgeInsets.only(
@@ -496,9 +481,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           ),
                                           child: Text(
                                             '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}:${timestamp.second.toString().padLeft(2, '0')}',
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
+                                            style: secondaryTextStyle(context),
                                           ),
                                         );
                                       },
@@ -510,18 +493,20 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   show: true,
                                   getDrawingHorizontalLine: (value) {
                                     return FlLine(
-                                      color: Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .textSecondary,
+                                      color:
+                                          Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .textSecondary,
                                       strokeWidth: 0.4,
                                       dashArray: [8, 4],
                                     );
                                   },
                                   getDrawingVerticalLine: (value) {
                                     return FlLine(
-                                      color: Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .textSecondary,
+                                      color:
+                                          Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .textSecondary,
                                       strokeWidth: 0.4,
                                       dashArray: [8, 4],
                                     );
@@ -530,9 +515,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                               ),
                             ),
                           ),
-                          const SizedBox(
-                            height: Constants.spacingMiddle,
-                          ),
+                          const SizedBox(height: Constants.spacingMiddle),
                           ..._containerMetrics.entries.map(
                             (e) => Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -545,7 +528,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           Characters('\u{200B}'),
                                         )
                                         .toString(),
-                                    style: noramlTextStyle(
+                                    style: normalTextStyle(
                                       context,
                                       size: Constants.sizeTextSecondary,
                                     ),
@@ -557,9 +540,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                     e.value.cpu[e.value.cpu.length - 1].y
                                         .toDouble(),
                                   ),
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
+                                  style: secondaryTextStyle(context),
                                 ),
                               ],
                             ),
@@ -581,9 +562,10 @@ class _LiveMetricsState extends State<LiveMetrics> {
                       decoration: BoxDecoration(
                         boxShadow: [
                           BoxShadow(
-                            color: Theme.of(context)
-                                .extension<CustomColors>()!
-                                .shadow,
+                            color:
+                                Theme.of(
+                                  context,
+                                ).extension<CustomColors>()!.shadow,
                             blurRadius: Constants.sizeBorderBlurRadius,
                             spreadRadius: Constants.sizeBorderSpreadRadius,
                             offset: const Offset(0.0, 0.0),
@@ -611,19 +593,21 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                     maxContentWidth:
                                         MediaQuery.of(context).size.width,
                                     getTooltipColor: (LineBarSpot touchedSpot) {
-                                      return Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .message;
+                                      return Theme.of(
+                                        context,
+                                      ).extension<CustomColors>()!.message;
                                     },
                                     getTooltipItems: (touchedSpots) {
-                                      return touchedSpots
-                                          .map((LineBarSpot touchedSpot) {
+                                      return touchedSpots.map((
+                                        LineBarSpot touchedSpot,
+                                      ) {
                                         return LineTooltipItem(
                                           '${_containerMetrics.keys.elementAt(touchedSpot.barIndex)}: ${touchedSpot.y > 1048576 ? formatMemoryMetric(touchedSpot.y, 2) : formatMemoryMetric(touchedSpot.y, 0)}',
                                           TextStyle(
-                                            color: Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .onMessage,
+                                            color:
+                                                Theme.of(context)
+                                                    .extension<CustomColors>()!
+                                                    .onMessage,
                                             fontWeight: FontWeight.normal,
                                             fontSize: 14,
                                           ),
@@ -633,40 +617,42 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   ),
                                 ),
                                 clipData: const FlClipData.all(),
-                                lineBarsData: _containerMetrics.entries
-                                    .map(
-                                      (e) => LineChartBarData(
-                                        spots: e.value.memory,
-                                        dotData: const FlDotData(
-                                          show: false,
-                                        ),
-                                        color: e.key == 'Requests'
-                                            ? Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .warning
-                                            : e.key == 'Limits'
-                                                ? Theme.of(context)
-                                                    .extension<CustomColors>()!
-                                                    .error
-                                                : Theme.of(context)
-                                                    .colorScheme
-                                                    .primary,
-                                        barWidth: 4,
-                                        isCurved: false,
-                                      ),
-                                    )
-                                    .toList(),
+                                lineBarsData:
+                                    _containerMetrics.entries
+                                        .map(
+                                          (e) => LineChartBarData(
+                                            spots: e.value.memory,
+                                            dotData: const FlDotData(
+                                              show: false,
+                                            ),
+                                            color:
+                                                e.key == 'Requests'
+                                                    ? Theme.of(context)
+                                                        .extension<
+                                                          CustomColors
+                                                        >()!
+                                                        .warning
+                                                    : e.key == 'Limits'
+                                                    ? Theme.of(context)
+                                                        .extension<
+                                                          CustomColors
+                                                        >()!
+                                                        .error
+                                                    : Theme.of(
+                                                      context,
+                                                    ).colorScheme.primary,
+                                            barWidth: 4,
+                                            isCurved: false,
+                                          ),
+                                        )
+                                        .toList(),
                                 titlesData: FlTitlesData(
                                   show: true,
                                   rightTitles: const AxisTitles(
-                                    sideTitles: SideTitles(
-                                      showTitles: false,
-                                    ),
+                                    sideTitles: SideTitles(showTitles: false),
                                   ),
                                   topTitles: const AxisTitles(
-                                    sideTitles: SideTitles(
-                                      showTitles: false,
-                                    ),
+                                    sideTitles: SideTitles(showTitles: false),
                                   ),
                                   leftTitles: AxisTitles(
                                     sideTitles: SideTitles(
@@ -680,9 +666,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           value > 1048576
                                               ? formatMemoryMetric(value, 2)
                                               : formatMemoryMetric(value, 0),
-                                          style: secondaryTextStyle(
-                                            context,
-                                          ),
+                                          style: secondaryTextStyle(context),
                                         );
                                       },
                                     ),
@@ -695,8 +679,8 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                       getTitlesWidget: (value, titleMeta) {
                                         final timestamp =
                                             DateTime.fromMillisecondsSinceEpoch(
-                                          value.round(),
-                                        );
+                                              value.round(),
+                                            );
 
                                         return Container(
                                           padding: const EdgeInsets.only(
@@ -705,9 +689,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           ),
                                           child: Text(
                                             '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}:${timestamp.second.toString().padLeft(2, '0')}',
-                                            style: secondaryTextStyle(
-                                              context,
-                                            ),
+                                            style: secondaryTextStyle(context),
                                           ),
                                         );
                                       },
@@ -719,18 +701,20 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                   show: true,
                                   getDrawingHorizontalLine: (value) {
                                     return FlLine(
-                                      color: Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .textSecondary,
+                                      color:
+                                          Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .textSecondary,
                                       strokeWidth: 0.4,
                                       dashArray: [8, 4],
                                     );
                                   },
                                   getDrawingVerticalLine: (value) {
                                     return FlLine(
-                                      color: Theme.of(context)
-                                          .extension<CustomColors>()!
-                                          .textSecondary,
+                                      color:
+                                          Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .textSecondary,
                                       strokeWidth: 0.4,
                                       dashArray: [8, 4],
                                     );
@@ -739,9 +723,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                               ),
                             ),
                           ),
-                          const SizedBox(
-                            height: Constants.spacingMiddle,
-                          ),
+                          const SizedBox(height: Constants.spacingMiddle),
                           ..._containerMetrics.entries.map(
                             (e) => Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -754,7 +736,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                           Characters('\u{200B}'),
                                         )
                                         .toString(),
-                                    style: noramlTextStyle(
+                                    style: normalTextStyle(
                                       context,
                                       size: Constants.sizeTextSecondary,
                                     ),
@@ -766,9 +748,7 @@ class _LiveMetricsState extends State<LiveMetrics> {
                                     e.value.memory[e.value.memory.length - 1].y
                                         .toDouble(),
                                   ),
-                                  style: secondaryTextStyle(
-                                    context,
-                                  ),
+                                  style: secondaryTextStyle(context),
                                 ),
                               ],
                             ),
@@ -809,9 +789,10 @@ class LiveMetricsContainers extends StatelessWidget {
       actions: List.generate(
         pod.spec != null ? pod.spec!.containers.length + 1 : 1,
         (index) => AppActionsWidgetAction(
-          title: index == pod.spec!.containers.length
-              ? 'All Containers'
-              : pod.spec?.containers[index].name ?? '',
+          title:
+              index == pod.spec!.containers.length
+                  ? 'All Containers'
+                  : pod.spec?.containers[index].name ?? '',
           color: Theme.of(context).colorScheme.primary,
           onTap: () {
             Navigator.pop(context);
@@ -821,9 +802,10 @@ class LiveMetricsContainers extends StatelessWidget {
                 name: name,
                 namespace: namespace,
                 pod: pod,
-                selectedContainer: index == pod.spec!.containers.length
-                    ? ''
-                    : pod.spec?.containers[index].name ?? '',
+                selectedContainer:
+                    index == pod.spec!.containers.length
+                        ? ''
+                        : pod.spec?.containers[index].name ?? '',
               ),
             );
           },

--- a/lib/widgets/resources/helpers/details_item_conditions.dart
+++ b/lib/widgets/resources/helpers/details_item_conditions.dart
@@ -10,10 +10,7 @@ import 'package:kubenav/widgets/shared/app_list_item.dart';
 /// The [DetailsItemConditions] widget is used to show the conditions of a
 /// Kubernetes resource.
 class DetailsItemConditions extends StatelessWidget {
-  const DetailsItemConditions({
-    super.key,
-    required this.conditions,
-  });
+  const DetailsItemConditions({super.key, required this.conditions});
 
   final List<IoK8sApimachineryPkgApisMetaV1Condition>? conditions;
 
@@ -24,9 +21,7 @@ class DetailsItemConditions extends StatelessWidget {
         children: [
           const SizedBox(height: Constants.spacingMiddle),
           Padding(
-            padding: const EdgeInsets.all(
-              Constants.spacingMiddle,
-            ),
+            padding: const EdgeInsets.all(Constants.spacingMiddle),
             child: Row(
               children: [
                 Expanded(
@@ -44,50 +39,45 @@ class DetailsItemConditions extends StatelessWidget {
               scrollDirection: Axis.horizontal,
               crossAxisCount: 2,
               childAspectRatio: 0.25,
-              children: List.generate(
-                conditions!.length,
-                (index) {
-                  return Container(
-                    margin: const EdgeInsets.only(
-                      top: Constants.spacingSmall,
-                      bottom: Constants.spacingSmall,
-                      left: Constants.spacingMiddle,
-                      right: Constants.spacingMiddle,
-                    ),
-                    child: AppListItem(
-                      onTap: () {
-                        showSnackbar(
-                          context,
-                          conditions![index].type,
-                          'Status: ${conditions![index].status}\nLast Transition Time: ${getAge(conditions![index].lastTransitionTime)}\nReason: ${conditions![index].reason}\nMessage: ${conditions![index].message}',
-                        );
-                      },
-                      child: Row(
-                        children: [
-                          Icon(
-                            conditions![index].status == 'True'
-                                ? Icons.radio_button_checked
-                                : Icons.radio_button_unchecked,
-                            size: 24,
-                            color: Theme.of(context).colorScheme.primary,
+              children: List.generate(conditions!.length, (index) {
+                return Container(
+                  margin: const EdgeInsets.only(
+                    top: Constants.spacingSmall,
+                    bottom: Constants.spacingSmall,
+                    left: Constants.spacingMiddle,
+                    right: Constants.spacingMiddle,
+                  ),
+                  child: AppListItem(
+                    onTap: () {
+                      showSnackbar(
+                        context,
+                        conditions![index].type,
+                        'Status: ${conditions![index].status}\nLast Transition Time: ${getAge(conditions![index].lastTransitionTime)}\nReason: ${conditions![index].reason}\nMessage: ${conditions![index].message}',
+                      );
+                    },
+                    child: Row(
+                      children: [
+                        Icon(
+                          conditions![index].status == 'True'
+                              ? Icons.radio_button_checked
+                              : Icons.radio_button_unchecked,
+                          size: 24,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: Constants.spacingSmall),
+                        Expanded(
+                          flex: 1,
+                          child: Text(
+                            conditions![index].type,
+                            style: normalTextStyle(context),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          const SizedBox(width: Constants.spacingSmall),
-                          Expanded(
-                            flex: 1,
-                            child: Text(
-                              conditions![index].type,
-                              style: noramlTextStyle(
-                                context,
-                              ),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                  );
-                },
-              ),
+                  ),
+                );
+              }),
             ),
           ),
         ],

--- a/lib/widgets/resources/resources_list.dart
+++ b/lib/widgets/resources/resources_list.dart
@@ -44,10 +44,7 @@ class ResourcesListData {
   String list;
   String? metrics;
 
-  ResourcesListData({
-    required this.list,
-    required this.metrics,
-  });
+  ResourcesListData({required this.list, required this.metrics});
 }
 
 /// The [ResourcesList] widget is used to display a list of [items] for a
@@ -93,15 +90,16 @@ class _ResourcesListState extends State<ResourcesList> {
       clustersRepository.activeClusterId,
     );
 
-    final listUrl = widget.resource.scope == ResourceScope.cluster
-        ? '${widget.resource.path}/${widget.resource.resource}?${widget.selector} ?? '
-            '}'
-        : widget.namespace != null
+    final listUrl =
+        widget.resource.scope == ResourceScope.cluster
+            ? '${widget.resource.path}/${widget.resource.resource}?${widget.selector} ?? '
+                '}'
+            : widget.namespace != null
             ? '${widget.resource.path}/namespaces/${widget.namespace}/${widget.resource.resource}?${widget.selector ?? ''}'
             : widget.selector != null &&
-                    widget.selector!.startsWith('fieldSelector=spec.nodeName=')
-                ? '${widget.resource.path}/${widget.resource.resource}?${widget.selector ?? ''}'
-                : '${widget.resource.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource.resource}?${widget.selector ?? ''}';
+                widget.selector!.startsWith('fieldSelector=spec.nodeName=')
+            ? '${widget.resource.path}/${widget.resource.resource}?${widget.selector ?? ''}'
+            : '${widget.resource.path}${cluster!.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource.resource}?${widget.selector ?? ''}';
 
     final listResult = await KubernetesService(
       cluster: cluster!,
@@ -114,9 +112,10 @@ class _ResourcesListState extends State<ResourcesList> {
               widget.resource.path == resourceNode.path) ||
           (widget.resource.resource == resourcePod.resource &&
               widget.resource.path == resourcePod.path)) {
-        final metricsUrl = widget.resource.scope == ResourceScope.cluster
-            ? '/apis/metrics.k8s.io/v1beta1/${widget.resource.resource}?${widget.selector ?? ''}'
-            : widget.namespace != null
+        final metricsUrl =
+            widget.resource.scope == ResourceScope.cluster
+                ? '/apis/metrics.k8s.io/v1beta1/${widget.resource.resource}?${widget.selector ?? ''}'
+                : widget.namespace != null
                 ? '/apis/metrics.k8s.io/v1beta1/namespaces/${widget.namespace}/${widget.resource.resource}?${widget.selector ?? ''}'
                 : '/apis/metrics.k8s.io/v1beta1${cluster.namespace != '' ? '/namespaces/${cluster.namespace}' : ''}/${widget.resource.resource}?${widget.selector ?? ''}';
 
@@ -128,26 +127,16 @@ class _ResourcesListState extends State<ResourcesList> {
 
         return await compute(
           widget.resource.decodeListData,
-          ResourcesListData(
-            list: listResult,
-            metrics: metricsResult,
-          ),
+          ResourcesListData(list: listResult, metrics: metricsResult),
         );
       }
     } catch (err) {
-      Logger.log(
-        'ResourcesList _fetchItems',
-        'Failed to Load Metrics',
-        err,
-      );
+      Logger.log('ResourcesList _fetchItems', 'Failed to Load Metrics', err);
     }
 
     return await compute(
       widget.resource.decodeListData,
-      ResourcesListData(
-        list: listResult,
-        metrics: null,
-      ),
+      ResourcesListData(list: listResult, metrics: null),
     );
   }
 
@@ -227,17 +216,18 @@ class _ResourcesListState extends State<ResourcesList> {
         /// user can change the active namespace of the cluster. If the resource
         /// is cluster scoped or when the user specified a selector (e.g. to
         /// view all Pods of a Deployment) we do not show the button.
-        actions: widget.resource.scope == ResourceScope.namespaced &&
-                widget.selector == null
-            ? [
-                IconButton(
-                  icon: const Icon(CustomIcons.namespaces),
-                  onPressed: () {
-                    showModal(context, const AppNamespacesWidget());
-                  },
-                ),
-              ]
-            : null,
+        actions:
+            widget.resource.scope == ResourceScope.namespaced &&
+                    widget.selector == null
+                ? [
+                  IconButton(
+                    icon: const Icon(CustomIcons.namespaces),
+                    onPressed: () {
+                      showModal(context, const AppNamespacesWidget());
+                    },
+                  ),
+                ]
+                : null,
 
         /// We always display the title of the resource as main title for the
         /// widget.
@@ -251,9 +241,9 @@ class _ResourcesListState extends State<ResourcesList> {
         title: Column(
           children: [
             Text(
-              Characters(widget.resource.plural)
-                  .replaceAll(Characters(''), Characters('\u{200B}'))
-                  .toString(),
+              Characters(
+                widget.resource.plural,
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
               textAlign: TextAlign.center,
               style: const TextStyle(
                 fontSize: 20,
@@ -263,44 +253,42 @@ class _ResourcesListState extends State<ResourcesList> {
             ),
             widget.selector == null
                 ? Text(
-                    Characters(
-                      clustersRepository
-                                      .getCluster(
-                                        clustersRepository.activeClusterId,
-                                      )
-                                      ?.namespace ==
-                                  '' ||
-                              (widget.resource.scope == ResourceScope.cluster)
-                          ? 'All Namespaces'
-                          : clustersRepository
-                                  .getCluster(
-                                    clustersRepository.activeClusterId,
-                                  )
-                                  ?.namespace ??
-                              'All Namespaces',
-                    )
-                        .replaceAll(Characters(''), Characters('\u{200B}'))
-                        .toString(),
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.normal,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  )
-                : Text(
-                    Characters(
-                      widget.namespace ?? 'All Namespaces',
-                    )
-                        .replaceAll(Characters(''), Characters('\u{200B}'))
-                        .toString(),
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.normal,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                  Characters(
+                        clustersRepository
+                                        .getCluster(
+                                          clustersRepository.activeClusterId,
+                                        )
+                                        ?.namespace ==
+                                    '' ||
+                                (widget.resource.scope == ResourceScope.cluster)
+                            ? 'All Namespaces'
+                            : clustersRepository
+                                    .getCluster(
+                                      clustersRepository.activeClusterId,
+                                    )
+                                    ?.namespace ??
+                                'All Namespaces',
+                      )
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.normal,
+                    overflow: TextOverflow.ellipsis,
                   ),
+                )
+                : Text(
+                  Characters(widget.namespace ?? 'All Namespaces')
+                      .replaceAll(Characters(''), Characters('\u{200B}'))
+                      .toString(),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.normal,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
           ],
         ),
       ),
@@ -375,9 +363,10 @@ class _ResourcesListState extends State<ResourcesList> {
                                   child: TextField(
                                     controller: _filterController,
                                     style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onPrimary,
+                                      color:
+                                          Theme.of(
+                                            context,
+                                          ).colorScheme.onPrimary,
                                     ),
                                     cursorColor:
                                         Theme.of(context).colorScheme.onPrimary,
@@ -389,26 +378,29 @@ class _ResourcesListState extends State<ResourcesList> {
                                       border: const OutlineInputBorder(),
                                       enabledBorder: OutlineInputBorder(
                                         borderSide: BorderSide(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onPrimary,
+                                          color:
+                                              Theme.of(
+                                                context,
+                                              ).colorScheme.onPrimary,
                                           width: 0.0,
                                         ),
                                       ),
                                       focusedBorder: OutlineInputBorder(
                                         borderSide: BorderSide(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onPrimary,
+                                          color:
+                                              Theme.of(
+                                                context,
+                                              ).colorScheme.onPrimary,
                                           width: 0.0,
                                         ),
                                       ),
                                       isDense: true,
                                       contentPadding: const EdgeInsets.all(8),
                                       hintStyle: TextStyle(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .onPrimary,
+                                        color:
+                                            Theme.of(
+                                              context,
+                                            ).colorScheme.onPrimary,
                                       ),
                                       hintText: 'Filter...',
                                       suffixIcon: IconButton(
@@ -417,9 +409,10 @@ class _ResourcesListState extends State<ResourcesList> {
                                         },
                                         icon: Icon(
                                           Icons.clear,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onPrimary,
+                                          color:
+                                              Theme.of(
+                                                context,
+                                              ).colorScheme.onPrimary,
                                         ),
                                       ),
                                     ),
@@ -458,10 +451,10 @@ class _ResourcesListState extends State<ResourcesList> {
                                 right: Constants.spacingMiddle,
                                 left: Constants.spacingMiddle,
                               ),
-                              separatorBuilder: (context, index) =>
-                                  const SizedBox(
-                                height: Constants.spacingMiddle,
-                              ),
+                              separatorBuilder:
+                                  (context, index) => const SizedBox(
+                                    height: Constants.spacingMiddle,
+                                  ),
                               itemCount: filteredItems.length,
                               itemBuilder: (context, index) {
                                 return widget.resource.listItemBuilder(
@@ -520,9 +513,7 @@ class ResourcesListActions extends StatelessWidget {
           onTap: () {
             showModal(
               context,
-              ResourcesListItemCreateResource(
-                resource: resource,
-              ),
+              ResourcesListItemCreateResource(resource: resource),
             );
           },
         ),
@@ -545,43 +536,39 @@ class ResourcesListActions extends StatelessWidget {
           onTap: refresh,
         ),
         AppResourceActionsModel(
-          title: bookmarksRepository.isBookmarked(
-                    BookmarkType.list,
-                    clustersRepository.activeClusterId,
-                    null,
-                    clustersRepository
-                        .getCluster(
-                          clustersRepository.activeClusterId,
-                        )
-                        ?.namespace,
-                    resource,
-                  ) >
-                  -1
-              ? 'Remove Bookmark'
-              : 'Add Bookmark',
-          icon: bookmarksRepository.isBookmarked(
-                    BookmarkType.list,
-                    clustersRepository.activeClusterId,
-                    null,
-                    clustersRepository
-                        .getCluster(
-                          clustersRepository.activeClusterId,
-                        )
-                        ?.namespace,
-                    resource,
-                  ) >
-                  -1
-              ? Icons.bookmark
-              : Icons.bookmark_border,
+          title:
+              bookmarksRepository.isBookmarked(
+                        BookmarkType.list,
+                        clustersRepository.activeClusterId,
+                        null,
+                        clustersRepository
+                            .getCluster(clustersRepository.activeClusterId)
+                            ?.namespace,
+                        resource,
+                      ) >
+                      -1
+                  ? 'Remove Bookmark'
+                  : 'Add Bookmark',
+          icon:
+              bookmarksRepository.isBookmarked(
+                        BookmarkType.list,
+                        clustersRepository.activeClusterId,
+                        null,
+                        clustersRepository
+                            .getCluster(clustersRepository.activeClusterId)
+                            ?.namespace,
+                        resource,
+                      ) >
+                      -1
+                  ? Icons.bookmark
+                  : Icons.bookmark_border,
           onTap: () {
             final bookmarkIndex = bookmarksRepository.isBookmarked(
               BookmarkType.list,
               clustersRepository.activeClusterId,
               null,
               clustersRepository
-                  .getCluster(
-                    clustersRepository.activeClusterId,
-                  )
+                  .getCluster(clustersRepository.activeClusterId)
                   ?.namespace,
               resource,
             );
@@ -593,9 +580,7 @@ class ResourcesListActions extends StatelessWidget {
                 clustersRepository.activeClusterId,
                 null,
                 clustersRepository
-                    .getCluster(
-                      clustersRepository.activeClusterId,
-                    )
+                    .getCluster(clustersRepository.activeClusterId)
                     ?.namespace,
                 resource,
               );
@@ -639,32 +624,33 @@ class ResourcesListStatus extends StatelessWidget {
         Icons.filter_list,
         color: Theme.of(context).colorScheme.onPrimary,
       ),
-      itemBuilder: (BuildContext context) => <PopupMenuEntry<ResourceStatus>>[
-        PopupMenuItem<ResourceStatus>(
-          value: ResourceStatus.undefined,
-          child: Text(
-            '${ResourceStatus.undefined.toLocalizedString()} ($undefinedCount)',
-          ),
-        ),
-        PopupMenuItem<ResourceStatus>(
-          value: ResourceStatus.success,
-          child: Text(
-            '${ResourceStatus.success.toLocalizedString()} ($successCount)',
-          ),
-        ),
-        PopupMenuItem<ResourceStatus>(
-          value: ResourceStatus.warning,
-          child: Text(
-            '${ResourceStatus.warning.toLocalizedString()} ($warningCount)',
-          ),
-        ),
-        PopupMenuItem<ResourceStatus>(
-          value: ResourceStatus.danger,
-          child: Text(
-            '${ResourceStatus.danger.toLocalizedString()} ($dangerCount)',
-          ),
-        ),
-      ],
+      itemBuilder:
+          (BuildContext context) => <PopupMenuEntry<ResourceStatus>>[
+            PopupMenuItem<ResourceStatus>(
+              value: ResourceStatus.undefined,
+              child: Text(
+                '${ResourceStatus.undefined.toLocalizedString()} ($undefinedCount)',
+              ),
+            ),
+            PopupMenuItem<ResourceStatus>(
+              value: ResourceStatus.success,
+              child: Text(
+                '${ResourceStatus.success.toLocalizedString()} ($successCount)',
+              ),
+            ),
+            PopupMenuItem<ResourceStatus>(
+              value: ResourceStatus.warning,
+              child: Text(
+                '${ResourceStatus.warning.toLocalizedString()} ($warningCount)',
+              ),
+            ),
+            PopupMenuItem<ResourceStatus>(
+              value: ResourceStatus.danger,
+              child: Text(
+                '${ResourceStatus.danger.toLocalizedString()} ($dangerCount)',
+              ),
+            ),
+          ],
     );
   }
 }
@@ -702,9 +688,10 @@ class ResourcesListItem extends StatelessWidget {
           Icon(
             Icons.radio_button_checked,
             size: 24,
-            color: status == ResourceStatus.success
-                ? Theme.of(context).extension<CustomColors>()!.success
-                : status == ResourceStatus.danger
+            color:
+                status == ResourceStatus.success
+                    ? Theme.of(context).extension<CustomColors>()!.success
+                    : status == ResourceStatus.danger
                     ? Theme.of(context).extension<CustomColors>()!.error
                     : Theme.of(context).extension<CustomColors>()!.warning,
           ),
@@ -773,33 +760,21 @@ class ResourcesListItem extends StatelessWidget {
                       .toString(),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: primaryTextStyle(
-                    context,
-                  ),
+                  style: primaryTextStyle(context),
                 ),
                 Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.start,
-                  children: List.generate(
-                    details.length,
-                    (index) {
-                      return Text(
-                        Characters(
-                          details[index],
-                        )
-                            .replaceAll(
-                              Characters(''),
-                              Characters('\u{200B}'),
-                            )
-                            .toString(),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: secondaryTextStyle(
-                          context,
-                        ),
-                      );
-                    },
-                  ),
+                  children: List.generate(details.length, (index) {
+                    return Text(
+                      Characters(details[index])
+                          .replaceAll(Characters(''), Characters('\u{200B}'))
+                          .toString(),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: secondaryTextStyle(context),
+                    );
+                  }),
                 ),
               ],
             ),
@@ -876,10 +851,7 @@ dynamic _createResourceDecodeYaml(String template) {
 /// editor, where the user can modify the template. The user can then create the
 /// resource by pressing the action button.
 class ResourcesListItemCreateResource extends StatefulWidget {
-  const ResourcesListItemCreateResource({
-    super.key,
-    required this.resource,
-  });
+  const ResourcesListItemCreateResource({super.key, required this.resource});
 
   final Resource resource;
 
@@ -905,9 +877,10 @@ class _ResourcesListItemCreateResourceState
 
     _codeController = CodeController(
       text: '',
-      language: appRepository.settings.editorFormat == 'json'
-          ? highlight_json.json
-          : highlight_yaml.yaml,
+      language:
+          appRepository.settings.editorFormat == 'json'
+              ? highlight_json.json
+              : highlight_yaml.yaml,
     );
 
     try {
@@ -953,17 +926,19 @@ class _ResourcesListItemCreateResourceState
       final cluster = await clustersRepository.getClusterWithCredentials(
         clustersRepository.activeClusterId,
       );
-      final manifest = appRepository.settings.editorFormat == 'json'
-          ? await compute(_createResourceDecodeJson, _codeController.text)
-          : await compute(_createResourceDecodeYaml, _codeController.text);
+      final manifest =
+          appRepository.settings.editorFormat == 'json'
+              ? await compute(_createResourceDecodeJson, _codeController.text)
+              : await compute(_createResourceDecodeYaml, _codeController.text);
       final name =
           manifest['metadata'] != null && manifest['metadata']['name'] != null
               ? manifest['metadata']['name']
               : '';
-      final namespace = manifest['metadata'] != null &&
-              manifest['metadata']['namespace'] != null
-          ? manifest['metadata']['namespace']
-          : '';
+      final namespace =
+          manifest['metadata'] != null &&
+                  manifest['metadata']['namespace'] != null
+              ? manifest['metadata']['namespace']
+              : '';
       final url =
           '${widget.resource.path}${namespace != null && namespace != '' ? '/namespaces/$namespace' : ''}/${widget.resource.resource}';
 
@@ -1002,11 +977,7 @@ class _ResourcesListItemCreateResourceState
         _isLoading = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Creation Failed',
-          err.toString(),
-        );
+        showSnackbar(context, 'Creation Failed', err.toString());
       }
     }
   }
@@ -1121,9 +1092,10 @@ class _ResourcesListItemDeleteResourcesState
         final name = widget.resource.getName(selectedItem.item);
         final namespace = widget.resource.getNamespace(selectedItem.item);
 
-        final url = namespace == null
-            ? '${widget.resource.path}/${widget.resource.resource}/$name'
-            : '${widget.resource.path}/namespaces/$namespace/${widget.resource.resource}/$name';
+        final url =
+            namespace == null
+                ? '${widget.resource.path}/${widget.resource.resource}/$name'
+                : '${widget.resource.path}/namespaces/$namespace/${widget.resource.resource}/$name';
 
         await KubernetesService(
           cluster: cluster!,
@@ -1174,9 +1146,10 @@ class _ResourcesListItemDeleteResourcesState
           Icon(
             Icons.radio_button_checked,
             size: 24,
-            color: status == ResourceStatus.success
-                ? Theme.of(context).extension<CustomColors>()!.success
-                : status == ResourceStatus.danger
+            color:
+                status == ResourceStatus.success
+                    ? Theme.of(context).extension<CustomColors>()!.success
+                    : status == ResourceStatus.danger
                     ? Theme.of(context).extension<CustomColors>()!.error
                     : Theme.of(context).extension<CustomColors>()!.warning,
           ),
@@ -1232,9 +1205,7 @@ class _ResourcesListItemDeleteResourcesState
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 separatorBuilder: (context, index) {
-                  return const SizedBox(
-                    height: Constants.spacingMiddle,
-                  );
+                  return const SizedBox(height: Constants.spacingMiddle);
                 },
                 itemCount: widget.items.length,
                 itemBuilder: (context, index) {
@@ -1242,9 +1213,10 @@ class _ResourcesListItemDeleteResourcesState
                     decoration: BoxDecoration(
                       boxShadow: [
                         BoxShadow(
-                          color: Theme.of(context)
-                              .extension<CustomColors>()!
-                              .shadow,
+                          color:
+                              Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.shadow,
                           blurRadius: Constants.sizeBorderBlurRadius,
                           spreadRadius: Constants.sizeBorderSpreadRadius,
                           offset: const Offset(0.0, 0.0),
@@ -1257,7 +1229,8 @@ class _ResourcesListItemDeleteResourcesState
                     ),
                     child: CheckboxListTile(
                       controlAffinity: ListTileControlAffinity.leading,
-                      value: _selectedItems
+                      value:
+                          _selectedItems
                               .where(
                                 (e) =>
                                     widget.resource.getName(e.item) ==
@@ -1280,53 +1253,55 @@ class _ResourcesListItemDeleteResourcesState
                         }
                         if (value == false) {
                           setState(() {
-                            _selectedItems = _selectedItems
-                                .where(
-                                  (e) => !(widget.resource.getName(e.item) ==
-                                          widget.resource.getName(
-                                            widget.items[index].item,
-                                          ) &&
-                                      widget.resource.getNamespace(e.item) ==
-                                          widget.resource.getNamespace(
-                                            widget.items[index].item,
-                                          )),
-                                )
-                                .toList();
+                            _selectedItems =
+                                _selectedItems
+                                    .where(
+                                      (e) =>
+                                          !(widget.resource.getName(e.item) ==
+                                                  widget.resource.getName(
+                                                    widget.items[index].item,
+                                                  ) &&
+                                              widget.resource.getNamespace(
+                                                    e.item,
+                                                  ) ==
+                                                  widget.resource.getNamespace(
+                                                    widget.items[index].item,
+                                                  )),
+                                    )
+                                    .toList();
                           });
                         }
                       },
                       title: Text(
                         Characters(
-                          widget.resource.getName(widget.items[index].item),
-                        )
+                              widget.resource.getName(widget.items[index].item),
+                            )
                             .replaceAll(Characters(''), Characters('\u{200B}'))
                             .toString(),
-                        style: noramlTextStyle(
-                          context,
-                        ),
+                        style: normalTextStyle(context),
                         overflow: TextOverflow.ellipsis,
                       ),
-                      subtitle: widget.resource
-                                  .getNamespace(widget.items[index].item) ==
-                              null
-                          ? null
-                          : Text(
-                              Characters(
-                                widget.resource.getNamespace(
-                                      widget.items[index].item,
-                                    ) ??
-                                    '',
-                              )
-                                  .replaceAll(
-                                    Characters(''),
-                                    Characters('\u{200B}'),
-                                  )
-                                  .toString(),
-                              style: secondaryTextStyle(
-                                context,
+                      subtitle:
+                          widget.resource.getNamespace(
+                                    widget.items[index].item,
+                                  ) ==
+                                  null
+                              ? null
+                              : Text(
+                                Characters(
+                                      widget.resource.getNamespace(
+                                            widget.items[index].item,
+                                          ) ??
+                                          '',
+                                    )
+                                    .replaceAll(
+                                      Characters(''),
+                                      Characters('\u{200B}'),
+                                    )
+                                    .toString(),
+                                style: secondaryTextStyle(context),
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              overflow: TextOverflow.ellipsis,
-                            ),
                       secondary: _buildStatus(
                         context,
                         widget.items[index].status,

--- a/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_aws.dart
@@ -23,10 +23,7 @@ import 'package:kubenav/widgets/shared/app_error_widget.dart';
 /// To get the clusters from AWS a [provider] is required. The provider must
 /// contain a valid set of credentails for the user.
 class SettingsAddClusterAWS extends StatefulWidget {
-  const SettingsAddClusterAWS({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterAWS({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -135,11 +132,7 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -167,9 +160,7 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -190,7 +181,8 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -203,9 +195,10 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
@@ -213,9 +206,7 @@ class _SettingsAddClusterAWSState extends State<SettingsAddClusterAWS> {
               Characters(
                 'aws_${widget.provider.aws?.region}_${_clusters[index].name}',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_awssso.dart
@@ -23,10 +23,7 @@ import 'package:kubenav/widgets/shared/app_error_widget.dart';
 /// To get the list of clusters a valid [provider] configuration is required,
 /// with the users credentials to access the AWS API.
 class SettingsAddClusterAWSSSO extends StatefulWidget {
-  const SettingsAddClusterAWSSSO({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterAWSSSO({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -122,7 +119,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
                   widget.provider.awssso!.ssoCredentials?.accessToken ?? '',
               userTokenExpireTimestamp:
                   widget.provider.awssso!.ssoCredentials?.accessTokenExpire ??
-                      0,
+                  0,
               namespace: 'default',
             ),
           );
@@ -139,11 +136,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -172,9 +165,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -195,7 +186,8 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -208,9 +200,10 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
@@ -218,9 +211,7 @@ class _SettingsAddClusterAWSSSOState extends State<SettingsAddClusterAWSSSO> {
               Characters(
                 'aws_${widget.provider.awssso?.region}_${_clusters[index].name}',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_azure.dart
@@ -21,10 +21,7 @@ import 'package:kubenav/widgets/shared/app_error_widget.dart';
 /// To get the list of clusters a valid [provider] configuration is required, so
 /// that we can get the clusters via the Azure API.
 class SettingsAddClusterAzure extends StatefulWidget {
-  const SettingsAddClusterAzure({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterAzure({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -124,11 +121,7 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -156,9 +149,7 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -179,7 +170,8 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -192,9 +184,10 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
@@ -202,9 +195,7 @@ class _SettingsAddClusterAzureState extends State<SettingsAddClusterAzure> {
               Characters(
                 _clusters[index].name ?? '',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_digitalocean.dart
@@ -24,10 +24,7 @@ import 'package:kubenav/widgets/shared/app_error_widget.dart';
 /// To get the clusters from the DigitalOcean API a valid [provider]
 /// configuration is required, with the users credentials to access the API.
 class SettingsAddClusterDigitalOcean extends StatefulWidget {
-  const SettingsAddClusterDigitalOcean({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterDigitalOcean({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -71,13 +68,7 @@ class _SettingsAddClusterDigitalOceanState
             widget.provider.digitalocean!.token ?? '',
           );
           tmpClusters[i].kubeconfig = Kubeconfig.fromJson(
-            json.decode(
-              json.encode(
-                loadYaml(
-                  kubeconfig,
-                ),
-              ),
-            ),
+            json.decode(json.encode(loadYaml(kubeconfig))),
           );
         }
 
@@ -141,11 +132,7 @@ class _SettingsAddClusterDigitalOceanState
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -174,9 +161,7 @@ class _SettingsAddClusterDigitalOceanState
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -197,7 +182,8 @@ class _SettingsAddClusterDigitalOceanState
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -210,9 +196,10 @@ class _SettingsAddClusterDigitalOceanState
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
@@ -220,9 +207,7 @@ class _SettingsAddClusterDigitalOceanState
               Characters(
                 _clusters[index].name ?? '',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_google.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_google.dart
@@ -23,10 +23,7 @@ import 'package:kubenav/widgets/shared/app_error_widget.dart';
 /// with the users access credentials so that we can call the Google API to get
 /// the clusters on behalf of the user.
 class SettingsAddClusterGoogle extends StatefulWidget {
-  const SettingsAddClusterGoogle({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterGoogle({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -53,8 +50,9 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
 
     try {
       if (widget.provider.google != null) {
-        final projects = await GoogleService()
-            .getProjects(widget.provider.google!.accessToken ?? '');
+        final projects = await GoogleService().getProjects(
+          widget.provider.google!.accessToken ?? '',
+        );
 
         final List<GoogleCluster> tmpClusters = [];
         for (var project in projects) {
@@ -133,11 +131,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -165,9 +159,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -188,7 +180,8 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -201,9 +194,10 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
@@ -211,9 +205,7 @@ class _SettingsAddClusterGoogleState extends State<SettingsAddClusterGoogle> {
               Characters(
                 'gke_${_clusters[index].location}_${_clusters[index].name}',
               ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/clusters/settings_add_cluster_rancher.dart
+++ b/lib/widgets/settings/clusters/settings_add_cluster_rancher.dart
@@ -18,10 +18,7 @@ import 'package:kubenav/widgets/shared/app_bottom_sheet_widget.dart';
 import 'package:kubenav/widgets/shared/app_error_widget.dart';
 
 class SettingsAddClusterRancher extends StatefulWidget {
-  const SettingsAddClusterRancher({
-    super.key,
-    required this.provider,
-  });
+  const SettingsAddClusterRancher({super.key, required this.provider});
 
   final ClusterProvider provider;
 
@@ -62,13 +59,7 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
             tmpClusters[i].id!,
           );
           tmpClusters[i].kubeconfig = Kubeconfig.fromJson(
-            json.decode(
-              json.encode(
-                loadYaml(
-                  kubeconfig.config ?? '',
-                ),
-              ),
-            ),
+            json.decode(json.encode(loadYaml(kubeconfig.config ?? ''))),
           );
         }
 
@@ -132,11 +123,7 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
         _isLoadingAddCluster = false;
       });
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Add Clusters',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Add Clusters', err.toString());
       }
     }
   }
@@ -164,9 +151,7 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       separatorBuilder: (context, index) {
-        return const SizedBox(
-          height: Constants.spacingMiddle,
-        );
+        return const SizedBox(height: Constants.spacingMiddle);
       },
       itemCount: _clusters.length,
       itemBuilder: (context, index) {
@@ -187,7 +172,8 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
           ),
           child: CheckboxListTile(
             controlAffinity: ListTileControlAffinity.leading,
-            value: _selectedClusters
+            value:
+                _selectedClusters
                     .where((c) => c.name == _clusters[index].name)
                     .toList()
                     .length ==
@@ -200,19 +186,18 @@ class _SettingsAddClusterRancherState extends State<SettingsAddClusterRancher> {
               }
               if (value == false) {
                 setState(() {
-                  _selectedClusters = _selectedClusters
-                      .where((c) => c.name != _clusters[index].name)
-                      .toList();
+                  _selectedClusters =
+                      _selectedClusters
+                          .where((c) => c.name != _clusters[index].name)
+                          .toList();
                 });
               }
             },
             title: Text(
-              Characters(_clusters[index].name ?? '')
-                  .replaceAll(Characters(''), Characters('\u{200B}'))
-                  .toString(),
-              style: noramlTextStyle(
-                context,
-              ),
+              Characters(
+                _clusters[index].name ?? '',
+              ).replaceAll(Characters(''), Characters('\u{200B}')).toString(),
+              style: normalTextStyle(context),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
+++ b/lib/widgets/settings/providers/settings_awssso_multiple_providers_select.dart
@@ -164,9 +164,7 @@ class _SettingsAWSSSOMultipleProvidersSelectState
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             separatorBuilder: (context, index) {
-              return const SizedBox(
-                height: Constants.spacingMiddle,
-              );
+              return const SizedBox(height: Constants.spacingMiddle);
             },
             itemCount: widget.accounts.length,
             itemBuilder: (context, accountIndex) {
@@ -190,9 +188,7 @@ class _SettingsAWSSSOMultipleProvidersSelectState
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     separatorBuilder: (context, index) {
-                      return const SizedBox(
-                        height: Constants.spacingMiddle,
-                      );
+                      return const SizedBox(height: Constants.spacingMiddle);
                     },
                     itemCount: widget.accounts[accountIndex].roles?.length ?? 0,
                     itemBuilder: (context, roleIndex) {
@@ -200,9 +196,10 @@ class _SettingsAWSSSOMultipleProvidersSelectState
                         decoration: BoxDecoration(
                           boxShadow: [
                             BoxShadow(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .shadow,
+                              color:
+                                  Theme.of(
+                                    context,
+                                  ).extension<CustomColors>()!.shadow,
                               blurRadius: Constants.sizeBorderBlurRadius,
                               spreadRadius: Constants.sizeBorderSpreadRadius,
                               offset: const Offset(0.0, 0.0),
@@ -215,14 +212,17 @@ class _SettingsAWSSSOMultipleProvidersSelectState
                         ),
                         child: CheckboxListTile(
                           controlAffinity: ListTileControlAffinity.leading,
-                          value: _selectedAccounts
+                          value:
+                              _selectedAccounts
                                   .where(
                                     (a) =>
                                         a.accountId ==
-                                            widget.accounts[accountIndex]
+                                            widget
+                                                .accounts[accountIndex]
                                                 .accountId &&
                                         a.role ==
-                                            widget.accounts[accountIndex]
+                                            widget
+                                                .accounts[accountIndex]
                                                 .roles![roleIndex],
                                   )
                                   .toList()
@@ -235,46 +235,57 @@ class _SettingsAWSSSOMultipleProvidersSelectState
                                   SelectedAWSSSOAccount(
                                     accountId:
                                         widget.accounts[accountIndex].accountId,
-                                    accountName: widget
-                                        .accounts[accountIndex].accountName,
-                                    role: widget.accounts[accountIndex]
-                                        .roles![roleIndex],
-                                    accessToken: widget
-                                        .accounts[accountIndex].accessToken,
-                                    accessTokenExpire: widget
-                                        .accounts[accountIndex]
-                                        .accessTokenExpire,
+                                    accountName:
+                                        widget
+                                            .accounts[accountIndex]
+                                            .accountName,
+                                    role:
+                                        widget
+                                            .accounts[accountIndex]
+                                            .roles![roleIndex],
+                                    accessToken:
+                                        widget
+                                            .accounts[accountIndex]
+                                            .accessToken,
+                                    accessTokenExpire:
+                                        widget
+                                            .accounts[accountIndex]
+                                            .accessTokenExpire,
                                   ),
                                 );
                               });
                             }
                             if (value == false) {
                               setState(() {
-                                _selectedAccounts = _selectedAccounts
-                                    .where(
-                                      (a) => !(a.accountId ==
-                                              widget.accounts[accountIndex]
-                                                  .accountId &&
-                                          a.role ==
-                                              widget.accounts[accountIndex]
-                                                  .roles![roleIndex]),
-                                    )
-                                    .toList();
+                                _selectedAccounts =
+                                    _selectedAccounts
+                                        .where(
+                                          (a) =>
+                                              !(a.accountId ==
+                                                      widget
+                                                          .accounts[accountIndex]
+                                                          .accountId &&
+                                                  a.role ==
+                                                      widget
+                                                          .accounts[accountIndex]
+                                                          .roles![roleIndex]),
+                                        )
+                                        .toList();
                               });
                             }
                           },
                           title: Text(
                             Characters(
-                              widget.accounts[accountIndex].roles![roleIndex],
-                            )
+                                  widget
+                                      .accounts[accountIndex]
+                                      .roles![roleIndex],
+                                )
                                 .replaceAll(
                                   Characters(''),
                                   Characters('\u{200B}'),
                                 )
                                 .toString(),
-                            style: noramlTextStyle(
-                              context,
-                            ),
+                            style: normalTextStyle(context),
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -41,9 +41,7 @@ class Settings extends StatelessWidget {
   /// If the user hasn't any clusters configured yet. We display the
   /// [AppNoClustersWidget] widget, so the user can go to the clusters page to
   /// add his first cluster.
-  Widget _buildClusters(
-    BuildContext context,
-  ) {
+  Widget _buildClusters(BuildContext context) {
     ClustersRepository clustersRepository = Provider.of<ClustersRepository>(
       context,
       listen: false,
@@ -100,9 +98,7 @@ class Settings extends StatelessWidget {
                       flex: 1,
                       child: Text(
                         clustersRepository.clusters[index].name,
-                        style: noramlTextStyle(
-                          context,
-                        ),
+                        style: normalTextStyle(context),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
@@ -121,9 +117,7 @@ class Settings extends StatelessWidget {
   /// page, where a user can add more clusters or reorder his existing clusters.
   Widget _buildViewAllClusters(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(
-        Constants.spacingMiddle,
-      ),
+      padding: const EdgeInsets.all(Constants.spacingMiddle),
       child: Row(
         children: [
           Expanded(
@@ -185,25 +179,14 @@ class Settings extends StatelessWidget {
       items: [
         AppVerticalListSimpleModel(
           onTap: () {
-            showModal(
-              context,
-              const Logger(),
-            );
+            showModal(context, const Logger());
           },
           children: [
-            Icon(
-              Icons.subject,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.subject, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Logs',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Logs', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -217,25 +200,14 @@ class Settings extends StatelessWidget {
         ),
         AppVerticalListSimpleModel(
           onTap: () {
-            navigate(
-              context,
-              const SettingsHelp(),
-            );
+            navigate(context, const SettingsHelp());
           },
           children: [
-            Icon(
-              Icons.help,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.help, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Help',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Help', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -261,16 +233,10 @@ class Settings extends StatelessWidget {
       context,
       listen: true,
     );
-    Provider.of<ClustersRepository>(
-      context,
-      listen: true,
-    );
+    Provider.of<ClustersRepository>(context, listen: true);
 
     return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text('Settings'),
-      ),
+      appBar: AppBar(centerTitle: true, title: const Text('Settings')),
       bottomNavigationBar: const AppBottomNavigationBarWidget(),
       floatingActionButton: const AppFloatingActionButtonsWidget(),
       body: SafeArea(
@@ -298,9 +264,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Provider',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Icon(
@@ -315,10 +279,7 @@ class Settings extends StatelessWidget {
                   ),
                   AppVerticalListSimpleModel(
                     onTap: () {
-                      navigate(
-                        context,
-                        const SettingsNamespaces(),
-                      );
+                      navigate(context, const SettingsNamespaces());
                     },
                     children: [
                       Icon(
@@ -330,9 +291,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Namespaces',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Icon(
@@ -356,9 +315,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Authentication',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Switch(
@@ -381,9 +338,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Show Clusters on Start',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Switch(
@@ -406,12 +361,7 @@ class Settings extends StatelessWidget {
                       const SizedBox(width: Constants.spacingSmall),
                       Expanded(
                         flex: 1,
-                        child: Text(
-                          'Theme',
-                          style: noramlTextStyle(
-                            context,
-                          ),
-                        ),
+                        child: Text('Theme', style: normalTextStyle(context)),
                       ),
                       DropdownButton(
                         value: themeRepository.themeName,
@@ -420,22 +370,25 @@ class Settings extends StatelessWidget {
                           color: Theme.of(context).colorScheme.primary,
                         ),
                         onChanged: (ThemeName? value) {
-                          themeRepository
-                              .setThemeName(value ?? ThemeName.light);
-                        },
-                        items: ThemeName.values.map((value) {
-                          return DropdownMenuItem(
-                            value: value,
-                            child: Text(
-                              value.toShortString(),
-                              style: TextStyle(
-                                color: Theme.of(context)
-                                    .extension<CustomColors>()!
-                                    .textPrimary,
-                              ),
-                            ),
+                          themeRepository.setThemeName(
+                            value ?? ThemeName.light,
                           );
-                        }).toList(),
+                        },
+                        items:
+                            ThemeName.values.map((value) {
+                              return DropdownMenuItem(
+                                value: value,
+                                child: Text(
+                                  value.toShortString(),
+                                  style: TextStyle(
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textPrimary,
+                                  ),
+                                ),
+                              );
+                            }).toList(),
                       ),
                     ],
                   ),
@@ -450,9 +403,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Editor Format',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       DropdownButton(
@@ -464,22 +415,21 @@ class Settings extends StatelessWidget {
                         onChanged: (String? newValue) {
                           appRepository.setEditorFormat(newValue ?? 'yaml');
                         },
-                        items: [
-                          'yaml',
-                          'json',
-                        ].map((value) {
-                          return DropdownMenuItem(
-                            value: value,
-                            child: Text(
-                              value,
-                              style: TextStyle(
-                                color: Theme.of(context)
-                                    .extension<CustomColors>()!
-                                    .textPrimary,
-                              ),
-                            ),
-                          );
-                        }).toList(),
+                        items:
+                            ['yaml', 'json'].map((value) {
+                              return DropdownMenuItem(
+                                value: value,
+                                child: Text(
+                                  value,
+                                  style: TextStyle(
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textPrimary,
+                                  ),
+                                ),
+                              );
+                            }).toList(),
                       ),
                     ],
                   ),
@@ -502,9 +452,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Home Page',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Icon(
@@ -534,12 +482,7 @@ class Settings extends StatelessWidget {
                       const SizedBox(width: Constants.spacingSmall),
                       Expanded(
                         flex: 1,
-                        child: Text(
-                          'Proxy',
-                          style: noramlTextStyle(
-                            context,
-                          ),
-                        ),
+                        child: Text('Proxy', style: normalTextStyle(context)),
                       ),
                       Icon(
                         Icons.arrow_forward_ios,
@@ -568,12 +511,7 @@ class Settings extends StatelessWidget {
                       const SizedBox(width: Constants.spacingSmall),
                       Expanded(
                         flex: 1,
-                        child: Text(
-                          'Timeout',
-                          style: noramlTextStyle(
-                            context,
-                          ),
-                        ),
+                        child: Text('Timeout', style: normalTextStyle(context)),
                       ),
                       Icon(
                         Icons.arrow_forward_ios,
@@ -604,9 +542,7 @@ class Settings extends StatelessWidget {
                         flex: 1,
                         child: Text(
                           'Prometheus',
-                          style: noramlTextStyle(
-                            context,
-                          ),
+                          style: normalTextStyle(context),
                         ),
                       ),
                       Icon(

--- a/lib/widgets/settings/settings/settings_info.dart
+++ b/lib/widgets/settings/settings/settings_info.dart
@@ -61,11 +61,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
         _version = packageInfo.version;
       });
     } catch (err) {
-      Logger.log(
-        'SettingsInfo _getVersion',
-        'Could not get package info',
-        err,
-      );
+      Logger.log('SettingsInfo _getVersion', 'Could not get package info', err);
     }
   }
 
@@ -87,19 +83,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
             );
           },
           children: [
-            Icon(
-              Icons.policy,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.policy, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Terms of Use',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Terms of Use', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -121,19 +109,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
             );
           },
           children: [
-            Icon(
-              Icons.favorite,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.favorite, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Restore Purchases',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Restore Purchases', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -164,19 +144,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
       items: [
         AppVerticalListSimpleModel(
           children: [
-            Icon(
-              Icons.code,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.code, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Version',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Version', style: normalTextStyle(context)),
             ),
             Container(
               padding: const EdgeInsets.only(
@@ -191,10 +163,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
                   Radius.circular(Constants.sizeBorderRadius),
                 ),
               ),
-              constraints: const BoxConstraints(
-                minWidth: 16,
-                minHeight: 16,
-              ),
+              constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
               child: Text(
                 _version,
                 style: secondaryTextStyle(
@@ -212,19 +181,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
             openUrl('https://kubenav.io');
           },
           children: [
-            Icon(
-              Icons.language,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.language, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Website',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Website', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -248,12 +209,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'GitHub',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('GitHub', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -277,12 +233,7 @@ class _SettingsInfoState extends State<SettingsInfo> {
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Twitter',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Twitter', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -321,9 +272,10 @@ class _SettingsInfoState extends State<SettingsInfo> {
                     child: Text(
                       licenseText,
                       style: TextStyle(
-                        color: Theme.of(context)
-                            .extension<CustomColors>()!
-                            .textPrimary,
+                        color:
+                            Theme.of(
+                              context,
+                            ).extension<CustomColors>()!.textPrimary,
                       ),
                     ),
                   ),
@@ -332,19 +284,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
             );
           },
           children: [
-            Icon(
-              Icons.copyright,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.copyright, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'License',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('License', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,
@@ -361,19 +305,11 @@ class _SettingsInfoState extends State<SettingsInfo> {
             openUrl('https://kubenav.io/privacy.html');
           },
           children: [
-            Icon(
-              Icons.policy,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+            Icon(Icons.policy, color: Theme.of(context).colorScheme.primary),
             const SizedBox(width: Constants.spacingSmall),
             Expanded(
               flex: 1,
-              child: Text(
-                'Privacy Policy',
-                style: noramlTextStyle(
-                  context,
-                ),
-              ),
+              child: Text('Privacy Policy', style: normalTextStyle(context)),
             ),
             Icon(
               Icons.arrow_forward_ios,

--- a/lib/widgets/settings/settings/settings_sponsor.dart
+++ b/lib/widgets/settings/settings/settings_sponsor.dart
@@ -51,9 +51,7 @@ class SettingsSponsor extends StatelessWidget {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(
-              Constants.spacingMiddle,
-            ),
+            padding: const EdgeInsets.all(Constants.spacingMiddle),
             child: Center(
               child: CircularProgressIndicator(
                 color: Theme.of(context).colorScheme.primary,
@@ -70,63 +68,57 @@ class SettingsSponsor extends StatelessWidget {
     /// were a user can buy it.
     return AppVerticalListSimpleWidget(
       title: 'Sponsor',
-      items: sponsorRepository.products
-          .map(
-            (e) => AppVerticalListSimpleModel(
-              onTap: () {
-                showModal(
-                  context,
-                  SettingsSponsorSubscribe(
-                    product: e,
-                  ),
-                );
-              },
-              children: [
-                Icon(
-                  Icons.favorite,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(width: Constants.spacingSmall),
-                Expanded(
-                  flex: 1,
-                  child: Text(
-                    titles.containsKey(e.id) ? titles[e.id]! : e.title,
-                    style: noramlTextStyle(
-                      context,
+      items:
+          sponsorRepository.products
+              .map(
+                (e) => AppVerticalListSimpleModel(
+                  onTap: () {
+                    showModal(context, SettingsSponsorSubscribe(product: e));
+                  },
+                  children: [
+                    Icon(
+                      Icons.favorite,
+                      color: Theme.of(context).colorScheme.primary,
                     ),
-                  ),
-                ),
-                Container(
-                  padding: const EdgeInsets.only(
-                    bottom: 2,
-                    top: 2,
-                    left: 6,
-                    right: 6,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    borderRadius: const BorderRadius.all(
-                      Radius.circular(Constants.sizeBorderRadius),
+                    const SizedBox(width: Constants.spacingSmall),
+                    Expanded(
+                      flex: 1,
+                      child: Text(
+                        titles.containsKey(e.id) ? titles[e.id]! : e.title,
+                        style: normalTextStyle(context),
+                      ),
                     ),
-                  ),
-                  constraints: const BoxConstraints(
-                    minWidth: 16,
-                    minHeight: 16,
-                  ),
-                  child: Text(
-                    e.price,
-                    style: secondaryTextStyle(
-                      context,
-                      size: 14,
-                      color: Theme.of(context).colorScheme.onPrimary,
+                    Container(
+                      padding: const EdgeInsets.only(
+                        bottom: 2,
+                        top: 2,
+                        left: 6,
+                        right: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primary,
+                        borderRadius: const BorderRadius.all(
+                          Radius.circular(Constants.sizeBorderRadius),
+                        ),
+                      ),
+                      constraints: const BoxConstraints(
+                        minWidth: 16,
+                        minHeight: 16,
+                      ),
+                      child: Text(
+                        e.price,
+                        style: secondaryTextStyle(
+                          context,
+                          size: 14,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
                     ),
-                    textAlign: TextAlign.center,
-                  ),
+                  ],
                 ),
-              ],
-            ),
-          )
-          .toList(),
+              )
+              .toList(),
     );
   }
 }

--- a/lib/widgets/settings/settings_help.dart
+++ b/lib/widgets/settings/settings_help.dart
@@ -31,11 +31,19 @@ class SettingsHelp extends StatelessWidget {
                 showModal(
                   context,
                   AppBottomSheetWidget(
-                    title: help_model
-                        .Help.list[sectionIndex].items[itemIndex].title,
+                    title:
+                        help_model
+                            .Help
+                            .list[sectionIndex]
+                            .items[itemIndex]
+                            .title,
                     subtitle: 'Help',
-                    icon: help_model
-                        .Help.list[sectionIndex].items[itemIndex].icon,
+                    icon:
+                        help_model
+                            .Help
+                            .list[sectionIndex]
+                            .items[itemIndex]
+                            .icon,
                     closePressed: () {
                       Navigator.pop(context);
                     },
@@ -45,9 +53,7 @@ class SettingsHelp extends StatelessWidget {
                     },
                     actionIsLoading: false,
                     child: Markdown(
-                      padding: const EdgeInsets.all(
-                        Constants.spacingMiddle,
-                      ),
+                      padding: const EdgeInsets.all(Constants.spacingMiddle),
                       styleSheet: MarkdownStyleSheet(
                         code: TextStyle(
                           fontFamily: getMonospaceFontFamily(),
@@ -59,8 +65,12 @@ class SettingsHelp extends StatelessWidget {
                         ),
                       ),
                       selectable: true,
-                      data: help_model
-                          .Help.list[sectionIndex].items[itemIndex].markdown,
+                      data:
+                          help_model
+                              .Help
+                              .list[sectionIndex]
+                              .items[itemIndex]
+                              .markdown,
                     ),
                   ),
                 );
@@ -75,9 +85,7 @@ class SettingsHelp extends StatelessWidget {
                   flex: 1,
                   child: Text(
                     help_model.Help.list[sectionIndex].items[itemIndex].title,
-                    style: noramlTextStyle(
-                      context,
-                    ),
+                    style: normalTextStyle(context),
                   ),
                 ),
                 Icon(
@@ -100,10 +108,7 @@ class SettingsHelp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text('Help'),
-      ),
+      appBar: AppBar(centerTitle: true, title: const Text('Help')),
       bottomNavigationBar: const AppBottomNavigationBarWidget(),
       floatingActionButton: const AppFloatingActionButtonsWidget(),
       body: SafeArea(

--- a/lib/widgets/shared/app_clusters_widget.dart
+++ b/lib/widgets/shared/app_clusters_widget.dart
@@ -64,38 +64,37 @@ class _AppClustersWidgetState extends State<AppClustersWidget> {
           child: ListView.separated(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
-            separatorBuilder: (context, index) => const SizedBox(
-              height: Constants.spacingMiddle,
-            ),
+            separatorBuilder:
+                (context, index) =>
+                    const SizedBox(height: Constants.spacingMiddle),
             itemCount: clustersRepository.clusters.length,
-            itemBuilder: (context, index) => AppListItem(
-              onTap: () {
-                _setActiveCluster(clustersRepository.clusters[index].id);
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    clustersRepository.clusters[index].id ==
-                            clustersRepository.activeClusterId
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      clustersRepository.clusters[index].name,
-                      style: noramlTextStyle(
-                        context,
+            itemBuilder:
+                (context, index) => AppListItem(
+                  onTap: () {
+                    _setActiveCluster(clustersRepository.clusters[index].id);
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        clustersRepository.clusters[index].id ==
+                                clustersRepository.activeClusterId
+                            ? Icons.radio_button_checked
+                            : Icons.radio_button_unchecked,
+                        size: 24,
+                        color: Theme.of(context).colorScheme.primary,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          clustersRepository.clusters[index].name,
+                          style: normalTextStyle(context),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
+                ),
           ),
         ),
       ),

--- a/lib/widgets/shared/app_namespaces_widget.dart
+++ b/lib/widgets/shared/app_namespaces_widget.dart
@@ -109,11 +109,7 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
       }
     } catch (err) {
       if (mounted) {
-        showSnackbar(
-          context,
-          'Failed to Change Namespace',
-          err.toString(),
-        );
+        showSnackbar(context, 'Failed to Change Namespace', err.toString());
       }
     }
   }
@@ -167,9 +163,7 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
               flex: 1,
               child: Text(
                 'All Namespaces',
-                style: noramlTextStyle(
-                  context,
-                ),
+                style: normalTextStyle(context),
                 overflow: TextOverflow.ellipsis,
               ),
             ),
@@ -177,17 +171,16 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
         ),
       ),
       SizedBox(
-        height: appRepository.settings.namespaces.isEmpty
-            ? 0
-            : Constants.spacingMiddle,
+        height:
+            appRepository.settings.namespaces.isEmpty
+                ? 0
+                : Constants.spacingMiddle,
       ),
       ListView.separated(
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         separatorBuilder: (context, index) {
-          return const SizedBox(
-            height: Constants.spacingMiddle,
-          );
+          return const SizedBox(height: Constants.spacingMiddle);
         },
         itemCount: appRepository.settings.namespaces.length,
         itemBuilder: (context, index) {
@@ -214,9 +207,7 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
                   flex: 1,
                   child: Text(
                     name,
-                    style: noramlTextStyle(
-                      context,
-                    ),
+                    style: normalTextStyle(context),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -318,8 +309,9 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
                     );
                   }
 
-                  final filteredNamespaces =
-                      _getFilteredNamespaces(snapshot.data!);
+                  final filteredNamespaces = _getFilteredNamespaces(
+                    snapshot.data!,
+                  );
 
                   return Column(
                     children: [
@@ -377,9 +369,7 @@ class _AppNamespacesWidgetState extends State<AppNamespacesWidget> {
                                   flex: 1,
                                   child: Text(
                                     name ?? '',
-                                    style: noramlTextStyle(
-                                      context,
-                                    ),
+                                    style: normalTextStyle(context),
                                     overflow: TextOverflow.ellipsis,
                                   ),
                                 ),

--- a/lib/widgets/shared/app_prometheus_chart_widget.dart
+++ b/lib/widgets/shared/app_prometheus_chart_widget.dart
@@ -79,10 +79,7 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
 
   @override
   Widget build(BuildContext context) {
-    Provider.of<ClustersRepository>(
-      context,
-      listen: true,
-    );
+    Provider.of<ClustersRepository>(context, listen: true);
 
     return AppBottomSheetWidget(
       title: widget.title,
@@ -132,9 +129,10 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                     decoration: BoxDecoration(
                       boxShadow: [
                         BoxShadow(
-                          color: Theme.of(context)
-                              .extension<CustomColors>()!
-                              .shadow,
+                          color:
+                              Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.shadow,
                           blurRadius: Constants.sizeBorderBlurRadius,
                           spreadRadius: Constants.sizeBorderSpreadRadius,
                           offset: const Offset(0.0, 0.0),
@@ -161,19 +159,21 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                   maxContentWidth:
                                       MediaQuery.of(context).size.width,
                                   getTooltipColor: (LineBarSpot touchedSpot) {
-                                    return Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .message;
+                                    return Theme.of(
+                                      context,
+                                    ).extension<CustomColors>()!.message;
                                   },
                                   getTooltipItems: (touchedSpots) {
-                                    return touchedSpots
-                                        .map((LineBarSpot touchedSpot) {
+                                    return touchedSpots.map((
+                                      LineBarSpot touchedSpot,
+                                    ) {
                                       return LineTooltipItem(
                                         '${_selectedLabel == '' ? snapshot.data![touchedSpot.barIndex].label : _selectedLabel}: ${NumberFormat.compact(locale: "en_US").format(touchedSpot.y)} ${widget.unit}',
                                         TextStyle(
-                                          color: Theme.of(context)
-                                              .extension<CustomColors>()!
-                                              .onMessage,
+                                          color:
+                                              Theme.of(context)
+                                                  .extension<CustomColors>()!
+                                                  .onMessage,
                                           fontWeight: FontWeight.normal,
                                           fontSize: 14,
                                         ),
@@ -183,48 +183,45 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                 ),
                               ),
                               clipData: const FlClipData.all(),
-                              lineBarsData: snapshot.data!
-                                  .where(
-                                    (e) =>
-                                        _selectedLabel == '' ||
-                                        e.label == _selectedLabel,
-                                  )
-                                  .map(
-                                    (e) => LineChartBarData(
-                                      spots: e.toSpots(),
-                                      dotData: const FlDotData(
-                                        show: false,
-                                      ),
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                      barWidth: 4,
-                                      isCurved: false,
-                                    ),
-                                  )
-                                  .toList(),
+                              lineBarsData:
+                                  snapshot.data!
+                                      .where(
+                                        (e) =>
+                                            _selectedLabel == '' ||
+                                            e.label == _selectedLabel,
+                                      )
+                                      .map(
+                                        (e) => LineChartBarData(
+                                          spots: e.toSpots(),
+                                          dotData: const FlDotData(show: false),
+                                          color:
+                                              Theme.of(
+                                                context,
+                                              ).colorScheme.primary,
+                                          barWidth: 4,
+                                          isCurved: false,
+                                        ),
+                                      )
+                                      .toList(),
                               titlesData: FlTitlesData(
                                 show: true,
                                 rightTitles: const AxisTitles(
-                                  sideTitles: SideTitles(
-                                    showTitles: false,
-                                  ),
+                                  sideTitles: SideTitles(showTitles: false),
                                 ),
                                 topTitles: const AxisTitles(
-                                  sideTitles: SideTitles(
-                                    showTitles: false,
-                                  ),
+                                  sideTitles: SideTitles(showTitles: false),
                                 ),
                                 leftTitles: AxisTitles(
                                   sideTitles: SideTitles(
                                     showTitles: true,
                                     reservedSize: 96,
-                                    getTitlesWidget:
-                                        (double value, TitleMeta meta) {
+                                    getTitlesWidget: (
+                                      double value,
+                                      TitleMeta meta,
+                                    ) {
                                       return Text(
                                         '${NumberFormat.compact(locale: "en_US").format(value)} ${widget.unit}',
-                                        style: secondaryTextStyle(
-                                          context,
-                                        ),
+                                        style: secondaryTextStyle(context),
                                       );
                                     },
                                   ),
@@ -234,14 +231,14 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                     showTitles: true,
                                     interval:
                                         (widget.time.end - widget.time.start) /
-                                            3 *
-                                            1000,
+                                        3 *
+                                        1000,
                                     reservedSize: 32,
                                     getTitlesWidget: (value, titleMeta) {
                                       final timestamp =
                                           DateTime.fromMillisecondsSinceEpoch(
-                                        value.round(),
-                                      );
+                                            value.round(),
+                                          );
 
                                       return Container(
                                         padding: const EdgeInsets.only(
@@ -250,9 +247,7 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                         ),
                                         child: Text(
                                           '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}',
-                                          style: secondaryTextStyle(
-                                            context,
-                                          ),
+                                          style: secondaryTextStyle(context),
                                         ),
                                       );
                                     },
@@ -264,18 +259,20 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                 show: true,
                                 getDrawingHorizontalLine: (value) {
                                   return FlLine(
-                                    color: Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .textSecondary,
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textSecondary,
                                     strokeWidth: 0.4,
                                     dashArray: [8, 4],
                                   );
                                 },
                                 getDrawingVerticalLine: (value) {
                                   return FlLine(
-                                    color: Theme.of(context)
-                                        .extension<CustomColors>()!
-                                        .textSecondary,
+                                    color:
+                                        Theme.of(context)
+                                            .extension<CustomColors>()!
+                                            .textSecondary,
                                     strokeWidth: 0.4,
                                     dashArray: [8, 4],
                                   );
@@ -284,9 +281,7 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                             ),
                           ),
                         ),
-                        const SizedBox(
-                          height: Constants.spacingMiddle,
-                        ),
+                        const SizedBox(height: Constants.spacingMiddle),
                         ...snapshot.data!.map(
                           (e) => InkWell(
                             onTap: () {
@@ -311,12 +306,13 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                           Characters('\u{200B}'),
                                         )
                                         .toString(),
-                                    style: noramlTextStyle(
+                                    style: normalTextStyle(
                                       context,
                                       size: Constants.sizeTextSecondary,
-                                      decoration: _selectedLabel == e.label
-                                          ? TextDecoration.underline
-                                          : null,
+                                      decoration:
+                                          _selectedLabel == e.label
+                                              ? TextDecoration.underline
+                                              : null,
                                     ),
                                     overflow: TextOverflow.ellipsis,
                                   ),
@@ -329,9 +325,10 @@ class _AppPrometheusChartWidgetState extends State<AppPrometheusChartWidget> {
                                       : '',
                                   style: secondaryTextStyle(
                                     context,
-                                    decoration: _selectedLabel == e.label
-                                        ? TextDecoration.underline
-                                        : null,
+                                    decoration:
+                                        _selectedLabel == e.label
+                                            ? TextDecoration.underline
+                                            : null,
                                   ),
                                 ),
                               ],

--- a/lib/widgets/shared/app_time_range_selector_widget.dart
+++ b/lib/widgets/shared/app_time_range_selector_widget.dart
@@ -113,39 +113,38 @@ class _AppTimeRangeSelectorWidgetState
           child: ListView.separated(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
-            separatorBuilder: (context, index) => const SizedBox(
-              height: Constants.spacingMiddle,
-            ),
+            separatorBuilder:
+                (context, index) =>
+                    const SizedBox(height: Constants.spacingMiddle),
             itemCount: times.length,
-            itemBuilder: (context, index) => AppListItem(
-              onTap: () {
-                setState(() {
-                  _selectedTime = times[index];
-                });
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    times[index] == _selectedTime
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: Constants.spacingSmall),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      times[index],
-                      style: noramlTextStyle(
-                        context,
+            itemBuilder:
+                (context, index) => AppListItem(
+                  onTap: () {
+                    setState(() {
+                      _selectedTime = times[index];
+                    });
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        times[index] == _selectedTime
+                            ? Icons.radio_button_checked
+                            : Icons.radio_button_unchecked,
+                        size: 24,
+                        color: Theme.of(context).colorScheme.primary,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                      const SizedBox(width: Constants.spacingSmall),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          times[index],
+                          style: normalTextStyle(context),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
+                ),
           ),
         ),
       ),


### PR DESCRIPTION
The name of the function was `noramlTextStyle` instead of
`normalTextStyle`.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
