### PR TITLE
Move initContainers to end of get_logs container selector

### DIFF
--- a/lib/widgets/resources/actions/get_logs.dart
+++ b/lib/widgets/resources/actions/get_logs.dart
@@ -218,15 +218,15 @@ class _GetLogsState extends State<GetLogs> {
     /// for the [_container] state.
     List<String> tmpContainers = [];
 
-    if (widget.pod.spec?.initContainers != null) {
-      for (var initContainer in widget.pod.spec!.initContainers) {
-        tmpContainers.add(initContainer.name);
-      }
-    }
-
     if (widget.pod.spec?.containers != null) {
       for (var container in widget.pod.spec!.containers) {
         tmpContainers.add(container.name);
+      }
+    }
+
+    if (widget.pod.spec?.initContainers != null) {
+      for (var initContainer in widget.pod.spec!.initContainers) {
+        tmpContainers.add(initContainer.name);
       }
     }
 


### PR DESCRIPTION
<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
I frequently use kubenav to check the logs in my cluster.  
Most of my pods have 1 or more initcontainers, but only one container I actually care about.

Before, the initcontainers where always first in the container list, requiring 2 more clicks before the I could see the logs I wanted.

With this change, the initcontainers are moved to the back of the list.

### Note:

Because this is such a small change, I didn't bother to actually test it. I have never used dart/flutter, so setting this all up would take me way too long.

The tests have successfully ran on a PR in my own repo: https://github.com/RubenNL/kubenav/actions/runs/16111308237