### PR TITLE
Improve Container Handling for Logs and Terminal

### DIFF
--- a/lib/widgets/resources/actions/get_logs.dart
+++ b/lib/widgets/resources/actions/get_logs.dart
@@ -132,9 +132,7 @@ class _GetLogsState extends State<GetLogs> {
               Navigator.pop(context);
               showModal(
                 context,
-                AppTerminalWidget(
-                  terminalIndex: terminalIndex,
-                ),
+                AppTerminalWidget(terminalIndex: terminalIndex),
                 fullScreen: true,
               );
             }
@@ -153,18 +151,19 @@ class _GetLogsState extends State<GetLogs> {
           /// via the [getLogs] method of the [KubernetesService] which uses
           /// platform channels to make the Kubernetes request. This has the
           /// advantage that we do not have to start a http server first.
-          final logs = await KubernetesService(
-            cluster: cluster!,
-            proxy: appRepository.settings.proxy,
-            timeout: appRepository.settings.timeout,
-          ).getLogs(
-            widget.names,
-            widget.namespace,
-            _container,
-            _sinceOptions[_since]!,
-            _filterController.text,
-            _previous,
-          );
+          final logs =
+              await KubernetesService(
+                cluster: cluster!,
+                proxy: appRepository.settings.proxy,
+                timeout: appRepository.settings.timeout,
+              ).getLogs(
+                widget.names,
+                widget.namespace,
+                _container,
+                _sinceOptions[_since]!,
+                _filterController.text,
+                _previous,
+              );
 
           final terminalIndex = terminalRepository.addTerminal(
             TerminalType.log,
@@ -181,25 +180,15 @@ class _GetLogsState extends State<GetLogs> {
             Navigator.pop(context);
             showModal(
               context,
-              AppTerminalWidget(
-                terminalIndex: terminalIndex,
-              ),
+              AppTerminalWidget(terminalIndex: terminalIndex),
               fullScreen: true,
             );
           }
         }
       } catch (err) {
-        Logger.log(
-          'GetLogs _getLogs',
-          'Failed to Get Logs',
-          err,
-        );
+        Logger.log('GetLogs _getLogs', 'Failed to Get Logs', err);
         if (mounted) {
-          showSnackbar(
-            context,
-            'Failed to Get Logs',
-            err.toString(),
-          );
+          showSnackbar(context, 'Failed to Get Logs', err.toString());
         }
         setState(() {
           _isLoading = false;
@@ -230,6 +219,12 @@ class _GetLogsState extends State<GetLogs> {
       }
     }
 
+    if (widget.pod.spec?.ephemeralContainers != null) {
+      for (var ephemeralContainer in widget.pod.spec!.ephemeralContainers!) {
+        tmpContainers.add(ephemeralContainer.name);
+      }
+    }
+
     if (tmpContainers.isNotEmpty) {
       _containers = tmpContainers;
 
@@ -238,13 +233,18 @@ class _GetLogsState extends State<GetLogs> {
       /// state. If the annotation is not available we use the first container
       /// from the list.
       if (widget.pod.metadata?.annotations != null &&
-          widget.pod.metadata!.annotations
-              .containsKey('kubectl.kubernetes.io/default-container') &&
+          widget.pod.metadata!.annotations.containsKey(
+            'kubectl.kubernetes.io/default-container',
+          ) &&
           tmpContainers.contains(
-            widget.pod.metadata!
+            widget
+                .pod
+                .metadata!
                 .annotations['kubectl.kubernetes.io/default-container'],
           )) {
-        _container = widget.pod.metadata!
+        _container = widget
+            .pod
+            .metadata!
             .annotations['kubectl.kubernetes.io/default-container']!;
       } else {
         _container = tmpContainers[0];
@@ -306,9 +306,9 @@ class _GetLogsState extends State<GetLogs> {
                           child: Text(
                             value,
                             style: TextStyle(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .textPrimary,
+                              color: Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.textPrimary,
                             ),
                           ),
                         );
@@ -339,9 +339,9 @@ class _GetLogsState extends State<GetLogs> {
                           child: Text(
                             value,
                             style: TextStyle(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .textPrimary,
+                              color: Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.textPrimary,
                             ),
                           ),
                         );

--- a/lib/widgets/resources/actions/get_terminal.dart
+++ b/lib/widgets/resources/actions/get_terminal.dart
@@ -112,9 +112,7 @@ class _GetTerminalState extends State<GetTerminal> {
             Navigator.pop(context);
             showModal(
               context,
-              AppTerminalWidget(
-                terminalIndex: terminalIndex,
-              ),
+              AppTerminalWidget(terminalIndex: terminalIndex),
               fullScreen: true,
             );
           }
@@ -135,11 +133,7 @@ class _GetTerminalState extends State<GetTerminal> {
           err,
         );
         if (mounted) {
-          showSnackbar(
-            context,
-            'Failed to Create Terminal',
-            err.toString(),
-          );
+          showSnackbar(context, 'Failed to Create Terminal', err.toString());
         }
         setState(() {
           _isLoading = false;
@@ -158,15 +152,15 @@ class _GetTerminalState extends State<GetTerminal> {
     /// for the [_container] state.
     List<String> tmpContainers = [];
 
-    if (widget.pod.spec?.initContainers != null) {
-      for (var initContainer in widget.pod.spec!.initContainers) {
-        tmpContainers.add(initContainer.name);
-      }
-    }
-
     if (widget.pod.spec?.containers != null) {
       for (var container in widget.pod.spec!.containers) {
         tmpContainers.add(container.name);
+      }
+    }
+
+    if (widget.pod.spec?.initContainers != null) {
+      for (var initContainer in widget.pod.spec!.initContainers) {
+        tmpContainers.add(initContainer.name);
       }
     }
 
@@ -184,13 +178,18 @@ class _GetTerminalState extends State<GetTerminal> {
       /// state. If the annotation is not available we use the first container
       /// from the list.
       if (widget.pod.metadata?.annotations != null &&
-          widget.pod.metadata!.annotations
-              .containsKey('kubectl.kubernetes.io/default-container') &&
+          widget.pod.metadata!.annotations.containsKey(
+            'kubectl.kubernetes.io/default-container',
+          ) &&
           tmpContainers.contains(
-            widget.pod.metadata!
+            widget
+                .pod
+                .metadata!
                 .annotations['kubectl.kubernetes.io/default-container'],
           )) {
-        _container = widget.pod.metadata!
+        _container = widget
+            .pod
+            .metadata!
             .annotations['kubectl.kubernetes.io/default-container']!;
       } else {
         _container = tmpContainers[0];
@@ -246,9 +245,9 @@ class _GetTerminalState extends State<GetTerminal> {
                           child: Text(
                             value,
                             style: TextStyle(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .textPrimary,
+                              color: Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.textPrimary,
                             ),
                           ),
                         );
@@ -273,20 +272,15 @@ class _GetTerminalState extends State<GetTerminal> {
                           _shell = value ?? 'sh';
                         });
                       },
-                      items: [
-                        'sh',
-                        'bash',
-                        'pwsh',
-                        'cmd',
-                      ].map((value) {
+                      items: ['sh', 'bash', 'pwsh', 'cmd'].map((value) {
                         return DropdownMenuItem(
                           value: value,
                           child: Text(
                             value,
                             style: TextStyle(
-                              color: Theme.of(context)
-                                  .extension<CustomColors>()!
-                                  .textPrimary,
+                              color: Theme.of(
+                                context,
+                              ).extension<CustomColors>()!.textPrimary,
                             ),
                           ),
                         );


### PR DESCRIPTION
This commit improves the container handling in the logs view, to show
the containers before the init containers as it was done in #802 for the
logs view.

Besides that this commit also adds the emphermal containers to the list
of containers which can be selected in the logs view. This was done
because they can also be selected for in the terminal view.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
