### PR TITLE
Fix `fromJson` Method for `AppRepositorySettingsPrometheus`

### DIFF
--- a/lib/repositories/app_repository.dart
+++ b/lib/repositories/app_repository.dart
@@ -601,7 +601,7 @@ class AppRepositorySettingsPrometheus {
           data.containsKey('insecureSkipTLSVerify') &&
               data['insecureSkipTLSVerify'] != null
           ? data['insecureSkipTLSVerify']
-          : '',
+          : false,
       clientCertificate:
           data.containsKey('clientCertificate') &&
               data['clientCertificate'] != null


### PR DESCRIPTION
If the `insecureSkipTLSVerify` field was not set, we tried to set it to
an empty string instead of a boolean `false`. This caused that the app
crashed during the start, when the field was not set.

<!--
  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
