### PR TITLE
Fix Helm release list showing only deployed

### DIFF
--- a/cmd/kubenav/helm/client.go
+++ b/cmd/kubenav/helm/client.go
@@ -25,7 +25,7 @@ type client struct {
 
 func (c *client) ListReleases() ([]*release.Release, error) {
 	listClient := action.NewList(c.ActionConfig)
-	listClient.StateMask = action.ListDeployed
+	listClient.StateMask = action.ListAll
 
 	return listClient.Run()
 }

--- a/lib/models/plugins/helm.dart
+++ b/lib/models/plugins/helm.dart
@@ -106,13 +106,18 @@ class Chart {
   });
 
   factory Chart.fromJson(Map<String, dynamic> data) {
+    final templates = data['templates'];
+
     return Chart(
       metadata: data.containsKey('metadata')
           ? Metadata.fromJson(data['metadata'])
           : null,
-      templates: data.containsKey('templates')
+      templates: templates is List
           ? List<File>.from(
-              data['templates'].map((template) => File.fromJson(template)),
+              templates.whereType<Map>().map(
+                (template) =>
+                    File.fromJson(Map<String, dynamic>.from(template)),
+              ),
             )
           : null,
       values: data.containsKey('values') ? data['values'] : null,


### PR DESCRIPTION
It is just a small fix to show all helm releases, not only deployed:

<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/607fb8f9-09e8-4b24-97be-d2be2110fffb" />

while:

<img width="1781" height="256" alt="Screenshot From 2026-06-17 09-34-31" src="https://github.com/user-attachments/assets/d9a359db-8d03-4b4d-96ca-ae2bb3fde483" />

after patch:
<img width="670" height="1195" alt="Screenshot From 2026-06-17 14-20-32" src="https://github.com/user-attachments/assets/dc6b7a74-5d56-484c-a447-6238845c3a3e" />



Not only related to visibility, it is more offten when you need to rollback release when it is not in successfull state.
 Related to #599 

## Summary
- change Helm release listing to include all release states instead of only deployed ones