### PR TITLE
Add Reset Action

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,6 +18,8 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - quick_actions_ios (0.0.1):
+    - Flutter
   - TPInAppReceipt (3.4.1):
     - TPInAppReceipt/Core (= 3.4.1)
   - TPInAppReceipt/Core (3.4.1):
@@ -34,6 +36,7 @@ DEPENDENCIES:
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - quick_actions_ios (from `.symlinks/plugins/quick_actions_ios/ios`)
   - TPInAppReceipt
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -59,6 +62,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  quick_actions_ios:
+    :path: ".symlinks/plugins/quick_actions_ios/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -72,6 +77,7 @@ SPEC CHECKSUMS:
   local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  quick_actions_ios: 4b07fb49d8d8f3518d7565fbb7a91014067a7d82
   TPInAppReceipt: 22dbc616bcd6c61672ebe062e60b6329a2af6323
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -22,4 +22,8 @@ class Storage {
   Future<String?> read(String key) async {
     return await _storage?.read(key: key);
   }
+
+  Future<void> delete(String key) async {
+    return await _storage?.delete(key: key);
+  }
 }

--- a/lib/widgets/home/home.dart
+++ b/lib/widgets/home/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:provider/provider.dart';
+import 'package:quick_actions/quick_actions.dart';
 
 import 'package:kubenav/repositories/app_repository.dart';
 import 'package:kubenav/repositories/bookmarks_repository.dart';
@@ -9,6 +10,7 @@ import 'package:kubenav/repositories/clusters_repository.dart';
 import 'package:kubenav/repositories/theme_repository.dart';
 import 'package:kubenav/widgets/home/home_clusters.dart';
 import 'package:kubenav/widgets/home/home_overview.dart';
+import 'package:kubenav/widgets/reset/reset.dart';
 
 /// The [Home] is the first widget which is displayed when a user opens the app.
 /// We use it to initialize the [AppRepository] and [ClustersRepository] and to
@@ -22,9 +24,31 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
+  String shortcut = '';
+
   @override
   void initState() {
     super.initState();
+
+    /// Add a "reset" quick action, so that a user can reset all the saved
+    /// providers, clusters and settings. This is required, because sometimes
+    /// the app crashes for a invalid cluster configuration and I wasn't able
+    /// until now, why this happens. So having a workaround that effect users
+    /// can start using the app again might be a good idea.
+    const QuickActions quickActions = QuickActions();
+    quickActions.initialize((String shortcutType) {
+      setState(() {
+        shortcut = shortcutType;
+      });
+    });
+    quickActions.setShortcutItems(<ShortcutItem>[
+      const ShortcutItem(
+        type: 'reset',
+        localizedTitle: 'Reset',
+        localizedSubtitle: 'Reset Data',
+      ),
+    ]);
+
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       ThemeRepository themeRepository = Provider.of<ThemeRepository>(
         context,
@@ -39,10 +63,7 @@ class _HomeState extends State<Home> {
         listen: false,
       );
       BookmarksRepository bookmarksRepository =
-          Provider.of<BookmarksRepository>(
-        context,
-        listen: false,
-      );
+          Provider.of<BookmarksRepository>(context, listen: false);
 
       if (!appRepository.isAuthenticated) {
         themeRepository.init().then((value) {
@@ -75,6 +96,10 @@ class _HomeState extends State<Home> {
 
     if (!appRepository.isAuthenticated) {
       return Container();
+    }
+
+    if (shortcut == 'reset') {
+      return const Reset();
     }
 
     if (appRepository.showClusters && clustersRepository.clusters.isNotEmpty) {

--- a/lib/widgets/reset/reset.dart
+++ b/lib/widgets/reset/reset.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import 'package:kubenav/utils/constants.dart';
+import 'package:kubenav/utils/helpers.dart';
+import 'package:kubenav/utils/storage.dart';
+
+class Reset extends StatefulWidget {
+  const Reset({super.key});
+
+  @override
+  State<Reset> createState() => _ResetState();
+}
+
+class _ResetState extends State<Reset> {
+  bool _isLoading = false;
+  String _success = '';
+  String _error = '';
+
+  Future<void> _reset() async {
+    setState(() {
+      _isLoading = true;
+      _success = '';
+      _error = '';
+    });
+
+    try {
+      await Storage().delete('kubenav-settings');
+      await Storage().delete('kubenav-crds');
+      await Storage().delete('kubenavClustersRepository');
+      await Storage().delete('kubenav-bookmarks-v5');
+      await Storage().delete('kubenav-theme');
+      setState(() {
+        _isLoading = false;
+        _success = 'App data was deleted. You can restart the app now.';
+        _error = '';
+      });
+    } catch (err) {
+      setState(() {
+        _isLoading = false;
+        _success = '';
+        _error = 'Failed to delete app data: $err.';
+      });
+    }
+  }
+
+  Widget _buildStatus(String success, String error) {
+    if (success != '') {
+      return Padding(
+        padding: EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(success, textAlign: TextAlign.center),
+      );
+    }
+    if (error != '') {
+      return Padding(
+        padding: EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(error, textAlign: TextAlign.center),
+      );
+    }
+
+    return Container();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        automaticallyImplyLeading: false,
+        title: Text(
+          'kubenav',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w500,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              Padding(
+                padding: EdgeInsets.all(Constants.spacingMiddle),
+                child: Text(
+                  'Click the reset button to delete all existing providers, clusters and settings. Please be aware that this can not be undone. If you delete all existing providers, clusters and settings you have to re-add them manually.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              _buildStatus(_success, _error),
+              Padding(
+                padding: EdgeInsets.all(Constants.spacingMiddle),
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xff326ce5),
+                    foregroundColor: Colors.white,
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        Constants.sizeBorderRadius,
+                      ),
+                    ),
+                  ),
+                  onPressed: _isLoading ? null : _reset,
+                  child:
+                      _isLoading
+                          ? SizedBox(
+                            height: 24,
+                            width: 24,
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          )
+                          : Text(
+                            'Reset',
+                            style: primaryTextStyle(
+                              context,
+                              color: Colors.white,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -688,6 +688,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "6d79aea8ad72696ac09d5c9dd9faf9e153775a5ec6224fadf5b9e8ad2d049bf3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.20"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: "837b7e6b5973784d3da56b8c959b446b215914f20405d88cd7d22a2fb94e4e4c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   package_info_plus: ^8.3.0
   path_provider: ^2.1.5
   provider: ^6.1.4
+  quick_actions: ^1.1.0
   url_launcher: ^6.3.1
   uuid: ^4.5.1
   web_socket_channel: ^3.0.2


### PR DESCRIPTION
Add a reset action, which can be called via quick actions (long press on
the app icon). This action is used to open the `Reset` widget instead of
the normally shown widgets after the app is started. The `Reset` widget
then provides an option to delete all existing providers, clusters and
settings.

This is a workaround for when the app crashs, because something is wrong
with a configured cluster. This is a hacky workaround, but should be
better then that users are not able to use the app at all.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
