### PR TITLE
Add new AWS Taipei region to constants

### DIFF
--- a/lib/services/providers/aws_service.dart
+++ b/lib/services/providers/aws_service.dart
@@ -16,6 +16,7 @@ const awsRegions = [
   'us-gov-west-1',
   'af-south-1',
   'ap-east-1',
+  'ap-east-2',
   'ap-south-1',
   'ap-northeast-1',
   'ap-northeast-2',


### PR DESCRIPTION
I’m trying to update constants according to #720 #721 discussion. If creating a corresponding issue is a must please let me know.