### PR TITLE
Return Panic as Error

### DIFF
--- a/cmd/kubenav/aws.go
+++ b/cmd/kubenav/aws.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,10 +54,10 @@ type AWSSSOAccount struct {
 
 // AWSGetClusters returns all clusters which can be accessed with the given
 // credentials.
-func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string) (string, error) {
+func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -116,10 +115,10 @@ func AWSGetClusters(accessKeyID, secretKey, region, sessionToken, roleArn string
 // AWSGetToken returns a token, which can be used to access the Kubernetes API
 // of a cluster with the given clusterID.
 // See: https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/7547c74e660f8d34d9980f2c69aa008eed1f48d0/pkg/token/token.go#L310
-func AWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID string) (string, error) {
+func AWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterID string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -149,10 +148,10 @@ func AWSGetToken(accessKeyID, secretKey, region, sessionToken, roleArn, clusterI
 // AWSGetSSOConfig registers a new AWS SSO client and starts the device
 // authentication. The client and device authentication is returned, so that we
 // can use the information in the following steps of the SSO flow.
-func AWSGetSSOConfig(ssoRegion, startURL string) (string, error) {
+func AWSGetSSOConfig(ssoRegion, startURL string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -197,10 +196,10 @@ func AWSGetSSOConfig(ssoRegion, startURL string) (string, error) {
 // AWSGetSSOToken is used to request a new token with the client and device
 // information from the former step in the sso flow. The retrieved access token
 // is then used to get the credentials for AWS.
-func AWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, accessToken string, accessTokenExpire int64) (string, error) {
+func AWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode, accessToken string, accessTokenExpire int64) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -261,10 +260,10 @@ func AWSGetSSOToken(accountID, roleName, ssoRegion, ssoClientID, ssoClientSecret
 // AWSGetSSOAccounts returns a list of accounts and roles for the currently
 // authenticated user, so that a user does not have to provide these information
 // by his own.
-func AWSGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode string) (string, error) {
+func AWSGetSSOAccounts(ssoRegion, ssoClientID, ssoClientSecret, ssoDeviceCode string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/azure.go
+++ b/cmd/kubenav/azure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -23,10 +22,10 @@ type AzureCluster struct {
 // AzureGetClusters returns all clusters wich are available with the provided
 // Azure credentials, the returned JSON encoded string contains all the clusters
 // with there name and kubeconfig.
-func AzureGetClusters(subscriptionID, tenantID, clientID, clientSecret string, isAdmin bool) (string, error) {
+func AzureGetClusters(subscriptionID, tenantID, clientID, clientSecret string, isAdmin bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/helm.go
+++ b/cmd/kubenav/helm.go
@@ -2,7 +2,7 @@ package kubenav
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"sort"
 	"time"
 
@@ -33,10 +33,10 @@ type UninstallOptions struct {
 
 // HelmListReleases returns a list of Helm releases for the given cluster and
 // namespace. If an error occures during the process the error is returned.
-func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace string) (string, error) {
+func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -70,10 +70,10 @@ func HelmListReleases(clusterServer, clusterCertificateAuthorityData string, clu
 // HelmGetRelease returns a single of Helm release. The Helm release is
 // identified by it's namespace, name and version. If an error occures during
 // the process the error is returned.
-func HelmGetRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64) (string, error) {
+func HelmGetRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -103,10 +103,10 @@ func HelmGetRelease(clusterServer, clusterCertificateAuthorityData string, clust
 // HelmListReleaseHistory returns the History of a release. The Helm release is
 // identified by it's namespace and name. If an error occures during the process
 // the error is returned.
-func HelmListReleaseHistory(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string) (string, error) {
+func HelmListReleaseHistory(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -140,10 +140,10 @@ func HelmListReleaseHistory(clusterServer, clusterCertificateAuthorityData strin
 // HelmRollbackRelease rolls back a Helm release. The Helm release is identified
 // by it's namespace and name. The Helm release is rolled back to the provided
 // version. If an error occures during the process the error is returned.
-func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64, options string) error {
+func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, version int64, options string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -172,10 +172,10 @@ func HelmRollbackRelease(clusterServer, clusterCertificateAuthorityData string, 
 // identified by it's namespace and name. If an error occures during the process
 // the error is returned. If the operation was successful the uninstall message
 // is returned.
-func HelmUninstallRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, options string) (string, error) {
+func HelmUninstallRelease(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, namespace, name string, options string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/helpers.go
+++ b/cmd/kubenav/helpers.go
@@ -2,7 +2,7 @@ package kubenav
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 
 	"github.com/wI2L/jsondiff"
 	"sigs.k8s.io/yaml"
@@ -12,16 +12,16 @@ import (
 // string. For that we have to unmarshal the json string into a
 // map[string]interface{} which we can then marshal to the prettified yaml
 // string.
-func PrettifyYAML(jsonStr string) (string, error) {
+func PrettifyYAML(jsonStr string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
 	var jsonObj map[string]interface{}
 
-	err := json.Unmarshal([]byte(jsonStr), &jsonObj)
+	err = json.Unmarshal([]byte(jsonStr), &jsonObj)
 	if err != nil {
 		return "", err
 	}
@@ -38,10 +38,10 @@ func PrettifyYAML(jsonStr string) (string, error) {
 // when a user edits a resource, where the source argument is the manifest of
 // the current resource and the target is the edited manifest. The returned
 // patch can then be send to the Kubernetes API to edit the resource.
-func CreateJSONPatch(source, target string) (string, error) {
+func CreateJSONPatch(source, target string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/kubernetes.go
+++ b/cmd/kubenav/kubernetes.go
@@ -25,10 +25,10 @@ import (
 // The "requestMethod", "requestURL" and "requestBody" arguments are then used
 // for the actually request. E.g. to get all Pods from the Kubernetes API the
 // method "GET" and the URL "/api/v1/pods" can be used.
-func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, requestMethod, requestURL, requestBody string) (string, error) {
+func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, requestMethod, requestURL, requestBody string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -81,10 +81,10 @@ func KubernetesRequest(clusterServer, clusterCertificateAuthorityData string, cl
 // are provided via the "names" parameter, which must be a comma separated list
 // of the Pod names. To use this function a user must also provide the
 // namespace, container, since and previous parameter.
-func KubernetesGetLogs(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, names, namespace, container string, since int64, filter string, previous bool) (string, error) {
+func KubernetesGetLogs(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, names, namespace, container string, since int64, filter string, previous bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/oidc.go
+++ b/cmd/kubenav/oidc.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -83,10 +82,10 @@ func oidcContext(ctx context.Context, certificateAuthority string) (context.Cont
 
 // OIDCGetLink returns the link for the configured OIDC provider. The Link can
 // then be used by the user to login.
-func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, state string) (string, error) {
+func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, state string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -160,10 +159,10 @@ func OIDCGetLink(discoveryURL, clientID, clientSecret, certificateAuthority, sco
 // OIDCGetRefreshToken returns a refresh token for the configured OIDC provider.
 // The refresh token can be used to get a new access token via the
 // OIDCGetAccessToken function.
-func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, code, verifier string, useAccessToken bool) (string, error) {
+func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, pkceMethod, code, verifier string, useAccessToken bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -226,10 +225,10 @@ func OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, certificateAuthor
 }
 
 // OIDCGetAccessToken is used to retrieve an access token from a refresh token.
-func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, refreshToken string, useAccessToken bool) (string, error) {
+func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthority, scopes string, addDefaultScopes bool, redirectURL, refreshToken string, useAccessToken bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -287,10 +286,10 @@ func OIDCGetAccessToken(discoveryURL, clientID, clientSecret, certificateAuthori
 	return string(oidcResponseBytes), nil
 }
 
-func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool) (string, error) {
+func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 
@@ -343,10 +342,10 @@ func OIDCDeviceAuth(discoveryURL, clientID, certificateAuthority, scopes string,
 	return string(deviceAuthData), nil
 }
 
-func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool, deviceCode string, useAccessToken bool) (string, error) {
+func OIDCDeviceAuthGetRefreshToken(discoveryURL, clientID, certificateAuthority, scopes string, addDefaultScopes bool, deviceCode string, useAccessToken bool) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 

--- a/cmd/kubenav/prometheus.go
+++ b/cmd/kubenav/prometheus.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"log"
 	"math"
 	"net"
 	"net/http"
@@ -64,10 +63,10 @@ type datum struct {
 
 // PrometheusGetData can be used to run a list multiple PromQL queries against a
 // Prometheus instance.
-func PrometheusGetData(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, request string) (string, error) {
+func PrometheusGetData(clusterServer, clusterCertificateAuthorityData string, clusterInsecureSkipTLSVerify bool, userClientCertificateData, userClientKeyData, userToken, userUsername, userPassword, proxy string, timeout int64, request string) (_ string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic: %#v", r)
+			err = fmt.Errorf("panic: %#v", r)
 		}
 	}()
 


### PR DESCRIPTION
Until now we only logged a panic, which could occure in the Go code. Now
we are returning a proper error message to the user, why the Go function
failed.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
